### PR TITLE
chore: Update image paths and add subtitle to welcome page

### DIFF
--- a/fern/products/docs/pages/getting-started/project-structure.mdx
+++ b/fern/products/docs/pages/getting-started/project-structure.mdx
@@ -1,7 +1,6 @@
 ---
-title: Project Strre
+title: ''
 description: An overview of the file and folder structure of a Fern Docs project
-og-description: aaa
 ---
 
 This page provides an overview of the file and folder structure of a Fern Docs project. The following structure is recommended for organizing your documentation content, but is customizable to fit your needs.

--- a/fern/products/docs/pages/getting-started/project-structure.mdx
+++ b/fern/products/docs/pages/getting-started/project-structure.mdx
@@ -1,11 +1,11 @@
 ---
-title: Project Structure
+title: ''
 description: An overview of the file and folder structure of a Fern Docs project
 ---
 
 This page provides an overview of the file and folder structure of a Fern Docs project. The following structure is recommended for organizing your documentation content, but is customizable to fit your needs.
 
-## Top-level folders 
+## Top-level folders
 
 <CodeBlock title="fern/">
 ```bash
@@ -104,7 +104,7 @@ title: Fern's Documentation
 ```
 </CodeBlock>
 
-## API Definitions 
+## API Definitions
 
 <AccordionGroup>
   <Accordion title="OpenAPI">
@@ -151,7 +151,6 @@ title: Fern's Documentation
   </Accordion>
 </AccordionGroup>
 
-
 ## `fern.config.json`
 
 The `fern.config.json` file specifies your organization name and the version of the Fern CLI used to generate the documentation. You can customize this file to reflect your organization's details.
@@ -160,7 +159,7 @@ The `fern.config.json` file specifies your organization name and the version of 
 ```json
 {
   "organization": "my-organization",
-  "version": "<Markdown src="/products/sdks/snippets/fern-config-json-version.mdx"/>"
+  "version": "0.65.27"
 }
 ```
-</CodeBlock> 
+</CodeBlock>

--- a/fern/products/docs/pages/getting-started/project-structure.mdx
+++ b/fern/products/docs/pages/getting-started/project-structure.mdx
@@ -1,6 +1,7 @@
 ---
-title: ''
+title: Project Strre
 description: An overview of the file and folder structure of a Fern Docs project
+og-description: aaa
 ---
 
 This page provides an overview of the file and folder structure of a Fern Docs project. The following structure is recommended for organizing your documentation content, but is customizable to fit your needs.

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -4,6 +4,7 @@ description: Explore our guides for how to generate SDKs and Docs with Fern.
 slug: /
 hide-toc: true
 layout: custom
+subtitle: hellooooo
 ---
 
 import { FernFooter } from "../../../components/FernFooter";
@@ -50,8 +51,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/sdks/overview/introduction">
             SDKs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             Generate client libraries in multiple languages.
@@ -70,31 +71,31 @@ import { FernFooter } from "../../../components/FernFooter";
           <span className="language-icons-label">Get started with:</span>
           {/* TypeScript */}
           <a className="language-icon" href="/sdks/generators/typescript/quickstart">
-            <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
+            <img src="file:681c2240-9a89-4bd4-ad25-0b5804fd5093" alt="TypeScript" className="language-icon-img" noZoom />
           </a>
           {/* Python */}
           <a className="language-icon" href="/sdks/generators/python/quickstart">
-            <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
+            <img src="file:574a4cc4-e058-49a1-a140-7d7cdfd48e79" alt="Python" className="language-icon-img" noZoom />
           </a> 
           {/* Go */}
           <a className="language-icon" href="/sdks/generators/go/quickstart">
-            <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
+            <img src="file:b641132c-4e5c-4a8a-894e-3a3b5832161b" alt="Go" className="language-icon-img" noZoom />
           </a>
           {/* Java */}
           <a className="language-icon" href="/sdks/generators/java/quickstart">
