### PR TITLE
test: attempt to reformat markdown

### DIFF
--- a/fern/products/cli-api-reference/cli-changelog/2025-05-16.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2025-05-16.mdx
@@ -10,7 +10,7 @@ don't overwrite each other during conversion, maintaining the integrity of the A
 
 
 ## 0.61.17
-**`(fix):`** Add support for preserving `maxLines` and `focus` attributes when using `<Code src="..." />` components in docs. 
+**`(fix):`** Add support for preserving `maxLines` and `focus` attributes when using `Code` components in docs. 
 These attributes are now properly carried over to the generated code blocks, allowing you to control 
 the display of referenced code snippets with features like line limits and syntax highlighting focus.
 

--- a/fern/products/cli-api-reference/cli-changelog/2025-05-16.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2025-05-16.mdx
@@ -10,7 +10,7 @@ don't overwrite each other during conversion, maintaining the integrity of the A
 
 
 ## 0.61.17
-**`(fix):`** Add support for preserving `maxLines` and `focus` attributes when using `Code` components in docs. 
+**`(fix):`** Add support for preserving `maxLines` and `focus` attributes when using `<Code>` components in docs. 
 These attributes are now properly carried over to the generated code blocks, allowing you to control 
 the display of referenced code snippets with features like line limits and syntax highlighting focus.
 

--- a/fern/products/cli-api-reference/cli-changelog/2025-05-28.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2025-05-28.mdx
@@ -19,12 +19,7 @@ This will be converted to a Fern type that combines the base properties with the
 
 
 ## 0.63.15
-**`(fix):`** The `<Code>` component now supports more flexible prop ordering and additional properties. You can now specify `maxLines` and `focus` props in any order relative to the `src` prop. For example:
-
-`<Code src="../snippets/example.ts" maxLines={20} focus={1-18} />` or `<Code maxLines={20} focus={1-18} src="../snippets/example.ts" />`
-
-Both formats will work the same way, preserving the specified properties in the generated markdown. The component will automatically detect and include any additional props in the code block's metastring.
-
+**`(fix):`** The `<Code>` component now supports more flexible prop ordering and additional properties. You can now specify `maxLines` and `focus` props in any order relative to the `src` prop. Regardless of order, formats will work the same way, preserving the specified properties in the generated markdown. The component will automatically detect and include any additional props in the code block's metastring.
 
 ## 0.63.14
 **`(fix):`** Fix duplicate properties in example IR generation.

--- a/fern/products/cli-api-reference/cli-changelog/2025-05-28.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2025-05-28.mdx
@@ -21,10 +21,7 @@ This will be converted to a Fern type that combines the base properties with the
 ## 0.63.15
 **`(fix):`** The `<Code>` component now supports more flexible prop ordering and additional properties. You can now specify `maxLines` and `focus` props in any order relative to the `src` prop. For example:
 
-```mdx
-<Code src="../snippets/example.ts" maxLines={20} focus={1-18} />
-<Code maxLines={20} focus={1-18} src="../snippets/example.ts" />
-```
+`<Code src="../snippets/example.ts" maxLines={20} focus={1-18} />` or `<Code maxLines={20} focus={1-18} src="../snippets/example.ts" />`
 
 Both formats will work the same way, preserving the specified properties in the generated markdown. The component will automatically detect and include any additional props in the code block's metastring.
 


### PR DESCRIPTION
this is just a test, the actual fix needs to happen in the fern repo