### PR TITLE
Hide custom code pages for Ruby, PHP, and .NET

### DIFF
--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -20,7 +20,6 @@ navigation:
             path: ./overview/typescript/custom-code.mdx
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
-            hidden: true
       - section: Python
         contents:
           - page: Quickstart
@@ -36,7 +35,6 @@ navigation:
             path: ./overview/python/custom-code.mdx  
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
-            hidden: true
       - section: Go
         contents:
           - page: Quickstart
@@ -52,7 +50,6 @@ navigation:
             path: ./overview/go/custom-code.mdx  
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
-            hidden: true
       - section: Java
         contents:
           - page: Quickstart
@@ -68,7 +65,6 @@ navigation:
             path: ./overview/java/custom-code.mdx
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
-            hidden: true
       - section: .NET
         contents:
           - page: Quickstart
@@ -81,11 +77,10 @@ navigation:
           - page: Publishing to Nuget
             path: ./overview/dotnet/publishing-to-nuget.mdx
           - page: Adding custom code
-            path: ./overview/dotnet/custom-code.mdx
             hidden: true
+            path: ./overview/dotnet/custom-code.mdx
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
-            hidden: true
       - section: PHP
         contents:
           - page: Quickstart
@@ -98,11 +93,10 @@ navigation:
           - page: Publishing to Packagist
             path: ./overview/php/publishing-to-packagist.mdx
           - page: Adding custom code
-            path: ./overview/php/custom-code.mdx
             hidden: true
+            path: ./overview/php/custom-code.mdx
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
-            hidden: true
       - section: Ruby
         contents:
           - page: Quickstart
@@ -115,11 +109,10 @@ navigation:
           - page: Publishing to RubyGems
             path: ./overview/ruby/publishing-to-rubygems.mdx
           - page: Adding custom code
-            path: ./overview/ruby/custom-code.mdx
             hidden: true
+            path: ./overview/ruby/custom-code.mdx
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
-            hidden: true
   - section: Guides
     contents:    
       - page: Customize Method Names

--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -20,6 +20,7 @@ navigation:
             path: ./overview/typescript/custom-code.mdx
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
+            hidden: true
       - section: Python
         contents:
           - page: Quickstart
@@ -35,6 +36,7 @@ navigation:
             path: ./overview/python/custom-code.mdx  
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
+            hidden: true
       - section: Go
         contents:
           - page: Quickstart
@@ -50,6 +52,7 @@ navigation:
             path: ./overview/go/custom-code.mdx  
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
+            hidden: true
       - section: Java
         contents:
           - page: Quickstart
@@ -65,6 +68,7 @@ navigation:
             path: ./overview/java/custom-code.mdx
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
+            hidden: true
       - section: .NET
         contents:
           - page: Quickstart
@@ -78,8 +82,10 @@ navigation:
             path: ./overview/dotnet/publishing-to-nuget.mdx
           - page: Adding custom code
             path: ./overview/dotnet/custom-code.mdx
+            hidden: true
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
+            hidden: true
       - section: PHP
         contents:
           - page: Quickstart
@@ -93,8 +99,10 @@ navigation:
             path: ./overview/php/publishing-to-packagist.mdx
           - page: Adding custom code
             path: ./overview/php/custom-code.mdx
+            hidden: true
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
+            hidden: true
       - section: Ruby
         contents:
           - page: Quickstart
@@ -108,8 +116,10 @@ navigation:
             path: ./overview/ruby/publishing-to-rubygems.mdx
           - page: Adding custom code
             path: ./overview/ruby/custom-code.mdx
+            hidden: true
           - link: Customer Showcase
             href: https://buildwithfern.com/showcase
+            hidden: true
   - section: Guides
     contents:    
       - page: Customize Method Names


### PR DESCRIPTION
No content for these pages on [Augment with Custom Code](https://buildwithfern.com/learn/sdks/capabilities/custom-code). 