-            <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
+            <img src="file:657e00f8-1bfc-43b6-adef-deffe2450605" alt="Java" className="language-icon-img" noZoom />
           </a>
           {/* C# */}
           <a className="language-icon" href="/sdks/generators/csharp/quickstart">
-            <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
+            <img src="file:2803071a-be84-4d54-9c18-4651c10c1b12" alt="C#" className="language-icon-img" noZoom />
           </a>
           {/* PHP */}
           <a className="language-icon" href="/sdks/generators/php/quickstart">
-            <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
+            <img src="file:4b8ccd74-8bda-497b-9518-50ee32e91eef" alt="PHP" className="language-icon-img" noZoom />
           </a>
           {/* Ruby */}
           <a className="language-icon" href="/sdks/generators/ruby/quickstart">
-            <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
+            <img src="file:0736a0b9-eabe-4dbf-9957-4a69001b5fbd" alt="Ruby" className="language-icon-img" noZoom />
           </a>
         </div>
 
@@ -102,18 +103,18 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/sdks/overview/introduction">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="/sdks/overview/quickstart">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -123,8 +124,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/docs/getting-started/overview">
             Docs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             A beautiful, interactive documentation website.
@@ -141,38 +142,38 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons-vertical">
           <a className="fern-button filled normal primary gap-1 w-fit a-btn" href="/docs/getting-started/overview">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right" className="hidden dark:block" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right" className="dark:hidden" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/quickstart">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
             <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/project-structure">
             Set up your project structure
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/writing-content/components/overview">
             See all available components
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/customization/what-is-docs-yml"> 
             Configure your docs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/api-references/generate-api-ref">
             Bring your own API spec
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/authentication/rbac">
             Control role-based access
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           
         </div>
@@ -183,8 +184,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/ask-fern/getting-started/what-is-ask-fern">
             Ask Fern
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             AI Search that lets users find answers in your documentation instantly.
@@ -201,18 +202,18 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/ask-fern/getting-started/what-is-ask-fern">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="/ask-fern/configuration/custom-prompting">
             Configure
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:3ba1e14f-0e55-4e86-87aa-bcb280ca24cd" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:71bdc507-ad63-49b4-a3d7-28004356aa20" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -226,8 +227,8 @@ import { FernFooter } from "../../../components/FernFooter";
       
       <div className="community-grid">
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/changelog-light.svg" alt="Changelog Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/changelog-dark.svg" alt="Changelog Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:c4d2944c-d85d-4932-b11f-a58293bdfb58" alt="Changelog Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:72448d31-e808-474f-a823-473d249b3139" alt="Changelog Preview" noZoom />
 
           <h3 className="community-card-title">Changelog</h3>
           <p className="community-card-description">
@@ -235,41 +236,41 @@ import { FernFooter } from "../../../components/FernFooter";
           </p>
           <div className="flex flex-row gap-2 flex-wrap items-center">
             <a className="language-icon" href="/docs/changelog">
-              <img src="./images/fern-logo.svg" alt="Docs" className="language-icon-img" noZoom />
+              <img src="file:9bf042b2-4806-43f3-a408-9933ad37e185" alt="Docs" className="language-icon-img" noZoom />
             </a>
             <a className="language-icon" href="/sdks/generators/typescript/changelog">
-              <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
+              <img src="file:681c2240-9a89-4bd4-ad25-0b5804fd5093" alt="TypeScript" className="language-icon-img" noZoom />
             </a>
             {/* Python */}
             <a className="language-icon" href="/sdks/generators/python/changelog">
-              <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
+              <img src="file:574a4cc4-e058-49a1-a140-7d7cdfd48e79" alt="Python" className="language-icon-img" noZoom />
             </a> 
             {/* Go */}
             <a className="language-icon" href="/sdks/generators/go/changelog">
