### PR TITLE
Add Global Headers guide

### DIFF
--- a/fern/products/sdks/guides/configure-global-headers.mdx
+++ b/fern/products/sdks/guides/configure-global-headers.mdx
@@ -6,9 +6,7 @@ description: Guide to configuring global headers in your SDKs.
 Your API may leverage certain headers for every endpoint or most endpoints.
 These are called **global headers**.
 
-Fern automatically identifies headers that are used in every request, or the
-majority of requests, and marks them as global. You can manually configure additional
-global headers in either `api.yml` (Fern Definition) or `openapi.yml`.
+## How it works for SDK users
 
 Once you configure a global header (either automatically detected or manually
 specified), Fern generates an SDK that accepts this as a constructor parameter.
@@ -23,11 +21,14 @@ class Client:
   def __init__(self, *, apiKey: str):
 ```
 
-## Specifying Global Headers in a Fern Definition or OpenAPI spec
-<Tabs>
-<Tab title="Fern Definition">
+## Specifying global headers
 
-### Global Headers
+Fern automatically identifies headers that are used in every request, or the
+majority of requests, and marks them as global. You can manually configure additional
+global headers in either `api.yml` (Fern Definition) or `openapi.yml`.
+
+<AccordionGroup>
+<Accordion title="Fern Definition">
 
 To specify headers that are meant to be included on every request:
 
@@ -73,11 +74,11 @@ service:
 If you'd like to see this feature, please upvote [this issue](https://github.com/fern-api/fern/issues/2930).
 </Note>
 
-</Tab>
-<Tab title="OpenAPI">
+</Accordion>
+<Accordion title="OpenAPI">
 
-### Global Headers
-Use the `x-fern-global-headers` extension to label additional headers as global or to alias the names of global headers:
+Use the `x-fern-global-headers` extension to label additional headers as global
+or to alias the names of global headers:
 
 ```yaml title="openapi.yml"
 x-fern-global-headers:
