### PR TITLE
Add Ruby Quickstart

### DIFF
--- a/fern/products/sdks/overview/ruby/quickstart.mdx
+++ b/fern/products/sdks/overview/ruby/quickstart.mdx
@@ -3,6 +3,87 @@ title: Ruby Quickstart
 description: Get started quickly with the Fern Ruby SDK.
 ---
 
-# Ruby Quickstart
+<Markdown src="/products/sdks/snippets/demo-warning.mdx"/>
 
-Follow these steps to quickly get up and running with the Fern Ruby SDK. 
+Generate a Ruby SDK by following the instructions on this page. 
+
+<Steps>
+<Markdown src="/products/sdks/snippets/install-cli.mdx"/>
+
+  ### Initialize the Fern Folder
+
+  You can use either the OpenAPI definition, AsyncAPI definition, or Fern
+  Definition to generate your SDK.
+
+  <AccordionGroup>
+    <Markdown src="/products/sdks/snippets/option-1-openapi.mdx"/>
+
+    <Markdown src="/products/sdks/snippets/option-2-asyncapi.mdx"/>
+    
+  <Accordion title="Option 3: Fern Definition">
+  
+  <Markdown src="/products/sdks/snippets/option-3-fern-def.mdx"/>
+
+  2.    Add the config option `outputSourceFiles: true` to
+        `generators.yml`. This ensures your SDK contains source files in
+        your preferred SDK language instead of compiled output. 
+
+        ```yaml {11-12}
+        # yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+        default-group: local
+        groups:
+          local:
+            generators:
+              - name: fernapi/fern-typescript-sdk
+                output:
+                  location: local-file-system
+                  path: ../sdks/typescript
+                version: <Markdown src="/snippets/version-number.mdx"/>
+                config:
+                  outputSourceFiles: true
+        ```
+
+        <Note>`fern init` creates a default configuration that includes the
+        TypeScript Node SDK generator. The `local` group containing this
+        generator only generates if you run fern generate without specifying a
+        group, or if you explicitly target it with `fern generate --group
+        local`. In subsequent steps, you'll add an additional generator for your
+        preferred SDK language.</Note>
+    </Accordion>
+
+  </AccordionGroup>
+
+<Markdown src="/products/sdks/snippets/pass-fern-check.mdx"/>
+
+### Add the SDK generator
+
+Add the Ruby SDK generator:
+
+```bash
+fern add fern-ruby-sdk --group sdk
+```
+
+This command adds the following to `generators.yml`:
+
+```yaml
+  sdk:
+    generators:
+      - name: fernapi/fern-ruby-sdk
+        version: <Markdown src="/snippets/version-number.mdx"/>
+        output:
+          location: local-file-system
+          path: ../sdks/ruby
+```
+
+<Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
+
+```bash
+fern/ # created in step 1
+sdks/ # created by fern generate --group sdk
+├─ ruby
+    ├─ YourOrganization_api_client.gemspec
+    ├─ test/
+    └─ lib/
+        └─ YourOrganization_api_client/
+``` 
+</Steps>


### PR DESCRIPTION
Most of the content here isn't new – it's reused across the Python and TypeScript quickstarts.