### PR TITLE
Update fern-typescript-node-sdk references

### DIFF
--- a/fern/products/sdks/overview/dotnet/quickstart.mdx
+++ b/fern/products/sdks/overview/dotnet/quickstart.mdx
@@ -34,7 +34,7 @@ Generate a C#/.NET SDK by following the instructions on this page.
         groups:
           local:
             generators:
-              - name: fernapi/fern-typescript-node-sdk
+              - name: fernapi/fern-typescript-sdk
                 output:
                   location: local-file-system
                   path: ../sdks/typescript
@@ -44,7 +44,7 @@ Generate a C#/.NET SDK by following the instructions on this page.
         ```
 
         <Note>`fern init` creates a default configuration that includes the
-        TypeScript Node SDK generator. The `local` group containing this
+        TypeScript SDK generator. The `local` group containing this
         generator only generates if you run fern generate without specifying a
         group, or if you explicitly target it with `fern generate --group
         local`. In subsequent steps, you'll add an additional generator for your

--- a/fern/products/sdks/overview/java/quickstart.mdx
+++ b/fern/products/sdks/overview/java/quickstart.mdx
@@ -34,7 +34,7 @@ Generate a Java SDK by following the instructions on this page.
         groups:
           local:
             generators:
-              - name: fernapi/fern-typescript-node-sdk
+              - name: fernapi/fern-typescript-sdk
                 output:
                   location: local-file-system
                   path: ../sdks/typescript
@@ -44,7 +44,7 @@ Generate a Java SDK by following the instructions on this page.
         ```
 
         <Note>`fern init` creates a default configuration that includes the
-        TypeScript Node SDK generator. The `local` group containing this
+        TypeScript SDK generator. The `local` group containing this
         generator only generates if you run fern generate without specifying a
         group, or if you explicitly target it with `fern generate --group
         local`. In subsequent steps, you'll add an additional generator for your

--- a/fern/products/sdks/overview/php/quickstart.mdx
+++ b/fern/products/sdks/overview/php/quickstart.mdx
@@ -34,7 +34,7 @@ Generate a PHP SDK by following the instructions on this page.
         groups:
           local:
             generators:
-              - name: fernapi/fern-typescript-node-sdk
+              - name: fernapi/fern-typescript-sdk
                 output:
                   location: local-file-system
                   path: ../sdks/typescript
@@ -44,7 +44,7 @@ Generate a PHP SDK by following the instructions on this page.
         ```
 
         <Note>`fern init` creates a default configuration that includes the
-        TypeScript Node SDK generator. The `local` group containing this
+        TypeScript SDK generator. The `local` group containing this
         generator only generates if you run fern generate without specifying a
         group, or if you explicitly target it with `fern generate --group
         local`. In subsequent steps, you'll add an additional generator for your

--- a/fern/products/sdks/overview/python/quickstart.mdx
+++ b/fern/products/sdks/overview/python/quickstart.mdx
@@ -34,7 +34,7 @@ Generate a Python SDK by following the instructions on this page.
         groups:
           local:
             generators:
-              - name: fernapi/fern-typescript-node-sdk
+              - name: fernapi/fern-typescript-sdk
                 output:
                   location: local-file-system
                   path: ../sdks/typescript
@@ -44,7 +44,7 @@ Generate a Python SDK by following the instructions on this page.
         ```
 
         <Note>`fern init` creates a default configuration that includes the
-        TypeScript Node SDK generator. The `local` group containing this
+        TypeScript SDK generator. The `local` group containing this
         generator only generates if you run fern generate without specifying a
         group, or if you explicitly target it with `fern generate --group
         local`. In subsequent steps, you'll add an additional generator for your

--- a/fern/products/sdks/overview/ruby/quickstart.mdx
+++ b/fern/products/sdks/overview/ruby/quickstart.mdx
@@ -44,7 +44,7 @@ Generate a Ruby SDK by following the instructions on this page.
         ```
 
         <Note>`fern init` creates a default configuration that includes the
-        TypeScript Node SDK generator. The `local` group containing this
+        TypeScript SDK generator. The `local` group containing this
         generator only generates if you run fern generate without specifying a
         group, or if you explicitly target it with `fern generate --group
         local`. In subsequent steps, you'll add an additional generator for your

--- a/fern/products/sdks/overview/typescript/configuration.mdx
+++ b/fern/products/sdks/overview/typescript/configuration.mdx
@@ -10,7 +10,7 @@ default-group: local
 groups:
   local:
     generators:
-      - name: fernapi/fern-typescript-node-sdk
+      - name: fernapi/fern-typescript-sdk
         version: 0.7.1
         config:
           namespaceExport: Acme

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -33,7 +33,7 @@ Generate a TypeScript SDK by following the instructions on this page.
         groups:
           local:
             generators:
-              - name: fernapi/fern-typescript-node-sdk
+              - name: fernapi/fern-typescript-sdk
                 output:
                   location: local-file-system
                   path: ../sdks/typescript
@@ -43,7 +43,7 @@ Generate a TypeScript SDK by following the instructions on this page.
         ```
 
         <Note>`fern init` creates a default configuration that includes the
-        TypeScript Node SDK generator. The `local` group containing this
+        TypeScript SDK generator. The `local` group containing this
         generator only generates if you run fern generate without specifying a
         group, or if you explicitly target it with `fern generate --group
         local`. In subsequent steps, you'll add an additional generator for your
@@ -59,7 +59,7 @@ Generate a TypeScript SDK by following the instructions on this page.
 Add the TypeScript SDK generator:
 
 ```bash
-fern add fern-typescript-node-sdk --group sdk
+fern add fern-typescript-sdk --group sdk
 ```
 
 This command adds the following to `generators.yml`:
@@ -67,7 +67,7 @@ This command adds the following to `generators.yml`:
 ```yaml
   sdk:
     generators:
-      - name: fernapi/fern-typescript-node-sdk
+      - name: fernapi/fern-typescript-sdk
         version: <Markdown src="/snippets/version-number.mdx"/>
         output:
           location: local-file-system
@@ -78,15 +78,12 @@ This command adds the following to `generators.yml`:
 ```bash
 fern/ # created in step 1
 sdks/ # created by fern generate --group sdk
-  ├─ typescript
-      ├─ cjs/
-          ├─ api/
-          ├─ core/
-          └─ errors/
-      └─ esm/
-          ├─ api/
-          ├─ core/
-          └─ errors/
+├─ typescript
+    ├─ Client.ts
+    ├─ index.ts
+    ├─ errors/
+    ├─ core/
+    └─ api/
 ```
   
 </Steps>


### PR DESCRIPTION
Change `fern-typescript-node-sdk` references to `fern-typescript-sdk` in new docs.