### PR TITLE
Add overview for Self-Hosted Documentation option

### DIFF
--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -97,7 +97,7 @@ navigation:
         path: ./pages/customization/user-feedback.mdx
       - page: Custom CSS & JS
         path: ./pages/component-library/custom-components/custom-css-js.mdx
-  - section: Deploy & Publish
+  - section: Preview & Publish
     collapsed: true
     contents:
       - page: Previewing changes locally 
@@ -108,8 +108,6 @@ navigation:
         path: ./pages/getting-started/publishing-your-docs.mdx
       - page: Setting up your domain
         path: ./pages/getting-started/setting-up-your-domain.mdx
-      - page: Self-hosted
-        path: ./pages/enterprise/self-hosted.mdx
   - section: Navigation
     collapsed: true
     contents:
@@ -182,6 +180,11 @@ navigation:
         path: ./pages/api-references/autopopulate-api-key.mdx
       - page: SSO
         path: ./pages/authentication/sso.mdx
+  -  section: Self-Hosted
+     collapsed: true
+     contents:
+      - page: Overview
+        path: ./pages/enterprise/self-hosted.mdx
   - section: Integrations
     collapsed: true
     contents:

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -97,7 +97,7 @@ navigation:
         path: ./pages/customization/user-feedback.mdx
       - page: Custom CSS & JS
         path: ./pages/component-library/custom-components/custom-css-js.mdx
-  - section: Preview & Publish
+  - section: Deploy & Publish
     collapsed: true
     contents:
       - page: Previewing changes locally 
@@ -108,6 +108,8 @@ navigation:
         path: ./pages/getting-started/publishing-your-docs.mdx
       - page: Setting up your domain
         path: ./pages/getting-started/setting-up-your-domain.mdx
+      - page: Self-hosted documentation
+        path: ./pages/enterprise/self-hosted.mdx
   - section: Navigation
     collapsed: true
     contents:
@@ -180,11 +182,6 @@ navigation:
         path: ./pages/api-references/autopopulate-api-key.mdx
       - page: SSO
         path: ./pages/authentication/sso.mdx
-  - section: Enterprise
-    collapsed: true
-    contents:
-      - page: Self-hosted
-        path: ./pages/enterprise/self-hosted.mdx
   - section: Integrations
     collapsed: true
     contents:

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -108,7 +108,7 @@ navigation:
         path: ./pages/getting-started/publishing-your-docs.mdx
       - page: Setting up your domain
         path: ./pages/getting-started/setting-up-your-domain.mdx
-      - page: Self-hosted documentation
+      - page: Self-hosted
         path: ./pages/enterprise/self-hosted.mdx
   - section: Navigation
     collapsed: true

--- a/fern/products/docs/pages/enterprise/self-hosted.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted.mdx
@@ -1,7 +1,54 @@
 ---
-title: Self-hosted Enterprise
+title: Self-Hosted Documentation
+description: Fern supports self-hosting so that you can run your docs site on your own infrastructure.
 ---
 
-Fern supports self-hosting so that you can run your docs site on your own infrastructure.
+Fern documentation websites are hosted on Fern's infrastructure by default. Self-hosting allows you to deploy your documentation site on your own infrastructure to meet specific security or compliance requirements.
 
-<Warning>Docs are coming soon for this page.<br/><br/>Please [book a demo](https://buildwithfern.com/book-demo) or [reach out to us](https://buildwithfern.com/book-demo) to get set up with this feature. </Warning> 
+## When to Use Self-Hosting
+
+Self-hosting is typically required for organizations that operate without internet access, have strict compliance requirements, or need full control over their documentation servers.
+
+When you self-host, you're responsible for server setup, security, maintenance, and deciding how to make the documentation accessible to your users.
+
+<Warning>
+Unless you have specific requirements that prevent using Fern's default hosting, we recommend **using our managed hosting solution** for easier setup and maintenance.
+</Warning>
+
+### Feature Support
+
+Self-hosted deployments include core Fern documentation website features like auto-generated API references, interactive documentation, SDK code snippets, search, and customizable branding. 
+
+However, features requiring external connections aren't supported, including [Ask Fern](/ask-fern/getting-started/what-is-ask-fern) (AI chat), [analytics](/integrations/overview), [live API key population](/docs/authentication/api-key-injection), and [SSO integrations](/docs/authentication/sso).
+
+<Info title="Extended feature support">
+**PDF export** and **offline AI chat functionality** are in development for self-hosted deployments. [Email us](mailto:support@buildwithfern.com) if you're interested in these features.
+</Info>
+
+## Setup Process
+
+Fern provides your documentation site as a ready-to-run Docker container that you can deploy on your own infrastructure.
+
+1. **Download the Docker image** - Fern provides the location of the most up-to-date Docker image containing the documentation frontend
+2. **Upload your fern folder** - Add your documentation source files to the container
+3. **Run the container** - Spin up your local server using standard Docker commands
+4. **Configure hosting** - Set up your server environment and decide how to publish/share the documentation
+
+### Architecture Diagram
+
+```mermaid
+sequenceDiagram
+    participant F as Fern
+    participant C as Customer
+    participant S as Customer Server
+
+    F->>C: Provides Docker image
+    C->>S: Upload fern folder
+    C->>S: Run Docker command
+    S->>S: Host documentation locally
+```
+
+
+
+
+

--- a/fern/products/docs/pages/enterprise/self-hosted.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted.mdx
@@ -3,6 +3,8 @@ title: Self-Hosted Documentation
 description: Fern supports self-hosting so that you can run your docs site on your own infrastructure.
 ---
 
+<Note>Self-hosted documentation is only available for the enterprise plan.</Note>
+
 Fern documentation websites are hosted on Fern's infrastructure by default. Self-hosting allows you to deploy your documentation site on your own infrastructure to meet specific security or compliance requirements.
 
 ## When to Use Self-Hosting

--- a/fern/products/docs/pages/enterprise/self-hosted.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted.mdx
@@ -32,9 +32,10 @@ However, features requiring external connections aren't supported, including [As
 Fern provides your documentation site as a ready-to-run Docker container that you can deploy on your own infrastructure.
 
 1. **Download the Docker image** - Fern provides the location of the most up-to-date Docker image containing the documentation frontend
-2. **Upload your fern folder** - Add your documentation source files to the container
-3. **Run the container** - Spin up your local server using standard Docker commands
-4. **Configure hosting** - Set up your server environment and decide how to publish/share the documentation
+1. **Upload your fern folder** - Add your documentation source files to the container
+1. **Run the container** - Spin up your local server using standard Docker commands
+1. **Configure hosting** - Set up your server environment and decide how to publish/share the documentation
+1. **Receive updated Docker images** - Fern releases new versions of the Docker image that your team can evaluate and deploy when ready.
 
 ### Architecture Diagram
 
@@ -48,6 +49,9 @@ sequenceDiagram
     C->>S: Upload fern folder
     C->>S: Run Docker command
     S->>S: Host documentation locally
+    F->>C: Releases updated Docker image
+    C->>C: Evaluate new version
+    C->>S: Deploy updated image
 ```
 
 


### PR DESCRIPTION
-Added new overview page
-Renamed **Preview & Publish** section to **Deploy and Publish** and moved Self-Hosted info there