### PR TITLE
add descriptions for readme config fields in generators.yml reference

### DIFF
--- a/fern/products/sdks/reference/generators-yml-reference.mdx
+++ b/fern/products/sdks/reference/generators-yml-reference.mdx
@@ -378,7 +378,7 @@ metadata:
 </ParamField>
 
 ## readme
-Controls what goes into the generated README files across all SDKs.
+Controls what goes into the generated README files across all SDKs, allowing you to customize the content and structure of your SDK documentation.
 
 ```yaml
 readme:
@@ -401,40 +401,39 @@ readme:
         path: "/users"
 ```
 
-<ParamField path="readme" type="ReadmeSchema" required={false} toc={true}>
-  Configuration for customizing the generated README files.
-</ParamField>
-
-<ParamField path="readme.bannerLink" type="string" required={false} toc={true}>
+<ParamField path="bannerLink" type="string" required={false} toc={true}>
   URL for a banner image or link that appears at the top of the README.
 </ParamField>
 
-<ParamField path="readme.introduction" type="string" required={false} toc={true}>
+<ParamField path="introduction" type="string" required={false} toc={true}>
   Custom introduction text that appears at the beginning of the README.
 </ParamField>
 
-<ParamField path="readme.apiReferenceLink" type="string" required={false} toc={true}>
+<ParamField path="apiReferenceLink" type="string" required={false} toc={true}>
   URL to your external API documentation or reference guide.
 </ParamField>
 
-<ParamField path="readme.defaultEndpoint" type="ReadmeEndpointSchema" required={false} toc={true}>
+<ParamField path="defaultEndpoint" type="ReadmeEndpointSchema" required={false} toc={true}>
   Specifies which endpoint's code snippet to showcase as the primary example in the README.
 </ParamField>
 
-<ParamField path="readme.defaultEndpoint.method" type="string" required={true} toc={true}>
+<ParamField path="features" type="map<string, list<ReadmeEndpointSchema>>" required={false} toc={true}>
+  Groups endpoints by feature name for organized README sections. Each feature becomes a section in the README with example code snippets for the listed endpoints.
+</ParamField>
+
+### defaultEndpoint
+Specifies which endpoint's code snippet to showcase as the primary example in the README.
+
+<ParamField path="method" type="string" required={true} toc={true}>
   HTTP method of the default endpoint (e.g., `GET`, `POST`, `PUT`, `DELETE`).
 </ParamField>
 
-<ParamField path="readme.defaultEndpoint.path" type="string" required={true} toc={true}>
+<ParamField path="path" type="string" required={true} toc={true}>
   Endpoint path for the default example (e.g., `/users`, `/auth/login`).
 </ParamField>
 
-<ParamField path="readme.defaultEndpoint.stream" type="boolean" required={false} toc={true}>
+<ParamField path="stream" type="boolean" required={false} toc={true}>
   Whether the endpoint is a streaming endpoint. Defaults to `false`.
-</ParamField>
-
-<ParamField path="readme.features" type="map<string, list<ReadmeEndpointSchema>>" required={false} toc={true}>
-  Groups endpoints by feature name for organized README sections. Each feature becomes a section in the README with example code snippets for the listed endpoints.
 </ParamField>
 
 ## default-group

--- a/fern/products/sdks/reference/generators-yml-reference.mdx
+++ b/fern/products/sdks/reference/generators-yml-reference.mdx
@@ -432,7 +432,7 @@ Specifies which endpoint's code snippet to showcase as the primary example in th
   Endpoint path for the default example (e.g., `/users`, `/auth/login`).
 </ParamField>
 
-<ParamField path="stream" type="boolean" required={false} toc={true}>
+<ParamField path="stream" type="boolean" required={false} default="false" toc={true}>
   Whether the endpoint is a streaming endpoint. Defaults to `false`.
 </ParamField>
 

--- a/fern/products/sdks/reference/generators-yml-reference.mdx
+++ b/fern/products/sdks/reference/generators-yml-reference.mdx
@@ -402,30 +402,39 @@ readme:
 ```
 
 <ParamField path="readme" type="ReadmeSchema" required={false} toc={true}>
+  Configuration for customizing the generated README files.
 </ParamField>
 
 <ParamField path="readme.bannerLink" type="string" required={false} toc={true}>
+  URL for a banner image or link that appears at the top of the README.
 </ParamField>
 
 <ParamField path="readme.introduction" type="string" required={false} toc={true}>
+  Custom introduction text that appears at the beginning of the README.
 </ParamField>
 
 <ParamField path="readme.apiReferenceLink" type="string" required={false} toc={true}>
+  URL to your external API documentation or reference guide.
 </ParamField>
 
 <ParamField path="readme.defaultEndpoint" type="ReadmeEndpointSchema" required={false} toc={true}>
+  Specifies which endpoint's code snippet to showcase as the primary example in the README.
 </ParamField>
 
 <ParamField path="readme.defaultEndpoint.method" type="string" required={true} toc={true}>
+  HTTP method of the default endpoint (e.g., `GET`, `POST`, `PUT`, `DELETE`).
 </ParamField>
 
 <ParamField path="readme.defaultEndpoint.path" type="string" required={true} toc={true}>
+  Endpoint path for the default example (e.g., `/users`, `/auth/login`).
 </ParamField>
 
 <ParamField path="readme.defaultEndpoint.stream" type="boolean" required={false} toc={true}>
+  Whether the endpoint is a streaming endpoint. Defaults to `false`.
 </ParamField>
 
 <ParamField path="readme.features" type="map<string, list<ReadmeEndpointSchema>>" required={false} toc={true}>
+  Groups endpoints by feature name for organized README sections. Each feature becomes a section in the README with example code snippets for the listed endpoints.
 </ParamField>
 
 ## default-group


### PR DESCRIPTION
We had some questions about readme generation so updating these values so customers know what each field is. 