### PR TITLE
Move Fern Folder Initialization Instructions into Fern folder page

### DIFF
--- a/fern/products/sdks/fern-folder.mdx
+++ b/fern/products/sdks/fern-folder.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview of the Fern Folder
+title: Set up the Fern Folder
 description: Describes the Fern folder structure
 ---
 
@@ -9,47 +9,39 @@ your API definitions, generators, and your CLI version.
 After you configure your `fern` folder, you'll be ready to start generating SDKs
 in different languages. 
 
-## Directory structure
+## Set up the fern folder
 
-You can initialize your Fern folder with either a Fern Definition or OpenAPI specification.
+<Steps>
 
-<Info>
-  You can always convert a Fern Definition to OpenAPI or OpenAPI to a Fern Definition later on.
-</Info>
+<Markdown src="/products/sdks/snippets/install-cli.mdx"/>
 
-The `fern` directory is initialized with:
+  ### Initialize the Fern Folder
+
+  <Markdown src="/products/sdks/snippets/initialize-fern-folder-intro.mdx"/>
+
+  <AccordionGroup>
+  <Markdown src="/products/sdks/snippets/option-1-openapi.mdx"/>
+
+  <Accordion title="Option 2: Fern Definition">
+  
+  <Markdown src="/products/sdks/snippets/option-2-fern-def.mdx"/>
+    </Accordion>
+
+    {/* <Markdown src="/products/sdks/snippets/option-3-asyncapi.mdx"/> */}
+    
+  </AccordionGroup>
+</Steps>
+
+## Learn more about the initialized files
+
+Every initialized `fern` directory has:
 * A `fern.config.json` file
 * A `generators.yml` file
-* Either a `definition/` (for a Fern Definition spec) or `openapi/` (for an OpenAPI spec) directory that contains your API specification files.
-
-<AccordionGroup>
-<Accordion title="Initializing with the Fern Definition">
-When you run `fern init`, your Fern folder will be initialized with the following files:
-```bash
-fern/
-  ├─ fern.config.json
-  ├─ generators.yml
-  └─ definition/
-    ├─ api.yml
-    └─ imdb.yml
-```
-</Accordion>
-<Accordion title="Initializing with OpenAPI">
-If you want to initialize Fern with an OpenAPI Specification, run `fern init --openapi path/to/openapi` instead.
-```yaml
-fern/
-  ├─ fern.config.json
-  ├─ generators.yml # required on Fern version 0.41.0 and above
-  └─ openapi/
-    ├─ openapi.yml
-```
-</Accordion>
-</AccordionGroup>
 
 ### `fern.config.json`
 
