### PR TITLE
fix: RBAC syntax

### DIFF
--- a/fern/products/docs/pages/authentication/rbac.mdx
+++ b/fern/products/docs/pages/authentication/rbac.mdx
@@ -125,7 +125,7 @@ navigation:
     layout: 
       - page: Welcome # this page is public
         path: pages/welcome.mdx
-        viewer: 
+        viewers: 
           - everyone 
   - tab: Documentation
     layout:


### PR DESCRIPTION
<img width="693" height="265" alt="Screenshot 2025-07-27 at 5 42 16 PM" src="https://github.com/user-attachments/assets/274ad53f-8d87-43a3-910e-6c48d428685f" />

`viewer` should be `viewers`
