### PR TITLE
docs(openapi): Add placeholder text and minor formatting updates to servers.mdx

### DIFF
--- a/fern/products/api-definition/pages/openapi/servers.mdx
+++ b/fern/products/api-definition/pages/openapi/servers.mdx
@@ -6,6 +6,8 @@ subtitle: Define server URLs and environments to help users connect to your API.
 
 OpenAPI allows you to specify one or more base URLs under the `servers` key.
 
+Another THING!
+
 ```yml openapi.yml 
 
 servers: 
@@ -14,6 +16,7 @@ servers:
 ```
 
 Specifying servers is valuable for both SDKs and Docs: 
+
 - For SDKs, your users won't need to manually specify the baseURL at client instantiation
 - For Docs, your API playground will automatically hit the correct server
 
@@ -82,3 +85,5 @@ api:
 ```
 
 <Info>To see an example of this in production, check out the Chariot [generators.yml](https://github.com/chariot-giving/chariot-openapi/blob/main/fern/apis/2025-02-24/generators.yml)</Info>
+
+PLACEHOLDER52f35b09ec19d17f6d94e5beeef5bcff0ada6f36062bd9bfc801bc4e13c84285


### PR DESCRIPTION
This PR makes minor documentation updates to the OpenAPI servers page, including adding placeholder text and formatting improvements. The changes include adding a test placeholder string, an additional exclamation, and some whitespace adjustments to improve readability. These appear to be temporary changes that may need further refinement before merging.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)