-Every fern folder has a single `fern.config.json` file. This file stores the organization and
-the version of the Fern CLI that you are using. 
+This file stores the organization and the version of the Fern CLI that you are
+using. 
 
 ```json
 {
@@ -70,9 +62,13 @@ API specification. For each generator, it specifies where the package is
 published and configures customizations like package metadata, output locations,
 and generation settings.
 
-## Configuring Multiple APIs
+<Info>
+  See the [`generators.yml` reference page](/learn/sdks/reference/generators-yml-reference) for more information.
+</Info>
 
-The Fern folder can house multiple API definitions. Instead of placing your API
+## Configure Multiple APIs
+
+The fern folder can house multiple API definitions. Instead of placing your API
 definitions at the top level, you can nest them within an `apis` folder. Be sure
 to include a `generators.yml` file within each API folder that specifies the
 location of the API definition. 

--- a/fern/products/sdks/overview/dotnet/quickstart.mdx
+++ b/fern/products/sdks/overview/dotnet/quickstart.mdx
@@ -3,54 +3,11 @@ title: .NET Quickstart
 description: Get started quickly with the Fern .NET SDK.
 ---
 
-<Markdown src="/products/sdks/snippets/demo-warning.mdx"/>
-
 Generate a C#/.NET SDK by following the instructions on this page. 
 
+<Markdown src="/products/sdks/snippets/quickstart-prereqs.mdx"/>
+
 <Steps>
-<Markdown src="/products/sdks/snippets/install-cli.mdx"/>
-
-  ### Initialize the Fern Folder
-
-  <Markdown src="/products/sdks/snippets/initialize-fern-folder-intro.mdx"/>
-
-  <AccordionGroup>
-    <Markdown src="/products/sdks/snippets/option-1-openapi.mdx"/>
-    
-  <Accordion title="Option 2: Fern Definition">
-  
-  <Markdown src="/products/sdks/snippets/option-2-fern-def.mdx"/>
-
-  2.    Add the config option `outputSourceFiles: true` to
-        `generators.yml`. This ensures your SDK contains source files in
-        your preferred SDK language instead of compiled output. 
-
-        ```yaml {11-12}
-        # yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
-        default-group: local
-        groups:
-          local:
-            generators:
-              - name: fernapi/fern-typescript-sdk
-                output:
-                  location: local-file-system
-                  path: ../sdks/typescript
-                version: <Markdown src="/snippets/version-number.mdx"/>
-                config:
-                  outputSourceFiles: true
-        ```
-
-        <Note>`fern init` creates a default configuration that includes the
-        TypeScript SDK generator. The `local` group containing this
-        generator only generates if you run fern generate without specifying a
-        group, or if you explicitly target it with `fern generate --group
-        local`. In subsequent steps, you'll add an additional generator for your
-        preferred SDK language.</Note>
-    </Accordion>
-
-    {/* <Markdown src="/products/sdks/snippets/option-3-asyncapi.mdx"/> */}
-
-  </AccordionGroup>
 
 <Markdown src="/products/sdks/snippets/pass-fern-check.mdx"/>
 

--- a/fern/products/sdks/overview/go/quickstart.mdx
+++ b/fern/products/sdks/overview/go/quickstart.mdx
@@ -3,54 +3,11 @@ title: Go Quickstart
 description: Get started quickly with the Fern Go SDK.
 ---
 
-<Markdown src="/products/sdks/snippets/demo-warning.mdx"/>
-
 Generate a Go SDK by following the instructions on this page. 
 
+<Markdown src="/products/sdks/snippets/quickstart-prereqs.mdx"/>
+
 <Steps>
-<Markdown src="/products/sdks/snippets/install-cli.mdx"/>
-
-  ### Initialize the Fern Folder
-
-  <Markdown src="/products/sdks/snippets/initialize-fern-folder-intro.mdx"/>
-
-  <AccordionGroup>
-    <Markdown src="/products/sdks/snippets/option-1-openapi.mdx"/>
-    
-  <Accordion title="Option 2: Fern Definition">
-  
-  <Markdown src="/products/sdks/snippets/option-2-fern-def.mdx"/>
-
-  2.    Add the config option `outputSourceFiles: true` to
-        `generators.yml`. This ensures your SDK contains source files in
-        your preferred SDK language instead of compiled output. 
-
-        ```yaml {11-12}
-        # yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
-        default-group: local
-        groups:
-          local:
-            generators:
-              - name: fernapi/fern-typescript-sdk
-                output:
-                  location: local-file-system
-                  path: ../sdks/typescript
-                version: <Markdown src="/snippets/version-number.mdx"/>
-                config:
-                  outputSourceFiles: true
-        ```
-
-        <Note>`fern init` creates a default configuration that includes the
-        TypeScript SDK generator. The `local` group containing this
-        generator only generates if you run fern generate without specifying a
-        group, or if you explicitly target it with `fern generate --group
-        local`. In subsequent steps, you'll add an additional generator for your
-        preferred SDK language.</Note>
-    </Accordion>
-
-    {/* <Markdown src="/products/sdks/snippets/option-3-asyncapi.mdx"/> */}
-
-  </AccordionGroup>
 
 <Markdown src="/products/sdks/snippets/pass-fern-check.mdx"/>
 

--- a/fern/products/sdks/overview/java/quickstart.mdx
+++ b/fern/products/sdks/overview/java/quickstart.mdx
@@ -3,54 +3,11 @@ title: Java Quickstart
 description: Get started quickly with the Fern Java SDK.
 ---
 
-<Markdown src="/products/sdks/snippets/demo-warning.mdx"/>
-
 Generate a Java SDK by following the instructions on this page. 
 
+<Markdown src="/products/sdks/snippets/quickstart-prereqs.mdx"/>
+
 <Steps>
-<Markdown src="/products/sdks/snippets/install-cli.mdx"/>
-
-  ### Initialize the Fern Folder
-
-  <Markdown src="/products/sdks/snippets/initialize-fern-folder-intro.mdx"/>
-
-  <AccordionGroup>
-    <Markdown src="/products/sdks/snippets/option-1-openapi.mdx"/>
-    
-  <Accordion title="Option 2: Fern Definition">
-  
-  <Markdown src="/products/sdks/snippets/option-2-fern-def.mdx"/>
-
-  2.    Add the config option `outputSourceFiles: true` to
-        `generators.yml`. This ensures your SDK contains source files in
-        your preferred SDK language instead of compiled output. 
-
-        ```yaml {11-12}
-        # yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
-        default-group: local
-        groups:
-          local:
-            generators:
-              - name: fernapi/fern-typescript-sdk
-                output:
-                  location: local-file-system
-                  path: ../sdks/typescript
-                version: <Markdown src="/snippets/version-number.mdx"/>
-                config:
-                  outputSourceFiles: true
-        ```
-
-        <Note>`fern init` creates a default configuration that includes the
-        TypeScript SDK generator. The `local` group containing this
-        generator only generates if you run fern generate without specifying a
-        group, or if you explicitly target it with `fern generate --group
-        local`. In subsequent steps, you'll add an additional generator for your
-        preferred SDK language.</Note>
-    </Accordion>
-
-    {/* <Markdown src="/products/sdks/snippets/option-3-asyncapi.mdx"/> */}
-
-  </AccordionGroup>
 
 <Markdown src="/products/sdks/snippets/pass-fern-check.mdx"/>
 

--- a/fern/products/sdks/overview/php/quickstart.mdx
+++ b/fern/products/sdks/overview/php/quickstart.mdx
@@ -3,54 +3,11 @@ title: PHP Quickstart
 description: Get started quickly with the Fern PHP SDK.
 ---
 
-<Markdown src="/products/sdks/snippets/demo-warning.mdx"/>
-
 Generate a PHP SDK by following the instructions on this page. 
 
+<Markdown src="/products/sdks/snippets/quickstart-prereqs.mdx"/>
+
 <Steps>
-<Markdown src="/products/sdks/snippets/install-cli.mdx"/>
-
-  ### Initialize the Fern Folder
-
-  <Markdown src="/products/sdks/snippets/initialize-fern-folder-intro.mdx"/>
-
-  <AccordionGroup>
-    <Markdown src="/products/sdks/snippets/option-1-openapi.mdx"/>
-    
-  <Accordion title="Option 2: Fern Definition">
-  
-  <Markdown src="/products/sdks/snippets/option-2-fern-def.mdx"/>
-
-  2.    Add the config option `outputSourceFiles: true` to
-        `generators.yml`. This ensures your SDK contains source files in
-        your preferred SDK language instead of compiled output. 
-
-        ```yaml {11-12}
-        # yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
-        default-group: local
-        groups:
-          local:
-            generators:
-              - name: fernapi/fern-typescript-sdk
-                output:
-                  location: local-file-system
-                  path: ../sdks/typescript
-                version: <Markdown src="/snippets/version-number.mdx"/>
-                config:
-                  outputSourceFiles: true
-        ```
-
-        <Note>`fern init` creates a default configuration that includes the
-        TypeScript SDK generator. The `local` group containing this
-        generator only generates if you run fern generate without specifying a
-        group, or if you explicitly target it with `fern generate --group
-        local`. In subsequent steps, you'll add an additional generator for your
-        preferred SDK language.</Note>
-    </Accordion>
-
-    {/* <Markdown src="/products/sdks/snippets/option-3-asyncapi.mdx"/> */}
-
-  </AccordionGroup>
 
 <Markdown src="/products/sdks/snippets/pass-fern-check.mdx"/>
 

--- a/fern/products/sdks/overview/python/quickstart.mdx
+++ b/fern/products/sdks/overview/python/quickstart.mdx
@@ -3,55 +3,11 @@ title: Python Quickstart
 description: Get started quickly with the Fern Python SDK.
 ---
 
-<Markdown src="/products/sdks/snippets/demo-warning.mdx"/>
-
 Generate a Python SDK by following the instructions on this page. 
 
+<Markdown src="/products/sdks/snippets/quickstart-prereqs.mdx"/>
+
 <Steps>
-<Markdown src="/products/sdks/snippets/install-cli.mdx"/>
-
-  ### Initialize the Fern Folder
-
-  <Markdown src="/products/sdks/snippets/initialize-fern-folder-intro.mdx"/>
-
-  <AccordionGroup>
-    <Markdown src="/products/sdks/snippets/option-1-openapi.mdx"/>
-    
-  <Accordion title="Option 2: Fern Definition">
-  
-  <Markdown src="/products/sdks/snippets/option-2-fern-def.mdx"/>
-
-  2.    Add the config option `outputSourceFiles: true` to
-        `generators.yml`. This ensures your SDK contains source files in
-        your preferred SDK language instead of compiled output. 
-
-        ```yaml {11-12}
-        # yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
-        default-group: local
-        groups:
-          local:
-            generators:
-              - name: fernapi/fern-typescript-sdk
-                output:
-                  location: local-file-system
-                  path: ../sdks/typescript
-                version: <Markdown src="/snippets/version-number.mdx"/>
-                config:
-                  outputSourceFiles: true
-        ```
-
-        <Note>`fern init` creates a default configuration that includes the
-        TypeScript SDK generator. The `local` group containing this
-        generator only generates if you run fern generate without specifying a
-        group, or if you explicitly target it with `fern generate --group
-        local`. In subsequent steps, you'll add an additional generator for your
-        preferred SDK language.</Note>
-    </Accordion>
-
-    {/* <Markdown src="/products/sdks/snippets/option-3-asyncapi.mdx"/> */}
-
-  </AccordionGroup>
-
 <Markdown src="/products/sdks/snippets/pass-fern-check.mdx"/>
 
 ### Add the SDK generator

--- a/fern/products/sdks/overview/ruby/quickstart.mdx
+++ b/fern/products/sdks/overview/ruby/quickstart.mdx
@@ -3,54 +3,11 @@ title: Ruby Quickstart
 description: Get started quickly with the Fern Ruby SDK.
 ---
 
-<Markdown src="/products/sdks/snippets/demo-warning.mdx"/>
-
 Generate a Ruby SDK by following the instructions on this page. 
 
+<Markdown src="/products/sdks/snippets/quickstart-prereqs.mdx"/>
+
 <Steps>
-<Markdown src="/products/sdks/snippets/install-cli.mdx"/>
-
-  ### Initialize the Fern Folder
-
-  <Markdown src="/products/sdks/snippets/initialize-fern-folder-intro.mdx"/>
-
-  <AccordionGroup>
-    <Markdown src="/products/sdks/snippets/option-1-openapi.mdx"/>
-    
-  <Accordion title="Option 2: Fern Definition">
-  
-  <Markdown src="/products/sdks/snippets/option-2-fern-def.mdx"/>
-
-  2.    Add the config option `outputSourceFiles: true` to
-        `generators.yml`. This ensures your SDK contains source files in
-        your preferred SDK language instead of compiled output. 
-
-        ```yaml {11-12}
-        # yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
-        default-group: local
-        groups:
-          local:
-            generators:
-              - name: fernapi/fern-typescript-sdk
-                output:
-                  location: local-file-system
-                  path: ../sdks/typescript
-                version: <Markdown src="/snippets/version-number.mdx"/>
-                config:
-                  outputSourceFiles: true
-        ```
-
-        <Note>`fern init` creates a default configuration that includes the
-        TypeScript SDK generator. The `local` group containing this
-        generator only generates if you run fern generate without specifying a
-        group, or if you explicitly target it with `fern generate --group
-        local`. In subsequent steps, you'll add an additional generator for your
-        preferred SDK language.</Note>
-    </Accordion>
-
-    {/* <Markdown src="/products/sdks/snippets/option-3-asyncapi.mdx"/> */}
-
-  </AccordionGroup>
 
 <Markdown src="/products/sdks/snippets/pass-fern-check.mdx"/>
 

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -3,54 +3,11 @@ title: TypeScript Quickstart
 description: Get started quickly with the Fern TypeScript SDK.
 ---
 
-<Markdown src="/products/sdks/snippets/demo-warning.mdx"/>
-
 Generate a TypeScript SDK by following the instructions on this page. 
 
+<Markdown src="/products/sdks/snippets/quickstart-prereqs.mdx"/>
+
 <Steps>
-<Markdown src="/products/sdks/snippets/install-cli.mdx"/>
-
-  ### Initialize the Fern Folder
-
-  <Markdown src="/products/sdks/snippets/initialize-fern-folder-intro.mdx"/>
-
-  <AccordionGroup>
-  <Markdown src="/products/sdks/snippets/option-1-openapi.mdx"/>
-
-  <Accordion title="Option 2: Fern Definition">
-  
-  <Markdown src="/products/sdks/snippets/option-2-fern-def.mdx"/>
-
-  2.    Add the config option `outputSourceFiles: true` to
-        `generators.yml`. This ensures your SDK contains source files in
-        your preferred SDK language instead of compiled output. 
-
-        ```yaml {11-12}
-        # yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
-        default-group: local
-        groups:
-          local:
-            generators:
-              - name: fernapi/fern-typescript-sdk
-                output:
-                  location: local-file-system
-                  path: ../sdks/typescript
-                version: <Markdown src="/snippets/typescript-sdk-version.mdx"/>
-                config:
-                  outputSourceFiles: true
-        ```
-
-        <Note>`fern init` creates a default configuration that includes the
-        TypeScript SDK generator. The `local` group containing this
-        generator only generates if you run fern generate without specifying a
-        group, or if you explicitly target it with `fern generate --group
-        local`. In subsequent steps, you'll add an additional generator for your
-        preferred SDK language.</Note>
-    </Accordion>
-
-    {/* <Markdown src="/products/sdks/snippets/option-3-asyncapi.mdx"/> */}
-    
-  </AccordionGroup>
 
  <Markdown src="/products/sdks/snippets/pass-fern-check.mdx"/>
 

--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -3,7 +3,7 @@ navigation:
     contents:
       - page: Introduction
         path: ./introduction.mdx
-      - page: Overview of the Fern Folder
+      - page: Set up the Fern Folder
         path: ./fern-folder.mdx
       - link: Customer Showcase
         href: https://buildwithfern.com/showcase

--- a/fern/products/sdks/snippets/initialize-fern-folder-intro.mdx
+++ b/fern/products/sdks/snippets/initialize-fern-folder-intro.mdx
@@ -1,2 +1,5 @@
-You can use either the OpenAPI definition or Fern
-  Definition to generate your SDK.
+You can initialize your Fern folder with either a Fern Definition or OpenAPI specification.
+
+  <Tip>
+    You can always convert a Fern Definition to OpenAPI or OpenAPI to a Fern Definition later on.
+  </Tip>

--- a/fern/products/sdks/snippets/quickstart-prereqs.mdx
+++ b/fern/products/sdks/snippets/quickstart-prereqs.mdx
@@ -1,0 +1,3 @@
+<Warning>
+    This page assumes you have an initialized fern folder. For more information, see [Set up the Fern Folder](/learn/sdks/overview/set-up-the-fern-folder)
+</Warning>


### PR DESCRIPTION
- Move fern folder initialization instructions into fern folder page
- Change fern folder page's title – it's now "Set up the fern folder"
- Make fern folder page more action-oriented

No new content – things are just moved around!