### PR TITLE
Add PHP configuration options

### DIFF
--- a/fern/products/sdks/overview/php/configuration.mdx
+++ b/fern/products/sdks/overview/php/configuration.mdx
@@ -5,13 +5,13 @@ description: Configuration options for the Fern PHP SDK.
 
 You can customize the behavior of the PHP SDK generator in `generators.yml`:
 
-```yaml {8-9}
+```yaml {7-8}
 default-group: local
 groups:
   local:
     generators:
       - name: fernapi/fern-python
-        version: 0.7.1
+        version: <Markdown src="/snippets/version-number.mdx"/>
         config:
           clientName: YourClientName
 ```
@@ -39,5 +39,3 @@ groups:
 <ParamField path="composerJson" type="Record<string, any>" required={false}>
 </ParamField>
 
-<ParamField path="client-class-name" type="string" required={false} deprecated={true}>
-</ParamField>

--- a/fern/products/sdks/overview/php/configuration.mdx
+++ b/fern/products/sdks/overview/php/configuration.mdx
@@ -3,6 +3,41 @@ title: PHP Configuration
 description: Configuration options for the Fern PHP SDK.
 ---
 
-# PHP Configuration
+You can customize the behavior of the PHP SDK generator in `generators.yml`:
 
-Discover how to configure the Fern PHP SDK for your project. 
+```yaml {8-9}
+default-group: local
+groups:
+  local:
+    generators:
+      - name: fernapi/fern-python
+        version: 0.7.1
+        config:
+          clientName: YourClientName
+```
+
+## SDK Configuration Options
+
+<ParamField path="clientName" type="string" required={false}>
+</ParamField>
+
+<ParamField path="inlinePathParameters" type="boolean" required={false}>
+</ParamField>
+
+<ParamField path="packageName" type="string" required={false}>
+</ParamField>
+
+<ParamField path="packagePath" type="string" required={false}>
+</ParamField>
+
+<ParamField path="propertyAccess" type="'public' | 'private'" required={false}>
+</ParamField>
+
+<ParamField path="namespace" type="string" required={false}>
+</ParamField>
+
+<ParamField path="composerJson" type="Record<string, any>" required={false}>
+</ParamField>
+
+<ParamField path="client-class-name" type="string" required={false} deprecated={true}>
+</ParamField>


### PR DESCRIPTION
Fill out configuration.mdx file for the PHP SDK based on the [PHP config class](https://github.com/fern-api/fern/blob/4cbae741c1f230bd1807cfc19948c8748aaa9eaa/generators/php/codegen/src/custom-config/BasePhpCustomConfigSchema.ts#L3-L15). I didn't include `client-class-name` because it's marked as deprecated. 