### PR TITLE
Restructure "GitHub Setup" page and rename to "Project Structure"

### DIFF
--- a/fern/products/sdks/fern-folder.mdx
+++ b/fern/products/sdks/fern-folder.mdx
@@ -1,13 +1,10 @@
 ---
-title: Set up the Fern Folder
-description: Describes the fern folder structure
+title: Quickstart
+subtitle: Set up the fern folder
 ---
 
 Configuring Fern starts with the `fern` folder, the root directory that contains
 your API definitions, generators, and your CLI version. 
-
-After you configure your `fern` folder, you'll be ready to start generating SDKs
-in different languages and [augmenting them with custom code](/sdks/overview/custom-code).
 
 ## Set up the fern folder
 
@@ -30,90 +27,8 @@ in different languages and [augmenting them with custom code](/sdks/overview/cus
     {/* <Markdown src="/products/sdks/snippets/option-3-asyncapi.mdx"/> */}    
   </AccordionGroup>
 
-    ### Set up GitHub
+  ### Next: Set up your repository structure
 
-    Now, you're ready to [set up your GitHub repositories](/sdks/overview/github).
-
-  ### Augment your SDK with custom code
-
-  Learn more about [adding custom code and utilizing a `.fernignore` file](/sdks/overview/custom-code).
-
+  Now that you have your `fern` folder initialized, [learn how to organize your repositories for SDK generation](/sdks/overview/github).
+ 
 </Steps>
-
-## Learn more about the initialized files
-
-Every initialized `fern` directory has:
-* A `fern.config.json` file
-* A `generators.yml` file
-
-### `fern.config.json`
-
-This file stores the organization and the version of the Fern CLI that you are
-using. 
-
-```json
-{
-    "organization": "imdb",
-    "version": "<Markdown src="/products/sdks/snippets/fern-config-json-version.mdx"/>"
-}
-```
-
-Every time you run a fern CLI command, the CLI downloads itself at the correct version to ensure 
-determinism. 
-
-<Note>To upgrade the CLI, run `fern upgrade`. This will update the version field in `fern.config.json` </Note>
-
-### `generators.yml`
-
-The `generators.yml` file specifies which SDKs Fern should generate from your
-API specification. For each generator, it specifies where the package is
-published and configures customizations like package metadata, output locations,
-and generation settings.
-
-<Info>
-  See the [`generators.yml` reference page](/sdks/reference/generators-yml) for more information.
-</Info>
-
-## Configure Multiple APIs
-
-The fern folder can house multiple API definitions. Instead of placing your API
-definitions at the top level, you can nest them within an `apis` folder. Be sure
-to include a `generators.yml` file within each API folder that specifies the
-location of the API definition. 
-
-<Tabs>
-<Tab title="OpenAPI Definition">
-```bash
-fern/
-  ├─ fern.config.json
-  ├─ generators.yml
-  └─ apis/
-    └─ imdb/
-        ├─ generators.yml
-        └─ openapi/
-          ├─ openapi.yml
-    └─ disney/
-        ├─ generators.yml
-        └─ openapi/
-          ├─ openapi.yml
-```
-</Tab>
-<Tab title="Fern Definition">
-```bash
-fern/
-  ├─ fern.config.json
-  ├─ generators.yml
-  └─ apis/
-    └─ imdb/
-        ├─ generators.yml
-        └─ definition/
-          ├─ api.yml
-          └─ imdb.yml
-    └─ disney/
-        ├─ generators.yml
-        └─ definition/
-          ├─ api.yml
-          └─ disney.yml
-```
-</Tab>
-</Tabs>

--- a/fern/products/sdks/github-setup.mdx
+++ b/fern/products/sdks/github-setup.mdx
@@ -7,7 +7,7 @@ Before generating SDKs with Fern, set up the proper GitHub repository structure 
 
 ## Repository architecture
 
-Fern recommends a parent-child repository structure, where:
+Fern recommends a parent-child repository structure containing:
 
 - **Parent repository**: Contains your API definitions and SDK generation configuration
 - **Child repositories**: Separate repositories for each SDK (TypeScript, Python, Go, etc.)
@@ -25,6 +25,10 @@ Fern recommends a parent-child repository structure, where:
 ```
 
 This separation allows you to manage API definitions centrally while keeping each SDK in its own repository for independent versioning and distribution.
+
+<Info>
+  For an example of this structure, see Cohere's [fern folder](https://github.com/cohere-ai/cohere-developer-experience/tree/23d6c541a01eb6b54dd9bb3588c805bb0e307713/fern) and [TypeScript](https://github.com/cohere-ai/cohere-typescript) and [Python](https://github.com/cohere-ai/cohere-python) child repositories.
+</Info>
 
 ## Core configuration files
 
@@ -45,10 +49,12 @@ This file stores your organization name and Fern CLI version:
 
 The `generators.yml` file specifies which SDKs to generate and where to publish them. It acts as the bridge between your API definitions and your SDK repositories.
 
+<Info>
 For examples, see Cohere's [`generators.yml`
 file](https://github.com/cohere-ai/cohere-developer-experience/blob/23d6c541a01eb6b54dd9bb3588c805bb0e307713/fern/apis/sdks/generators.yml)
 and Vapi's [`generators.yml`
 file](https://github.com/VapiAI/docs/blob/9c674c2b16ba03e864e26673c5290c88048c9a7a/fern/apis/api/generators.yml).
+</Info>
 
 
 <Info>

--- a/fern/products/sdks/github-setup.mdx
+++ b/fern/products/sdks/github-setup.mdx
@@ -1,109 +1,154 @@
 ---
-title: Structure your GitHub repositories
-description: Set up GitHub repositories for your SDKs
+title: Project structure
+description: An overview of the file and folder structure of a Fern SDKs project
 ---
 
-Before generating SDKs with Fern, you'll need to set up the proper GitHub
-repository structure to house your API definitions and SDK code so it's
-intuitive for you and your users to access, maintain, and update code. 
+Before generating SDKs with Fern, set up the proper GitHub repository structure to house your API definitions and SDK code so it's intuitive for you and your users to access, maintain, and update code.
 
-<Steps>
-## Structuring your top-level repository
+## Repository architecture
 
-1. Identify or create a top-level GitHub repository where you want all of your
-   SDK and API code to live. 
-1. Install the [Fern GitHub App](https://github.com/apps/fern-api) on the
-   top-level repository and all SDK repositories. Select **Configure**, then
-   scroll down to **Repository Access**. Select **Only select repositories** and
-   in the dropdown select the repository for your SDK. Click **Save**. 
+Fern recommends a parent-child repository structure, where:
 
-For example, your basic GitHub file structure should look something like this:
+- **Parent repository**: Contains your API definitions and SDK generation configuration
+- **Child repositories**: Separate repositories for each SDK (TypeScript, Python, Go, etc.)
 
-```
-├─ company-repo # Top-level repo for all SDKs
-    ├─ fern/
-      ├─ apis/
-        ├─ sdks/
-          └── generators.yml # Contains settings for all SDKs
-```
-Your `generators.yml` file will contain a group for each of your SDKs. Each group points
-to the GitHub repository for the relevant SDK.
-
-For example, the `group` for a TypeScript SDK might look like this:
-
-```yaml title="generators.yml"
-  ts-sdk:
-    generators:
-      - name: fernapi/fern-typescript-sdk
-        version: 2.6.3
-        github:
-          repository: your-organization/your-typescript-repo
+```bash
+├─ company-repo                 # Parent repository
+│  └─ fern/
+│     ├─ fern.config.json
+│     ├─ apis/
+│     │  └─ sdks/
+│     │     └─ generators.yml   # References child repos
+├─ typescript-sdk-repo          # Child repository
+├─ python-sdk-repo              # Child repository  
+└─ go-sdk-repo                  # Child repository
 ```
 
-For additional examples, see Cohere's [`generators.yml`
+This separation allows you to manage API definitions centrally while keeping each SDK in its own repository for independent versioning and distribution.
+
+## Core configuration files
+
+[Initializing your `fern` folder](/sdks/overview/quickstart) creates two key configuration files:
+
+### `fern.config.json`
+
+This file stores your organization name and Fern CLI version:
+
+```json
+{
+    "organization": "your-organization",
+    "version": "<Markdown src="/products/sdks/snippets/fern-config-json-version.mdx"/>"
+}
+```
+
+### `generators.yml`
+
+The `generators.yml` file specifies which SDKs to generate and where to publish them. It acts as the bridge between your API definitions and your SDK repositories.
+
+For examples, see Cohere's [`generators.yml`
 file](https://github.com/cohere-ai/cohere-developer-experience/blob/23d6c541a01eb6b54dd9bb3588c805bb0e307713/fern/apis/sdks/generators.yml)
 and Vapi's [`generators.yml`
 file](https://github.com/VapiAI/docs/blob/9c674c2b16ba03e864e26673c5290c88048c9a7a/fern/apis/api/generators.yml).
 
-<Info>You can also additionally configure the `github` section to whether Fern
-should commit and release, create a pull request, or push code to a branch when
-you make changes to your SDK code. See [GitHub
-Configuration](/sdks/reference/generators-yml#github-configuration) for more
-details. </Info>
 
-## Structuring SDK-specific repositories
+<Info>
+  See the [`generators.yml` reference page](/sdks/reference/generators-yml) for complete configuration options.
+</Info>
 
-1. Create a new GitHub repository called `company-<language>` (or something
-   similar) for each of your SDKs, if you haven't done so already. 
-1. Install the [Fern GitHub App](https://github.com/apps/fern-api) on the
-   top-level repository and all SDK repositories. Select **Configure**, then
-   scroll down to **Repository Access**. Select **Only select repositories** and
-   in the dropdown select the repository for your SDK. Click **Save**. 
+## Parent repository structure
 
+The parent repository contains your API definitions and the `generators.yml` file that references your child SDK repositories.
 
-The repository structure for a specific SDK should look similar to this:
+<CodeBlock title="Parent repository structure">
+```bash
+company-repo/
+├─ fern/
+│  ├─ fern.config.json
+│  ├─ apis/
+│  │  └─ sdks/
+│  │     └─ generators.yml      # SDK generation configuration
+```
+</CodeBlock>
 
-```{6-11}
-├─ company-repo # Top-level repo for all SDKs
-    ├─ fern/
-      ├─ apis/
-        ├─ sdks/
-          └──  generators.yml # Contains settings for all SDKs
-    ├─ typescript-sdk-repo # Repository for a TypeScript SDK
-        ├─ .github/workflows/ # Contains GitHub Actions for publishing to package repositories, etc. 
-        ├─ scripts/
-        ├─ src/
-        ├─ tests/
-        └── .fernignore # Lists files that Fern shouldn't modify
-    ├─ python-sdk-repo
-    └── go-sdk-repo
+Your `generators.yml` file contains a group for each SDK and points to the corresponding child repository:
+
+```yaml title="generators.yml"
+groups:
+  ts-sdk:
+    generators:
+      - name: fernapi/fern-typescript-sdk
+        version: <Markdown src="/snippets/version-number-ts.mdx"/>
+        github:
+          repository: your-organization/typescript-sdk-repo
+  
+  python-sdk:
+    generators:
+      - name: fernapi/fern-python-sdk
+        version: <Markdown src="/snippets/version-number-python.mdx"/>
+        github:
+          repository: your-organization/python-sdk-repo
 ```
 
-Fern generates most of the SDK files listed in this example repository (`scripts/`, `src/`, `tests`,
-`.fernignore`, etc.), including any custom code you added. You have to manually set up `.github/workflows` to execute actions, like publishing SDK versions to a package repository. 
+## Child repository structure
 
-For additional examples, see Cohere's [Python SDK repository](https://github.com/cohere-ai/cohere-python) and [Vapi's TypeScript SDK repository](https://github.com/VapiAI/server-sdk-typescript).
-  
-## Generate an SDK in your desired language
+Each SDK has its own repository with the following structure:
 
-Once you've set up your GitHub repository structure, you can proceed with generating SDKs in your desired languages.
+<CodeBlock title="Child repository structure">
+```bash
+typescript-sdk-repo/            # Individual SDK repository
+├─ .github/workflows/           # Publishing workflows
+├─ scripts/
+├─ src/
+├─ tests/
+└─ .fernignore                  # Files Fern shouldn't modify
+```
+</CodeBlock>
 
-  <CardGroup cols={3}>
-    <Card title="TypeScript" icon={<img src="./images/icons/ts-light.svg" alt="TypeScript logo" className="h-6 w-6" noZoom />}  href="/sdks/generators/typescript/quickstart">
-    </Card>
-    <Card title="Python" icon={<img src="./images/icons/python-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/python/quickstart">
-    </Card>
-    <Card title="Go" icon={<img src="./images/icons/go-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/go/quickstart">
-    </Card>
-    <Card title="Java" icon={<img src="./images/icons/java-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/java/quickstart">
-    </Card>
-    <Card title=".NET" icon={<img src="./images/icons/csharp-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/csharp/quickstart">
-    </Card>
-    <Card title="PHP" icon={<img src="./images/icons/php-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/php/quickstart">
-    </Card>
-    <Card title="Ruby" icon={<img src="./images/icons/ruby-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/php/quickstart">
-    </Card>
-  </CardGroup>
+Fern generates most of these files automatically, including preserving any custom code you've added.
 
-  </Steps>
+## Setup instructions
 
+1. **Create repositories**: Set up your parent repository and one child repository for each SDK
+2. **Install Fern GitHub App**: Install the [Fern GitHub App](https://github.com/apps/fern-api) on all repositories (parent and children)
+3. **Configure generators.yml**: Add each child repository to your `generators.yml` file
+
+## Multiple API definitions
+
+For multiple APIs, organize them in separate folders within the `apis` directory:
+
+<Tabs>
+<Tab title="OpenAPI Definition">
+```bash
+fern/
+  ├─ fern.config.json
+  ├─ generators.yml
+  └─ apis/
+    └─ imdb/
+        ├─ generators.yml
+        └─ openapi/
+          ├─ openapi.yml
+    └─ disney/
+        ├─ generators.yml
+        └─ openapi/
+          ├─ openapi.yml
+```
+</Tab>
+<Tab title="Fern Definition">
+```bash
+fern/
+  ├─ fern.config.json
+  ├─ generators.yml
+  └─ apis/
+    └─ imdb/
+        ├─ generators.yml
+        └─ definition/
+          ├─ api.yml
+          └─ imdb.yml
+    └─ disney/
+        ├─ generators.yml
+        └─ definition/
+          ├─ api.yml
+          └─ disney.yml
+```
+</Tab>
+</Tabs>

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -5,13 +5,7 @@ description: Get started quickly with the Fern TypeScript SDK.
 
 Generate a TypeScript SDK by following the instructions on this page. 
 
-<Info>
-  This page assumes that you have:
-
-  * An initialized `fern` folder on your local machine. See [Set up the `fern`
-    folder](/sdks/overview/quickstart).
-  * A GitHub repository for your TypeScript SDK. See [Set up your GitHub repositories](/sdks/overview/github).
-</Info>
+<Markdown src="/products/sdks/snippets/setup-fern-folder-callout.mdx"/>
 
 <Steps>
 

--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -7,7 +7,7 @@ navigation:
       - page: Quickstart
         path: ./fern-folder.mdx
         slug: quickstart
-      - page: GitHub Setup
+      - page: Project Structure
         path: ./github-setup.mdx
         slug: github
       - page: Adding Custom Code

--- a/fern/products/sdks/snippets/setup-fern-folder-callout.mdx
+++ b/fern/products/sdks/snippets/setup-fern-folder-callout.mdx
@@ -1,3 +1,7 @@
-<Info>This guide assumes that you already have an initialized `fern` folder on
-your local machine. See [Set up the `fern` folder](/sdks/overview/quickstart) for more
-details.</Info>
+<Info>
+  This page assumes that you have:
+
+  * An initialized `fern` folder on your local machine. See [Set up the `fern`
+    folder](/sdks/overview/quickstart).
+  * A GitHub repository for your TypeScript SDK. See [Project Structure](/sdks/overview/github).
+</Info>


### PR DESCRIPTION
Also move project structure-related info into this page from Quickstart