### PR TITLE
Add Java Custom Code Page

### DIFF
--- a/fern/products/sdks/overview/java/custom-code.mdx
+++ b/fern/products/sdks/overview/java/custom-code.mdx
@@ -38,7 +38,7 @@ description: Augment your Java SDK with custom utilities
 
     ### Consume the helper
 
-    Now your users can consume the helper function by importing it from the SDK:
+    <Markdown src="/products/sdks/snippets/consume-method.mdx"/>
 
     ```java
     import com.example.helper.Helper;
@@ -96,7 +96,7 @@ description: Augment your Java SDK with custom utilities
 
       ### Consume the method
 
-      Now your users can consume the helper function by importing it from the SDK:
+      <Markdown src="/products/sdks/snippets/consume-method.mdx"/>
 
       ```java
       client.myHelper();

--- a/fern/products/sdks/overview/java/custom-code.mdx
+++ b/fern/products/sdks/overview/java/custom-code.mdx
@@ -3,6 +3,56 @@ title: Adding custom code
 description: Augment your Java SDK with custom utilities
 ---
 
-Learn how to extend your Fern Java SDK with custom code and utilities.
+<Markdown src="/products/sdks/snippets/custom-code-intro.mdx"/>
 
-<Warning>This page is a WIP, please refer to our previous [documentation](https://buildwithfern.com/learn/sdks/capabilities/custom-code).</Warning>
+## Adding custom logic
+
+<Markdown src="/products/sdks/snippets/custom-logic-intro.mdx"/>
+
+<Steps>
+
+    ### Create a new file and add your custom logic
+    
+    ```java title="src/main/java/<package>/Helper.java"
+    package com.example.helper;
+
+    public class Helper {
+
+    public static void myHelper() {
+        System.out.println("Hello World!");
+    }
+
+    }
+    ```
+
+    ### Add your file to `.fernignore`
+
+    <Tip>A `.fernignore` file is automatically created in your SDK repository when you use GitHub publishing.</Tip>
+
+
+    ```yaml {3} title=".fernignore"
+    # Specify files that shouldn't be modified by Fern
+
+    src/main/java/<package>/Helper.java
+    ```
+
+    ### Consume the helper
+
+    Now your users can consume the helper function by importing it from the SDK:
+
+    ```java
+    import com.example.helper.Helper;
+
+    public class Main {
+
+    public static void main(String[] args) {
+        Helper.myHelper();
+    }
+
+    }
+    ```
+</Steps>
+
+    ## Adding custom SDK methods
+
+    <Markdown src="/products/sdks/snippets/custom-sdk-methods-intro.mdx"/>

--- a/fern/products/sdks/overview/java/custom-code.mdx
+++ b/fern/products/sdks/overview/java/custom-code.mdx
@@ -56,3 +56,64 @@ description: Augment your Java SDK with custom utilities
     ## Adding custom SDK methods
 
     <Markdown src="/products/sdks/snippets/custom-sdk-methods-intro.mdx"/>
+
+    <Steps>
+      ### Update `generators.yml` configuration
+      Name your Fern-generated client something like `BaseClient` to reflect that this client will be extended.
+
+      ```yml {4} title="generators.yml"
+      - name: fernapi/fern-java-sdk
+          version: "..."
+          config:
+            client-class-name: BaseClient
+      ```
+
+      ### Import and extend the generated client
+
+      First, import the Fern generated base client and extend it. Then, add whatever methods you want.
+
+      ```java title="src/main/java/com/example/MyClient.java"
+      package com.example;
+
+      import com.example.client.BaseClient;
+
+      public class MyClient extends BaseClient { // extend the Fern generated client
+
+        public void myHelper() {
+          System.out.println("Hello World!");
+        }
+
+      }
+      ```
+
+      ### Update `.fernignore`
+
+      Add the `MyClient.java` to `.fernignore`.
+
+        ```diff title=".fernignore"
+        + src/main/java/com/example/MyClient.java
+        ```
+
+      ### Consume the method
+
+      Now your users can consume the helper function by importing it from the SDK:
+
+      ```java
+      client.myHelper();
+      ```
+    </Steps>
+
+
+## Adding custom dependencies
+
+To add packages that your custom code requires, update your `generators.yml`.
+
+      ```yaml {4-7} title="generators.yml"
+      - name: fernapi/fern-java-sdk
+        version: "..."
+        config:
+          custom-dependencies:
+            - org.apache.commons:commons-lang3:3.12.0
+            - org.slf4j:slf4j-api:2.0.7
+
+      ```

--- a/fern/products/sdks/overview/python/custom-code.mdx
+++ b/fern/products/sdks/overview/python/custom-code.mdx
@@ -32,7 +32,7 @@ description: Augment your Python SDK with custom utilities
 
     ### Consume the helper
 
-    Now your users can consume the helper function by importing it from the SDK:
+    <Markdown src="/products/sdks/snippets/consume-method.mdx"/>
 
     ```python
     from package.helper import my_helper
@@ -109,7 +109,7 @@ description: Augment your Python SDK with custom utilities
 
       ### Consume the method
 
-      Now your users can consume the helper function by importing it from the SDK:
+      <Markdown src="/products/sdks/snippets/consume-method.mdx"/>
 
       ```python
       client.my_helper()

--- a/fern/products/sdks/overview/python/custom-code.mdx
+++ b/fern/products/sdks/overview/python/custom-code.mdx
@@ -3,21 +3,11 @@ title: Adding custom code
 description: Augment your Python SDK with custom utilities
 ---
 
-Fern-generated SDKs are designed to be extended with custom code. Your custom
-code can add additional functionality to the SDK and live in harmony with the
-generated code. This page explains how to configure custom logic using a
-`.fernignore` file, create custom SDK methods, and add additional dependencies to your Python SDK.
+<Markdown src="/products/sdks/snippets/custom-code-intro.mdx"/>
 
 ## Adding custom logic
 
-If you want your SDK to do more than just make basic API calls (like combining
-multiple calls, processing data, adding utilities), you can use `.fernignore` to
-protect your custom code from being overwritten during regeneration.
-
-Simply add your custom files to the SDK repository and  list them out in `.fernignore`. Fern
-won't override any files that you add in `.fernignore`.
-
-To get started adding custom code:
+<Markdown src="/products/sdks/snippets/custom-logic-intro.mdx"/>
 
 <Steps>
 
@@ -53,9 +43,7 @@ To get started adding custom code:
 
     ## Adding custom SDK methods
 
-    Fern also allows you to add custom methods to the SDK itself (e.g.
-    `client.my_method()` ) by inheriting the Fern generated client and then
-    extending it.
+    <Markdown src="/products/sdks/snippets/custom-sdk-methods-intro.mdx"/>
 
     <Note>
       See an example from ElevenLabs using this process in their [Python SDK](https://github.com/elevenlabs/elevenlabs-python/blob/main/src/elevenlabs/client.py).

--- a/fern/products/sdks/overview/python/custom-code.mdx
+++ b/fern/products/sdks/overview/python/custom-code.mdx
@@ -52,9 +52,9 @@ description: Augment your Python SDK with custom utilities
     <Steps>
       ### Update `generators.yml` configuration
 
-      To add a custom method to the Python SDK, you will need to configure the
-      generator to output the client in a file called `base_client.py`. Then, you can
-      extend the base client and add whatever methods you want.
+      Name your Fern-generated client something like `BaseClient` to reflect
+      that this client will be extended. Configure the generator to output the
+      client in a file called `base_client.py`.
 
       ```yaml {4-8} title="generators.yml"
       - name: fernapi/fern-python-sdk

--- a/fern/products/sdks/snippets/consume-method.mdx
+++ b/fern/products/sdks/snippets/consume-method.mdx
@@ -1,0 +1,1 @@
+ Now your users can consume the helper function by importing it from the SDK.

--- a/fern/products/sdks/snippets/custom-code-intro.mdx
+++ b/fern/products/sdks/snippets/custom-code-intro.mdx
@@ -1,4 +1,6 @@
 Fern-generated SDKs are designed to be extended with custom code. Your custom
 code can add additional functionality to the SDK and live in harmony with the
-generated code. This page explains how to configure custom logic using a
+generated code. 
+
+This page explains how to configure custom logic using a
 `.fernignore` file, create custom SDK methods, and add additional dependencies to your SDK.

--- a/fern/products/sdks/snippets/custom-code-intro.mdx
+++ b/fern/products/sdks/snippets/custom-code-intro.mdx
@@ -1,0 +1,4 @@
+Fern-generated SDKs are designed to be extended with custom code. Your custom
+code can add additional functionality to the SDK and live in harmony with the
+generated code. This page explains how to configure custom logic using a
+`.fernignore` file, create custom SDK methods, and add additional dependencies to your SDK.

--- a/fern/products/sdks/snippets/custom-logic-intro.mdx
+++ b/fern/products/sdks/snippets/custom-logic-intro.mdx
@@ -1,0 +1,8 @@
+If you want your SDK to do more than just make basic API calls (like combining
+multiple calls, processing data, adding utilities), you can use `.fernignore` to
+protect your custom code from being overwritten during regeneration.
+
+Simply add your custom files to the SDK repository and  list them out in `.fernignore`. Fern
+won't override any files that you add in `.fernignore`.
+
+To get started adding custom code:

--- a/fern/products/sdks/snippets/custom-sdk-methods-intro.mdx
+++ b/fern/products/sdks/snippets/custom-sdk-methods-intro.mdx
@@ -1,0 +1,3 @@
+Fern also allows you to add custom methods to the SDK itself (e.g.
+`client.my_method()` ) by inheriting the Fern generated client and then
+extending it.


### PR DESCRIPTION
Copied over [Augment with Custom Code](https://buildwithfern.com/learn/sdks/capabilities/custom-code) and made some edits for clarity. Moved text that's the same across languages into snippets, and updated both this page and the Python page with the snippets where relevant. 