### PR TITLE
docs: Update Java SDK design doc with placeholder sections

### DIFF
--- a/fern/products/sdks/overview/java/design.mdx
+++ b/fern/products/sdks/overview/java/design.mdx
@@ -1,8 +1,17 @@
 ---
 title: Java SDK Design
-description: "Key design decisions behind our Java SDK generator"
+description: Key design decisions behind our Java SDK generator
 ---
 
 Learn about the design principles and philosophy behind the Fern Java SDK. 
 
-<Warning>This page is a WIP, please refer to our previous [documentation](https://buildwithfern.com/learn/sdks/introduction/overview).</Warning> 
+
+
+## Add a section
+
+Add a paragraph
+
+`Add an image`
+
+<Warning>This page is a WIP, please refer to our previous [documentation](https://buildwithfern.com/learn/sdks/introduction/overview).</Warning>
+


### PR DESCRIPTION

Added placeholder sections to the Java SDK design documentation page including a new section header, paragraph placeholder, and image placeholder. This provides a basic structure for the upcoming content while maintaining the existing WIP notice. The description field was also cleaned up by removing unnecessary quotation marks.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)