### PR TITLE
chore: Update image paths to use file references in welcome page

### DIFF
--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -6,17 +6,13 @@ hide-toc: true
 layout: custom
 ---
 
-import { FernStatusWidget } from "../../../components/FernStatus";
-
-<style>
+import { FernStatusWidget } from "../../../components/FernStatus";<style>
   {`
     #builtwithfern {
       display: none !important;
     }
   `}
-</style>
-
-<div className="absolute inset-0 z-[-1] box-border block">
+</style><div className="absolute inset-0 z-[-1] box-border block">
   <div 
     style={{
       inset: 0,
@@ -29,9 +25,7 @@ import { FernStatusWidget } from "../../../components/FernStatus";
   <div className="bg-gradient-blue-left box-border block" />
   <div className="bg-gradient-green-right box-border block" />
   <div className="bg-gradient-blue-right box-border block" />
-</div>
-
-<div className="lp-page-container">
+</div><div className="lp-page-container">
   {/* Main Content */}
   <div className="main-content">
     {/* Dashed Pattern - Left Side */}
@@ -68,13 +62,13 @@ import { FernStatusWidget } from "../../../components/FernStatus";
         
         <div className="sdks-preview">
           <img
-            src="./images/sdks-preview-light.svg"
+            src="file:bb9892b9-aada-4b86-8149-858796fff863"
             alt="SDK Generation Preview"
             className="sdks-preview-img dark:hidden"
             noZoom
           />
           <img
-            src="./images/sdks-preview-dark.svg"
+            src="file:bde00923-2471-4892-a8e8-d6db9688e83f"
             alt="SDK Generation Preview"
             className="sdks-preview-img hidden dark:block"
             noZoom
@@ -86,31 +80,31 @@ import { FernStatusWidget } from "../../../components/FernStatus";
           <span className="language-icons-label">Get started with:</span>
           {/* TypeScript */}
           <a className="language-icon" href="/sdks/overview/typescript/quickstart">
-            <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
+            <img src="file:21000412-e01c-4b74-9c48-0a407a1b49ab" alt="TypeScript" className="language-icon-img" noZoom />
           </a>
           {/* Python */}
           <a className="language-icon" href="/sdks/overview/python/quickstart">
-            <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
+            <img src="file:2b313a0e-3e91-4399-8741-f96ee45409e5" alt="Python" className="language-icon-img" noZoom />
           </a> 
           {/* Go */}
           <a className="language-icon" href="/sdks/overview/go/quickstart">
-            <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
+            <img src="file:4cb9272b-a072-4913-94f3-780fecf2742b" alt="Go" className="language-icon-img" noZoom />
           </a>
           {/* Java */}
           <a className="language-icon" href="/sdks/overview/java/quickstart">
-            <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
+            <img src="file:dd49fe5a-53ce-4d6e-9643-406eda1be7e9" alt="Java" className="language-icon-img" noZoom />
           </a>
           {/* Ruby */}
           <a className="language-icon" href="/sdks/overview/ruby/quickstart">
-            <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
+            <img src="file:3c899aca-928f-4643-bc02-6b674bf7fc87" alt="Ruby" className="language-icon-img" noZoom />
           </a>
           {/* C# */}
           <a className="language-icon" href="/sdks/overview/net/quickstart">
-            <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
+            <img src="file:7a0fff0a-2179-4d90-a859-ba353e8dbac5" alt="C#" className="language-icon-img" noZoom />
           </a>
           {/* PHP */}
           <a className="language-icon" href="/sdks/overview/php/quickstart">
-            <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
+            <img src="file:8c0036d4-65d9-4c15-a9ca-18d0a8545093" alt="PHP" className="language-icon-img" noZoom />
           </a>
         </div>
 
@@ -118,18 +112,18 @@ import { FernStatusWidget } from "../../../components/FernStatus";
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/sdks/overview/typescript/quickstart">
             Quickstart
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="/sdks/overview/introduction">
             Capabilities  
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -143,49 +137,49 @@ import { FernStatusWidget } from "../../../components/FernStatus";
           </p>
         </div>
         
-        <img src="./images/docs-preview-light.svg" alt="Docs Preview" className="docs-preview-img dark:hidden" noZoom />
-        <img src="./images/docs-preview-dark.svg" alt="Docs Preview" className="docs-preview-img hidden dark:block" noZoom />
+        <img src="file:3513c528-1506-4c3a-966f-72f697268534" alt="Docs Preview" className="docs-preview-img dark:hidden" noZoom />
+        <img src="file:dcb6867d-93af-402e-a646-19de56fb4214" alt="Docs Preview" className="docs-preview-img hidden dark:block" noZoom />
 
         <div className="action-buttons-vertical">
           <a className="fern-button filled normal primary gap-1 w-fit a-btn" href="/docs/getting-started/quickstart">
             Quickstart
-            <img src="./images/arrow-right-white.svg" alt="Arrow right" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right" className="hidden dark:block" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right" className="dark:hidden" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/migrate-from-an-existing-site">
             Import your brand language
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/guides/getting-started/add-multiple-specs">
             Add multiple specs to your docs site
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/navigation/tabs">
             Set up tabs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/navigation/products"> 
             Configure multiple products
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/navigation/versions">
             Create versions
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/reference/frontmatter">
             Customize slug from MDX
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/component-library/overview">
             See all available components
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -199,19 +193,19 @@ import { FernStatusWidget } from "../../../components/FernStatus";
           </p>
         </div>
 
-        <img src="./images/ai-search-preview-light.svg" alt="AI Search Mockup" className="ai-search-preview-img dark:hidden" noZoom />
-        <img src="./images/ai-search-preview-dark.svg" alt="AI Search Mockup" className="ai-search-preview-img hidden dark:block" noZoom />
+        <img src="file:87d8db0b-ae13-4d88-b48e-c4788242778c" alt="AI Search Mockup" className="ai-search-preview-img dark:hidden" noZoom />
+        <img src="file:822580f2-349d-4bab-a797-bdb10fbc73ec" alt="AI Search Mockup" className="ai-search-preview-img hidden dark:block" noZoom />
 
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/ask-fern/configuration/custom-prompting">
             Configure
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:151a08c9-df29-4f6b-b3ee-e16ca124d140" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -225,8 +219,8 @@ import { FernStatusWidget } from "../../../components/FernStatus";
       
       <div className="community-grid">
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/changelog-light.svg" alt="Changelog Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/changelog-dark.svg" alt="Changelog Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:f4c89221-a613-4771-9e25-696114b731e4" alt="Changelog Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:6c62a513-0dd3-4ea3-8ac2-df2fa88f1cf6" alt="Changelog Preview" noZoom />
 
           <h3 className="community-card-title">Changelog</h3>
           <p className="community-card-description">
@@ -234,14 +228,14 @@ import { FernStatusWidget } from "../../../components/FernStatus";
           </p>
           <a className="fern-button outlined normal gap-1 a-btn" href="/docs/changelog">
             Docs
-            <img src="./images/arrow-right-dark.svg" alt="Arrow right dark" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right dark" className="hidden dark:block" noZoom />
+            <img src="file:6069d44f-7c71-4631-b496-bb7de9c8dcb0" alt="Arrow right dark" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right dark" className="hidden dark:block" noZoom />
           </a>
         </div>
 
         <div className="community-card"> 
-          <img className="m-0 dark:hidden" src="./images/github-light.svg" alt="Github Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/github-dark.svg" alt="Github Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:21d787ea-7a53-4cb2-8435-7aa19e040c1e" alt="Github Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:7bfe4aec-61d0-4800-8b08-3a5d82ac017c" alt="Github Preview" noZoom />
 
           <h3 className="community-card-title">Github</h3>
           <p className="community-card-description">
@@ -249,14 +243,14 @@ import { FernStatusWidget } from "../../../components/FernStatus";
           </p>
           <a className="fern-button outlined normal gap-1 a-btn" href="https://github.com/fern-api/fern">
             View
-            <img src="./images/arrow-right-dark.svg" alt="Arrow right dark" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right dark" className="hidden dark:block" noZoom />
+            <img src="file:6069d44f-7c71-4631-b496-bb7de9c8dcb0" alt="Arrow right dark" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Arrow right dark" className="hidden dark:block" noZoom />
           </a>
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/slack-light.svg" alt="Discord Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/slack-dark.svg" alt="Discord Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:fa631477-45e5-4523-b32d-23a035f7d41f" alt="Discord Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:298091e2-2024-474f-9c06-9de2bb333fbd" alt="Discord Preview" noZoom />
 
           <h3 className="community-card-title">Slack</h3>
           <p className="community-card-description">
@@ -264,14 +258,14 @@ import { FernStatusWidget } from "../../../components/FernStatus";
           </p>
           <a className="fern-button outlined normal gap-1 a-btn" href="https://buildwithfern.com/slack">
             View
-            <img src="./images/arrow-right-dark.svg" alt="Twitter Preview" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Twitter Preview" className="hidden dark:block" noZoom />
+            <img src="file:6069d44f-7c71-4631-b496-bb7de9c8dcb0" alt="Twitter Preview" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Twitter Preview" className="hidden dark:block" noZoom />
           </a>
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/x-light.svg" alt="Twitter Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/x-dark.svg" alt="Twitter Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:a0ac4fcd-8794-4c2a-8235-820d57ccc9e0" alt="Twitter Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:d9834b6c-1c16-4169-b6b6-98e6a2b7ddfc" alt="Twitter Preview" noZoom />
 
           <h3 className="community-card-title">
             <span className="twitter-strikethrough">Twitter</span> X
@@ -281,8 +275,8 @@ import { FernStatusWidget } from "../../../components/FernStatus";
           </p>
           <a className="fern-button outlined normal gap-1 a-btn" href="https://x.com/buildwithfern">
             View
-            <img src="./images/arrow-right-dark.svg" alt="Twitter Preview" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Twitter Preview" className="hidden dark:block" noZoom />
+            <img src="file:6069d44f-7c71-4631-b496-bb7de9c8dcb0" alt="Twitter Preview" className="dark:hidden" noZoom />
+            <img src="file:6d2dcce3-67d3-48ef-b60f-79612c5d8805" alt="Twitter Preview" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -299,15 +293,15 @@ import { FernStatusWidget } from "../../../components/FernStatus";
       
       <div className="help-buttons">
         <a className="fern-button outlined normal gap-2 a-btn" href="https://github.com/fern-api/fern/issues">
-          <img src="./images/github-light.svg" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/github-dark.svg" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:21d787ea-7a53-4cb2-8435-7aa19e040c1e" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:7bfe4aec-61d0-4800-8b08-3a5d82ac017c" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
 
           File a Github issue
         </a>
 
         <a className="fern-button outlined normal gap-2 a-btn" href="mailto:support@buildwithfern.com">
-          <img src="./images/email-light.svg" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/email-dark.svg" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:b6f18bc3-5cd1-408d-9d58-800984a0a727" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:bbc9ceb2-05f0-41cc-9f4b-369e6f36c9da" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
 
           Email us
         </a>
@@ -319,11 +313,11 @@ import { FernStatusWidget } from "../../../components/FernStatus";
       <div className="footer-top">
         {/* Left Column - Logo and Status */}
         <a className="footer-logo" href="https://buildwithfern.com">
-          <img src="./images/builtwithfern-light.svg" alt="Fern" className="footer-logo-img dark:hidden" noZoom />
-          <img src="./images/builtwithfern-dark.svg" alt="Fern" className="footer-logo-img hidden dark:block" noZoom />
+          <img src="file:a45a835a-abf9-43ca-830e-d2ce15596e86" alt="Fern" className="footer-logo-img dark:hidden" noZoom />
+          <img src="file:806d97ba-2e00-47a9-9965-221b2ffa4cf8" alt="Fern" className="footer-logo-img hidden dark:block" noZoom />
 
-          <img src="./images/builtwithfern-frame-light.svg" alt="Fern" className="footer-logo-frame dark:hidden" noZoom />
-          <img src="./images/builtwithfern-frame-dark.svg" alt="Fern" className="footer-logo-frame hidden dark:block" noZoom />
+          <img src="file:a2d733f7-c964-4d80-9ddc-3dfcee720a88" alt="Fern" className="footer-logo-frame dark:hidden" noZoom />
+          <img src="file:7feeebca-6448-468b-8d68-4bfa2065f0f5" alt="Fern" className="footer-logo-frame hidden dark:block" noZoom />
         </a>
         
         <div className="footer-status">
@@ -334,7 +328,7 @@ import { FernStatusWidget } from "../../../components/FernStatus";
           <FernStatusWidget />
           
           <a className="soc2-badge" href="https://security.buildwithfern.com/">
-            <img src="./images/soc2.svg" alt="Soc 2 Type II" className="soc2-badge-img" noZoom />
+            <img src="file:ab1bd9ad-5343-4892-ad6c-6c9dca920fcb" alt="Soc 2 Type II" className="soc2-badge-img" noZoom />
             <span className="status-text">Soc 2 Type II</span>
           </a>
         </div>


### PR DESCRIPTION

This PR updates all image source paths in the welcome.mdx page from relative file paths (./images/*) to file reference IDs. The change appears to be related to how images are handled in the visual editor, moving from direct file references to a file ID system. No functional changes to the actual images or layout were made - this is purely a technical update to the image reference format.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)