### PR TITLE
docs: Add placeholder text and test change to OpenAPI servers documentation

### DIFF
--- a/fern/products/api-definition/pages/openapi/auth.mdx
+++ b/fern/products/api-definition/pages/openapi/auth.mdx
@@ -1,9 +1,11 @@
 ---
 title: Authentication
-subtitle: Model auth schemes such as bearer, basic, and api key. 
+subtitle: Model auth schemes such as bearer, basic, and api key.
 ---
 
 Configuring authentication schemes happens in the `components.securitySchemes` section of OpenAPI. 
+
+testing
 
 ```yml title="openapi.yml" {2-3}
 components: 
@@ -112,7 +114,7 @@ components:
           env: PLANTSTORE_CLIENT_SECRET
 ```
 
-The generated SDK would look like: 
+PLACEHOLDER10ee42b5c814815d9779dd9501cf6d82f084053452713baac7cdaf8a0278360c
 
 ```ts index.ts
 
@@ -148,8 +150,7 @@ const client = new Client({
 })
 ```
 
-If you want to control variable naming and environment variables to scan, 
-use the configuration below: 
+PLACEHOLDERb64a0e78a36be1b80ce04294200dd76252e7d81c034abe2e93ef75cb75791afe
 
 ```yaml title="openapi.yml" {7-10}
 components: 
@@ -164,7 +165,7 @@ components:
         prefix: "Token " # Optional      
 ```
 
-The generated SDK would look like: 
+PLACEHOLDER10ee42b5c814815d9779dd9501cf6d82f084053452713baac7cdaf8a0278360c
 
 ```ts index.ts
 

--- a/fern/products/api-definition/pages/openapi/servers.mdx
+++ b/fern/products/api-definition/pages/openapi/servers.mdx
@@ -6,6 +6,8 @@ subtitle: Define server URLs and environments to help users connect to your API.
 
 OpenAPI allows you to specify one or more base URLs under the `servers` key.
 
+I am trying a change.
+
 ```yml openapi.yml 
 
 servers: 
@@ -14,6 +16,7 @@ servers:
 ```
 
 Specifying servers is valuable for both SDKs and Docs: 
+
 - For SDKs, your users won't need to manually specify the baseURL at client instantiation
 - For Docs, your API playground will automatically hit the correct server
 
@@ -82,3 +85,5 @@ api:
 ```
 
 <Info>To see an example of this in production, check out the Chariot [generators.yml](https://github.com/chariot-giving/chariot-openapi/blob/main/fern/apis/2025-02-24/generators.yml)</Info>
+
+PLACEHOLDER52f35b09ec19d17f6d94e5beeef5bcff0ada6f36062bd9bfc801bc4e13c84285


### PR DESCRIPTION

Updates the OpenAPI servers documentation page with test content and a placeholder hash. This appears to be a temporary change, likely for testing purposes, that adds a test line "I am trying a change" and appends a placeholder hash value at the bottom of the document.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)