### PR TITLE
Add Homepage Links

### DIFF
--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -152,12 +152,12 @@ import { FernStatusWidget } from "../../../components/FernStatus";
             <img src="./images/arrow-right-white.svg" alt="Arrow right" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-black.svg" alt="Arrow right" className="hidden dark:block" noZoom />
           </a>
-          <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/guides/getting-started/migrate-from-an-existing-site">
+          <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/migrate-from-an-existing-site">
             Import your brand language
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
-          <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/guides/getting-started/add-multiple-specs">
+          <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/add-multiple-specs">
             Add multiple specs to your docs site
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -85,31 +85,31 @@ import { FernStatusWidget } from "../../../components/FernStatus";
         <div className="language-icons">
           <span className="language-icons-label">Get started with:</span>
           {/* TypeScript */}
-          <a className="language-icon" href="/sdks/fern-sdks/typescript/quickstart">
+          <a className="language-icon" href="/sdks/overview/typescript/quickstart">
             <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
           </a>
           {/* Python */}
-          <a className="language-icon" href="/sdks/fern-sdks/python/quickstart">
+          <a className="language-icon" href="/sdks/overview/python/quickstart">
             <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
           </a> 
           {/* Go */}
-          <a className="language-icon" href="/sdks/fern-sdks/go/quickstart">
+          <a className="language-icon" href="/sdks/overview/go/quickstart">
             <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
           </a>
           {/* Java */}
-          <a className="language-icon" href="/sdks/fern-sdks/java/quickstart">
+          <a className="language-icon" href="/sdks/overview/java/quickstart">
             <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
           </a>
           {/* Ruby */}
-          <a className="language-icon" href="/sdks/fern-sdks/ruby/quickstart">
+          <a className="language-icon" href="/sdks/overview/ruby/quickstart">
             <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
           </a>
           {/* C# */}
-          <a className="language-icon" href="/sdks/fern-sdks/csharp/quickstart">
+          <a className="language-icon" href="/sdks/overview/net/quickstart">
             <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
           </a>
           {/* PHP */}
-          <a className="language-icon" href="/sdks/fern-sdks/php/quickstart">
+          <a className="language-icon" href="/sdks/overview/php/quickstart">
             <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
           </a>
         </div>

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -157,7 +157,7 @@ import { FernStatusWidget } from "../../../components/FernStatus";
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
-          <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/add-multiple-specs">
+          <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/guides/getting-started/add-multiple-specs">
             Add multiple specs to your docs site
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -116,12 +116,12 @@ import { FernStatusWidget } from "../../../components/FernStatus";
 
         {/* Action Buttons */}
         <div className="action-buttons">
-          <a className="fern-button filled normal primary gap-1 a-btn">
+          <a className="fern-button filled normal primary gap-1 a-btn" href="/sdks/overview/typescript/quickstart">
             Quickstart
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
-          <a className="fern-button minimal normal gap-1 a-btn">
+          <a className="fern-button minimal normal gap-1 a-btn" href="/sdks/overview/introduction">
             Capabilities  
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
@@ -147,7 +147,7 @@ import { FernStatusWidget } from "../../../components/FernStatus";
         <img src="./images/docs-preview-dark.svg" alt="Docs Preview" className="docs-preview-img hidden dark:block" noZoom />
 
         <div className="action-buttons-vertical">
-          <a className="fern-button filled normal primary gap-1 w-fit a-btn" href="/docs/guides/getting-started/quickstart">
+          <a className="fern-button filled normal primary gap-1 w-fit a-btn" href="/docs/getting-started/quickstart">
             Quickstart
             <img src="./images/arrow-right-white.svg" alt="Arrow right" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-black.svg" alt="Arrow right" className="hidden dark:block" noZoom />
@@ -358,9 +358,9 @@ import { FernStatusWidget } from "../../../components/FernStatus";
           <div className="footer-column">
             <h4 className="footer-column-title">Documentation</h4>
             <div className="footer-column-links">
-              <a href="#" className="footer-link">OpenAPI Compatibility</a>
-              <a href="#" className="footer-link">SDKs</a>
-              <a href="#" className="footer-link">Docs</a>
+              <a href="/openapi/getting-started/overview" className="footer-link">OpenAPI Compatibility</a>
+              <a href="/sdks/overview/introduction" className="footer-link">SDKs</a>
+              <a href="docs/getting-started/overview" className="footer-link">Docs</a>
             </div>
           </div>
 


### PR DESCRIPTION
Wasn't quite sure what the Quickstart and Capabilities buttons on the SDKs card should point to – made a guess, happy to change! The link for "Adding multiple specs to your doc site" is currently broken. I didn't see a relevant page to link to, so I left it as-is. 