-              <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
+              <img src="file:b641132c-4e5c-4a8a-894e-3a3b5832161b" alt="Go" className="language-icon-img" noZoom />
             </a>
             {/* Java */}
             <a className="language-icon" href="/sdks/generators/java/changelog">
-              <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
+              <img src="file:657e00f8-1bfc-43b6-adef-deffe2450605" alt="Java" className="language-icon-img" noZoom />
             </a>
             {/* C# */}
             <a className="language-icon" href="/sdks/generators/csharp/changelog">
-              <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
+              <img src="file:2803071a-be84-4d54-9c18-4651c10c1b12" alt="C#" className="language-icon-img" noZoom />
             </a>
             {/* PHP */}
             <a className="language-icon" href="/sdks/generators/php/changelog">
-              <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
+              <img src="file:4b8ccd74-8bda-497b-9518-50ee32e91eef" alt="PHP" className="language-icon-img" noZoom />
             </a>
             {/* Ruby */}
             <a className="language-icon" href="/sdks/generators/ruby/changelog">
-              <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
+              <img src="file:0736a0b9-eabe-4dbf-9957-4a69001b5fbd" alt="Ruby" className="language-icon-img" noZoom />
             </a>
           </div>
         </div>
 
         <div className="community-card"> 
-          <img className="m-0 dark:hidden" src="./images/github-light.svg" alt="Github Preview" noZoom/>
-          <img className="m-0 hidden dark:block" src="./images/github-dark.svg" alt="Github Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:add477be-fb76-40d6-b9b1-f6e117385428" alt="Github Preview" noZoom/>
+          <img className="m-0 hidden dark:block" src="file:a2e68bac-cf3c-48ff-9eb9-aafd68e8b4ec" alt="Github Preview" noZoom />
 
           <h3 className="community-card-title">Github</h3>
           <p className="community-card-description">
@@ -281,8 +282,8 @@ import { FernFooter } from "../../../components/FernFooter";
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/slack-light.svg" alt="Discord Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/slack-dark.svg" alt="Discord Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:0ae80216-fa8e-497c-bae6-ec0008de9634" alt="Discord Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:7abd6ffd-9359-43e2-b4b7-de8a787e1f73" alt="Discord Preview" noZoom />
 
           <h3 className="community-card-title">Slack</h3>
           <p className="community-card-description">
@@ -294,8 +295,8 @@ import { FernFooter } from "../../../components/FernFooter";
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/x-light.svg" alt="Twitter Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/x-dark.svg" alt="Twitter Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:9e647043-fce1-4b02-a224-243a90e069c4" alt="Twitter Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:febd0fd0-788f-4f89-9629-b722226c150d" alt="Twitter Preview" noZoom />
 
           <h3 className="community-card-title">
             <span className="twitter-strikethrough">Twitter</span> X
@@ -321,15 +322,15 @@ import { FernFooter } from "../../../components/FernFooter";
       
       <div className="help-buttons">
         <a className="fern-button outlined normal gap-2 a-btn" href="https://github.com/fern-api/fern/issues">
-          <img src="./images/github-light.svg" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/github-dark.svg" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:add477be-fb76-40d6-b9b1-f6e117385428" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:a2e68bac-cf3c-48ff-9eb9-aafd68e8b4ec" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
 
           File a Github issue
         </a>
 
         <a className="fern-button outlined normal gap-2 a-btn" href="mailto:support@buildwithfern.com">
-          <img src="./images/email-light.svg" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/email-dark.svg" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:a927690f-3dc0-4476-a1be-f640f0b1d37c" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:315af824-ed66-49f9-a7c2-d1fd7c7e728d" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
 
           Email us
         </a>


### PR DESCRIPTION
This PR updates all image source paths to use file references instead of relative paths in the welcome.mdx file. Additionally, adds a "hellooooo" subtitle to the page frontmatter. These changes appear to be related to migrating image assets to a new file reference system while maintaining the same visual functionality in both light and dark modes.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)