### PR TITLE
danny's bug bash fixes

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -62,7 +62,7 @@ products:
     path: ./products/cli-api-reference/cli-api-reference.yml
     icon: fa-regular fa-terminal
     image: ./images/product-switcher/cli-api-reference-light.png
-    slug: cli-api-reference
+    skip-slug: true
   
   # - display-name: AsyncAPI
   #   path: ./products/asyncapi-def/asyncapi-def.yml

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -62,7 +62,7 @@ products:
     path: ./products/cli-api-reference/cli-api-reference.yml
     icon: fa-regular fa-terminal
     image: ./images/product-switcher/cli-api-reference-light.png
-    skip-slug: true
+    slug: cli-api-reference
   
   # - display-name: AsyncAPI
   #   path: ./products/asyncapi-def/asyncapi-def.yml

--- a/fern/products/api-definition/pages/introduction/what-is-the-fern-folder.mdx
+++ b/fern/products/api-definition/pages/introduction/what-is-the-fern-folder.mdx
@@ -1,14 +1,13 @@
 ---
 title: The Fern Folder
-description: Describes the Fern folder structure
+description: Describes the fern folder structure and its contents
 ---
 
-Configuring fern starts with the `fern` folder. The fern folder contains your API definitions,
-generators, and your CLI version.
+Configuring fern starts with the `fern` folder which contains your API definitions, generators, and your CLI version.
 
 ## Directory structure
 
-When you run `fern init`, your Fern folder will be initialized with the following files:
+When you run `fern init`, your fern folder will be initialized with the following files:
 ```bash
 fern/
   ├─ fern.config.json
@@ -88,7 +87,7 @@ api:
 
 ## Multiple APIs
 
-The Fern folder is capable of housing multiple API definitions. Instead of placing your API definition at the top-level, you can nest them within an `apis` folder. Be sure to include a `generators.yml` file within each API folder that specifies the location of the API definition. 
+The fern folder is capable of housing multiple API definitions. Instead of placing your API definition at the top-level, you can nest them within an `apis` folder. Be sure to include a `generators.yml` file within each API folder that specifies the location of the API definition. 
 
 <Tabs>
 <Tab title="OpenAPI Definition">

--- a/fern/products/api-definition/pages/openapi/automation.mdx
+++ b/fern/products/api-definition/pages/openapi/automation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sync your OpenAPI Specification
-subtitle: Pull your latest OpenAPI Specification into your Fern Folder automatically.
+subtitle: Pull your latest OpenAPI Specification into your fern folder automatically.
 ---
 
 If you host your OpenAPI Specification at a publicly available URL, you can have Fern programmatically fetch the latest spec on a preconfigured cadence through the [sync-openapi GitHub Action](https://github.com/fern-api/sync-openapi). This ensures your committed OpenAPI spec stays up to date with your live API.
@@ -49,6 +49,6 @@ If you host your OpenAPI Specification at a publicly available URL, you can have
     Navigate to your repository's `Settings > Secrets and variables > Actions`. Select **New repository secret**, name it `OPENAPI_SYNC_TOKEN`, add your token, and click **Add secret**.
   </Step>
 </Steps>
-By default, this will create daily PRs with API spec updates to the repo containing your Fern folder. If you would like to adjust the frequency, learn more about GitHub's [schedule event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule).
+By default, this will create daily PRs with API spec updates to the repo containing your fern folder. If you would like to adjust the frequency, learn more about GitHub's [schedule event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule).
 
 <Info> For detailed configuration options and other use cases, see the [sync-openapi GitHub Action README](https://github.com/fern-api/sync-openapi). </Info>

--- a/fern/products/api-definition/pages/openapi/overview.mdx
+++ b/fern/products/api-definition/pages/openapi/overview.mdx
@@ -104,9 +104,9 @@ components:
       in: header
 ```
 
-## Setup your Fern folder
+## Setup your fern folder
 
