### PR TITLE
docs: Add servers configuration guide for OpenAPI documentation

### DIFF
--- a/fern/products/openapi-def/pages/servers.mdx
+++ b/fern/products/openapi-def/pages/servers.mdx
@@ -1,0 +1,80 @@
+---
+title: Servers
+description: Configure server URLs and environments to help users connect to your API.
+subtitle: Define server URLs and environments to help users connect to your API.
+---
+
+OpenAPI allows you to specify one or more base URLs under the `servers` key.
+
+```yml openapi.yml 
+
+servers: 
+  - url: https://api.yourcompany.com/
+  - url: https://api.eu.yourcompany.com/
+```
+
+Specifying servers is valuable for both SDKs and Docs:
+
+- For SDKs, your users won't need to manually specify the baseURL at client instantiation
+
+- For Docs, your API playground will automatically hit the correct server
+
+## Naming your servers
+
+If you have more than one server, we recommend specifying an `x-fern-server-name` to name the server.
+
+```yml openapi.yml {3,5}
+servers: 
+  - x-fern-server-name: Production
+    url: https://api.yourcompany.com/
+  - x-fern-server-name: Production_EU
+    url: https://api.eu.yourcompany.com/
+```
+
+## Multiple Base URLs for a single API
+
+If you have a microservice architecture, it is possible that you may have different endpoints hosted at different URLs. For example, your AI endpoints might be hosted at `ai.yourcompany.com` and the rest of your endpoints might be hosted at `api.yourcompany.com`.
+
+To specify this, you will need to add configuration to both your `generators.yml` and OpenAPI spec. The snippet directly below shows how to configure an environment with multiple urls in your `generators.yml`. AND MORE
+
+```yml generators.yml {3-8}
+api: 
+  default-environment: Production
+  default-url: api
+  environments: 
+    Production: 
+      api: api.yourcompany.com
+      ai: ai.yourcompany.com
+  specs: 
+    - openapi: ./path/to/your/openapi
+      overrides: ./path/to/your/overrides # optional
+```
+
+Once you've specified the environments in your `generators.yml`, you can use the `x-fern-server-name` extension to specify which server the operation belongs to.
+
+```yml openapi.yml {4}
+paths: 
+  /chat: 
+    post: 
+      x-fern-server-name: ai 
+```
+
+If you have multiple environments like development or staging, you can model those in your `generators.yml` as well.
+
+```yml generators.yml {7-12}
+api: 
+  default-environment: Production
+  default-url: api
+  environments: 
+    Production: 
+      api: api.yourcompany.com
+      ai: ai.yourcompany.com
+    Staging: 
+      api: api.staging.yourcompany.com
+      ai: ai.staging.yourcompany.com    
+    Dev: 
+      api: api.dev.yourcompany.com
+      ai: ai.dev.yourcompany.com          
+```
+
+<Info>To see an example of this in production, check out the Chariot [generators.yml](https://github.com/chariot-giving/chariot-openapi/blob/main/fern/apis/2025-02-24/generators.yml)</Info>


### PR DESCRIPTION

This PR adds a new documentation page explaining how to configure server URLs and environments in OpenAPI specifications. The guide covers basic server configuration, server naming conventions using x-fern-server-name, and advanced multi-URL setups for microservice architectures. It includes practical examples for setting up multiple environments (Production, Staging, Dev) and demonstrates how to properly configure the generators.yml file alongside the OpenAPI spec.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)