### PR TITLE
docs: Update quickstart guide with placeholder text

### DIFF
--- a/fern/products/docs/pages/guides/getting-started/quickstart.mdx
+++ b/fern/products/docs/pages/guides/getting-started/quickstart.mdx
@@ -4,4 +4,6 @@ title: Quickstart
 
 Get started quickly with our documentation platform in just a few steps.
 
-<Warning>This page is a WIP, please refer to our previous [documentation](https://buildwithfern.com/learn/docs/getting-started/overview).</Warning> 
+What is this? this is deep.
+
+<Warning>This page is a WIP, please refer to our previous [documentation](https://buildwithfern.com/learn/docs/getting-started/overview).</Warning>


### PR DESCRIPTION

Added placeholder text "What is this? this is deep." to the quickstart guide page while maintaining the existing WIP warning message. This appears to be a temporary content addition that will need to be replaced with actual documentation content.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)