-Start by initializing your Fern folder with an OpenAPI spec
+Start by initializing your fern folder with an OpenAPI spec
 
 <CodeGroup>
 ```sh file

--- a/fern/products/cli-api-reference/cli-changelog/2023-08-16.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2023-08-16.mdx
@@ -1,3 +1,3 @@
 ## 0.15.0-rc0
-**`(chore):`** - **Break**: The fern directory now has a top-level `apis` directory to handle apis and docs no longer live within an api definition
+**`(chore):`** - **Break**: The fern folder now has a top-level `apis` directory to handle apis and docs no longer live within an api definition
 

--- a/fern/products/cli-api-reference/cli-changelog/2023-11-20.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2023-11-20.mdx
@@ -24,5 +24,5 @@
 **`(chore):`** _It's been forever since we released a non release candidate!_
 
 **Break**
-- The file structure of the Fern folder has now changed. If you have a single API, your definition can live directly at the top-level. If you have multiple, they will need to live in an apis folder. When you run `fern upgrade` the directory structure will automatically be updated. 
+- The file structure of the fern folder has now changed. If you have a single API, your definition can live directly at the top-level. If you have multiple, they will need to live in an apis folder. When you run `fern upgrade` the directory structure will automatically be updated. 
 

--- a/fern/products/cli-api-reference/pages/api-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/api-get-started.mdx
@@ -7,28 +7,6 @@ subtitle: 'Welcome to the Fern API reference.'
 
 The Fern API allows you to manage SDKs and code snippets using Fern's public RESTful API.
 
-## Accessing the Fern API
-
-Fern maintains official API clients for TypeScript and Python. We recommend using these clients, though the API supports any language or framework that sends HTTP requests. Let us know if you'd like an SDK in another language.
-
-<CardGroup cols={2}>
-    <Card 
-        title='TypeScript' 
-        icon={<img src="https://upload.wikimedia.org/wikipedia/commons/d/d9/Node.js_logo.svg" alt="Node.js logo"/>} 
-        href='https://github.com/fern-api/typescript-sdk'
-    >
-    API client
-    </Card>
-
-    <Card 
-        title='Python' 
-        icon={<img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg" alt="Python logo"/>} 
-        href='https://github.com/fern-api/python-sdk'
-    >
-    API client
-    </Card>
-</CardGroup>
-
 ## Authentication
 
 Fern API requests require a bearer token for authentication. Use the CLI command [`fern token`](/learn/cli-api/cli-reference/commands#fern-token) to generate a bearer token. Tokens do not expire.

--- a/fern/products/openapi-def/pages/automation.mdx
+++ b/fern/products/openapi-def/pages/automation.mdx
@@ -49,6 +49,6 @@ If you host your OpenAPI Specification at a publicly available URL, you can have
     Navigate to your repository's `Settings > Secrets and variables > Actions`. Select **New repository secret**, name it `OPENAPI_SYNC_TOKEN`, add your token, and click **Add secret**.
   </Step>
 </Steps>
-By default, this will create daily PRs with API spec updates to the repo containing your Fern folder. If you would like to adjust the frequency, learn more about GitHub's [schedule event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule).
+By default, this will create daily PRs with API spec updates to the repo containing your fern folder. If you would like to adjust the frequency, learn more about GitHub's [schedule event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule).
 
 <Info> For detailed configuration options and other use cases, see the [sync-openapi GitHub Action README](https://github.com/fern-api/sync-openapi). </Info>

--- a/fern/products/openapi-def/pages/overview.mdx
+++ b/fern/products/openapi-def/pages/overview.mdx
@@ -104,9 +104,9 @@ components:
       in: header
 ```
 
-## Setup your Fern folder
+## Setup your fern folder
 
-Start by initializing your Fern folder with an OpenAPI spec
+Start by initializing your fern folder with an OpenAPI spec
 
 <CodeGroup>
 ```sh file

--- a/fern/products/sdks/fern-folder.mdx
+++ b/fern/products/sdks/fern-folder.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up the Fern Folder
-description: Describes the Fern folder structure
+description: Describes the fern folder structure
 ---
 
 Configuring Fern starts with the `fern` folder, the root directory that contains

--- a/fern/products/sdks/snippets/initialize-fern-folder-intro.mdx
+++ b/fern/products/sdks/snippets/initialize-fern-folder-intro.mdx
@@ -1,4 +1,4 @@
-You can initialize your Fern folder with either a Fern Definition or OpenAPI specification.
+You can initialize your fern folder with either a Fern Definition or OpenAPI specification.
 
   <Tip>
     You can always convert a Fern Definition to OpenAPI or OpenAPI to a Fern Definition later on.

--- a/fern/products/sdks/snippets/option-1-openapi.mdx
+++ b/fern/products/sdks/snippets/option-1-openapi.mdx
@@ -1,5 +1,5 @@
     <Accordion title="Option 1: OpenAPI">
-      Initialize the Fern folder using your OpenAPI Specification. Run one of the following commands based on your spec's location.
+      Initialize the fern folder using your OpenAPI Specification. Run one of the following commands based on your spec's location.
 
       <Tip>
       Fern can handle both JSON and YML formats for OpenAPI specifications, and the --openapi flag accepts either format, so you can use whichever format your API spec is available in.

--- a/fern/products/sdks/snippets/option-2-fern-def.mdx
+++ b/fern/products/sdks/snippets/option-2-fern-def.mdx
@@ -1,4 +1,4 @@
-1.    Initialize the Fern folder using the Fern Definition by running the following command:
+1.    Initialize the fern folder using the Fern Definition by running the following command:
 
       ```bash
       fern init --organization <YourOrganization>

--- a/fern/products/sdks/snippets/option-3-asyncapi.mdx
+++ b/fern/products/sdks/snippets/option-3-asyncapi.mdx
@@ -1,5 +1,5 @@
     <Accordion title="Option 3: AsyncAPI">
-      Initialize the Fern folder using your AsyncAPI Specification. Run one of the following commands based on your spec's location.
+      Initialize the fern folder using your AsyncAPI Specification. Run one of the following commands based on your spec's location.
 
       <Tip>
       Fern can handle both JSON and YML formats for AsyncAPI specifications, and the --openapi flag accepts either format, so you can use whichever format your API spec is available in.


### PR DESCRIPTION
- change `Fern folder` and `Fern directory` to `fern folder`
- remove SDKs for Fern's APIs