### PR TITLE
fix relative path for java custom client

### DIFF
--- a/fern/products/sdks/overview/java/configuration.mdx
+++ b/fern/products/sdks/overview/java/configuration.mdx
@@ -46,7 +46,7 @@ Example:
 
 <ParamField path="enable-extensible-builders" type="boolean" default="false" required={false} toc={true}>
 
-When enabled, generates extensible builder classes that support customization through inheritance. This allows you to [add custom code](/learn/v2/sdks/generators/java/custom-code#adding-custom-client-configuration) to extend the generated builders with additional functionality.
+When enabled, generates extensible builder classes that support customization through inheritance. This allows you to [add custom code](/sdks/generators/java/custom-code#adding-custom-client-configuration) to extend the generated builders with additional functionality.
 </ParamField>
 
 <ParamField path="enable-forward-compatible-enums" type="boolean" default="false" required={false} toc={true}>


### PR DESCRIPTION
Old behavior doesn't work in prod -- by using this relative path it works locally and in prod. 