@@ -96,5 +97,5 @@ class Client:
 
   def __init__(self, *, apiKey: str, userpoolId: typing.Optional[str])
 ```
-</Tab>
-</Tabs>
+</Accordion>
+</AccordionGroup>

--- a/fern/products/sdks/guides/configure-global-headers.mdx
+++ b/fern/products/sdks/guides/configure-global-headers.mdx
@@ -3,6 +3,95 @@ title: Configure Global Headers
 description: Guide to configuring global headers in your SDKs.
 ---
 
-Learn how to configure global headers for all requests made by your SDKs. 
+Your API may leverage certain headers for every endpoint or most endpoints.
+These are called **global headers**.
 
-<Warning>Docs are coming soon for this page.<br/><br/>Please [book a demo](https://buildwithfern.com/book-demo) or [reach out to us](https://buildwithfern.com/book-demo) to get set up with this feature. </Warning> 
+Fern automatically pulls out headers that are used in every request, or the
+majority of requests, and marks them as global. You can manually configure additional
+headers as global in either `api.yml` (Fern Definition) or `openapi.yml`.
+
+Once you configure a global header, Fern generates an SDK that accepts this as a
+constructor parameter. Users can then provide the value once, and the generated
+SDK automatically includes the header in all their API calls:
+
+```python
+import os
+
+class Client:
+
+  def __init__(self, *, apiKey: str):
+```
+<Tabs>
+<Tab title="Fern Definition">
+
+## Global Headers
+
+To specify headers that are meant to be included on every request:
+
+<CodeBlock title="api.yml">
+```yaml {3}
+name: api
+headers:
+  X-App-Id: string
+```
+</CodeBlock>
+
+## Global path parameters
+You can also specify path parameters that are meant to be included on every request:
+
+<CodeBlock title="api.yml">
+```yaml
+name: api
+base-path: /{userId}/{orgId}
+path-parameters:
+  userId: string
+  orgId: string
+```
+</CodeBlock>
+
+### Overriding the base path
+
+If you have certain endpoints that do not live at the configured `base-path`, you can 
+override the `base-path` at the endpoint level. 
+
+```yml imdb.yml {5}
+service: 
+  endpoints: 
+    getMovie: 
+      method: POST
+      base-path: "override/{arg}"
+      path: "movies/{movieId}"
+      path-parameters: 
+        arg: string
+```
+
+<Note>
+  You cannot yet specify query parameters that are meant to be included on every request.
+If you'd like to see this feature, please upvote [this issue](https://github.com/fern-api/fern/issues/2930).
+</Note>
+
+</Tab>
+<Tab title="OpenAPI">
+
+## Global Headers
+Use the `x-fern-global-headers` extension to label additional headers as global or to alias the names of global headers:
+
+```yaml title="openapi.yml"
+x-fern-global-headers:
+  - header: custom_api_key
+    name: api_key
+  - header: userpool_id
+    optional: true
+```
+
+yields the following client:
+
+```python
+import os
+
+class Client:
+
+  def __init__(self, *, apiKey: str, userpoolId: typing.Optional[str])
+```
+</Tab>
+</Tabs>

--- a/fern/products/sdks/guides/configure-global-headers.mdx
+++ b/fern/products/sdks/guides/configure-global-headers.mdx
@@ -6,13 +6,14 @@ description: Guide to configuring global headers in your SDKs.
 Your API may leverage certain headers for every endpoint or most endpoints.
 These are called **global headers**.
 
-Fern automatically pulls out headers that are used in every request, or the
+Fern automatically identifies headers that are used in every request, or the
 majority of requests, and marks them as global. You can manually configure additional
-headers as global in either `api.yml` (Fern Definition) or `openapi.yml`.
+global headers in either `api.yml` (Fern Definition) or `openapi.yml`.
 
-Once you configure a global header, Fern generates an SDK that accepts this as a
-constructor parameter. Users can then provide the value once, and the generated
-SDK automatically includes the header in all their API calls:
+Once you configure a global header (either automatically detected or manually
+specified), Fern generates an SDK that accepts this as a constructor parameter.
+Users can then provide the value once, and the generated SDK automatically
+includes the header in all their API calls:
 
 ```python
 import os
@@ -21,10 +22,12 @@ class Client:
 
   def __init__(self, *, apiKey: str):
 ```
+
+## Specifying Global Headers in a Fern Definition or OpenAPI spec
 <Tabs>
 <Tab title="Fern Definition">
 
-## Global Headers
+### Global Headers
 
 To specify headers that are meant to be included on every request:
 
@@ -36,7 +39,7 @@ headers:
 ```
 </CodeBlock>
 
-## Global path parameters
+### Global path parameters
 You can also specify path parameters that are meant to be included on every request:
 
 <CodeBlock title="api.yml">
@@ -49,7 +52,7 @@ path-parameters:
 ```
 </CodeBlock>
 
-### Overriding the base path
+#### Overriding the base path
 
 If you have certain endpoints that do not live at the configured `base-path`, you can 
 override the `base-path` at the endpoint level. 
@@ -73,7 +76,7 @@ If you'd like to see this feature, please upvote [this issue](https://github.com
 </Tab>
 <Tab title="OpenAPI">
 
-## Global Headers
+### Global Headers
 Use the `x-fern-global-headers` extension to label additional headers as global or to alias the names of global headers:
 
 ```yaml title="openapi.yml"
@@ -84,7 +87,7 @@ x-fern-global-headers:
     optional: true
 ```
 
-yields the following client:
+This configuration yields the following client:
 
 ```python
 import os


### PR DESCRIPTION
Pulled content from [this page on Fern Definition global headers](https://buildwithfern.com/learn/api-definition/fern/api-yml/global-headers) and [this section on OpenAPI global headers](https://buildwithfern.com/learn/api-definition/openapi/extensions/others#global-headers)