### PR TITLE
chore: landing page slug configuration options

### DIFF
--- a/fern/products/docs/pages/customization/what-is-docs-yml.mdx
+++ b/fern/products/docs/pages/customization/what-is-docs-yml.mdx
@@ -504,6 +504,7 @@ The GitHub repository must be **public** for the "Edit this page" feature to wor
 landing-page: 
   page: Page Title
   path: path/to/landing-page.mdx
+  slug: /welcome
 ```
 
 <ParamField path="page" type="string" required={true}>
@@ -512,6 +513,12 @@ landing-page:
 
 <ParamField path="path" type="string" required={true}>
   Relative filepath to the desired landing page Markdown file. 
+</ParamField>
+
+<ParamField path="slug" type="string" required={false}>
+  The slug of the landing page. Defaults to the page name. 
+  
+  The slug can also be overridden in the frontmatter of the landing page Markdown file.
 </ParamField>
 
 See [Vapi's landing page live](https://docs.vapi.ai/) and the associated [Markdown file](https://github.com/VapiAI/docs/blob/main/fern/quickstart/introduction.mdx?plain=1).

--- a/fern/products/docs/pages/seo/configuring-slugs.mdx
+++ b/fern/products/docs/pages/seo/configuring-slugs.mdx
@@ -83,6 +83,16 @@ navigation:
 
 In the example above, the **Welcome** page would be hosted at `plantstore.docs.buildwithfern.com/guides/get-started/welcome`. 
 
+#### Modify a landing page's slug
+To modify the slug used for a tab, you can set the `slug` within the `landing-page` object. 
+
+```yaml title="docs.yml" {4}
+landing-page: 
+  page: Page Title
+  path: path/to/landing-page.mdx
+  slug: /welcome
+```
+
 #### Override a page's slug
 You can set the exact slug of a page within its frontmatter. [You can read more about the frontmatter configuration here](/learn/docs/content/frontmatter#slug). 
 


### PR DESCRIPTION
how to override the slug of a landing page