### PR TITLE
refactor: Update image paths to use file IDs in welcome page

### DIFF
--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -50,8 +50,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/sdks/overview/introduction">
             SDKs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             Generate client libraries in multiple languages.
@@ -70,31 +70,31 @@ import { FernFooter } from "../../../components/FernFooter";
           <span className="language-icons-label">Get started with:</span>
           {/* TypeScript */}
           <a className="language-icon" href="/sdks/generators/typescript/quickstart">
-            <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
+            <img src="file:26f461c1-0580-4b8e-b57b-f6371c3ad201" alt="TypeScript" className="language-icon-img" noZoom />
           </a>
           {/* Python */}
           <a className="language-icon" href="/sdks/generators/python/quickstart">
-            <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
+            <img src="file:fac9dd30-d5ee-4bd4-a6f8-defa67507211" alt="Python" className="language-icon-img" noZoom />
           </a> 
           {/* Go */}
           <a className="language-icon" href="/sdks/generators/go/quickstart">
-            <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
+            <img src="file:19367265-e731-4093-90c9-bf42e7b7bcff" alt="Go" className="language-icon-img" noZoom />
           </a>
           {/* Java */}
           <a className="language-icon" href="/sdks/generators/java/quickstart">
-            <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
+            <img src="file:07246839-ed3a-4f85-946b-27f20e4ea0af" alt="Java" className="language-icon-img" noZoom />
           </a>
           {/* C# */}
           <a className="language-icon" href="/sdks/generators/csharp/quickstart">
-            <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
+            <img src="file:890360e6-7049-47bc-9e44-ce2afae3dc51" alt="C#" className="language-icon-img" noZoom />
           </a>
           {/* PHP */}
           <a className="language-icon" href="/sdks/generators/php/quickstart">
-            <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
+            <img src="file:44429bee-a3e2-4eee-9bc2-cf35ad40c536" alt="PHP" className="language-icon-img" noZoom />
           </a>
           {/* Ruby */}
           <a className="language-icon" href="/sdks/generators/ruby/quickstart">
-            <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
+            <img src="file:810e2329-bcff-4423-8e9c-aabbe489a885" alt="Ruby" className="language-icon-img" noZoom />
           </a>
         </div>
 
@@ -102,18 +102,18 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/sdks/overview/introduction">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="/sdks/overview/quickstart">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -123,8 +123,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/docs/getting-started/overview">
             Docs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             A beautiful, interactive documentation website.
@@ -141,38 +141,38 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons-vertical">
           <a className="fern-button filled normal primary gap-1 w-fit a-btn" href="/docs/getting-started/overview">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right" className="hidden dark:block" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right" className="dark:hidden" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/quickstart">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
             <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/project-structure">
             Set up your project structure
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/writing-content/components/overview">
             See all available components
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/customization/what-is-docs-yml"> 
             Configure your docs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/api-references/generate-api-ref">
             Bring your own API spec
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/authentication/rbac">
             Control role-based access
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           
         </div>
@@ -183,8 +183,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/ask-fern/getting-started/what-is-ask-fern">
             Ask Fern
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             AI Search that lets users find answers in your documentation instantly.
@@ -201,18 +201,18 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/ask-fern/getting-started/what-is-ask-fern">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="/ask-fern/configuration/custom-prompting">
             Configure
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:37cd42fe-9fbc-43e5-b912-a8201ac08db4" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:490991a1-5102-4219-8252-246f1a542dd9" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -226,8 +226,8 @@ import { FernFooter } from "../../../components/FernFooter";
       
       <div className="community-grid">
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/changelog-light.svg" alt="Changelog Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/changelog-dark.svg" alt="Changelog Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:f393aacc-52aa-49d2-acef-8ad2c2d05015" alt="Changelog Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:2203e932-e49e-4fdc-8c16-5f70553dadd0" alt="Changelog Preview" noZoom />
 
           <h3 className="community-card-title">Changelog</h3>
           <p className="community-card-description">
@@ -235,41 +235,41 @@ import { FernFooter } from "../../../components/FernFooter";
           </p>
           <div className="flex flex-row gap-2 flex-wrap items-center">
             <a className="language-icon" href="/docs/changelog">
-              <img src="./images/fern-logo.svg" alt="Docs" className="language-icon-img" noZoom />
+              <img src="file:77236e23-1f49-4de4-8c3e-4ca83ef1b9fa" alt="Docs" className="language-icon-img" noZoom />
             </a>
             <a className="language-icon" href="/sdks/generators/typescript/changelog">
-              <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
+              <img src="file:26f461c1-0580-4b8e-b57b-f6371c3ad201" alt="TypeScript" className="language-icon-img" noZoom />
             </a>
             {/* Python */}
             <a className="language-icon" href="/sdks/generators/python/changelog">
-              <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
+              <img src="file:fac9dd30-d5ee-4bd4-a6f8-defa67507211" alt="Python" className="language-icon-img" noZoom />
             </a> 
             {/* Go */}
             <a className="language-icon" href="/sdks/generators/go/changelog">
-              <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
+              <img src="file:19367265-e731-4093-90c9-bf42e7b7bcff" alt="Go" className="language-icon-img" noZoom />
             </a>
             {/* Java */}
             <a className="language-icon" href="/sdks/generators/java/changelog">
-              <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
+              <img src="file:07246839-ed3a-4f85-946b-27f20e4ea0af" alt="Java" className="language-icon-img" noZoom />
             </a>
             {/* C# */}
             <a className="language-icon" href="/sdks/generators/csharp/changelog">
-              <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
+              <img src="file:890360e6-7049-47bc-9e44-ce2afae3dc51" alt="C#" className="language-icon-img" noZoom />
             </a>
             {/* PHP */}
             <a className="language-icon" href="/sdks/generators/php/changelog">
-              <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
+              <img src="file:44429bee-a3e2-4eee-9bc2-cf35ad40c536" alt="PHP" className="language-icon-img" noZoom />
             </a>
             {/* Ruby */}
             <a className="language-icon" href="/sdks/generators/ruby/changelog">
-              <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
+              <img src="file:810e2329-bcff-4423-8e9c-aabbe489a885" alt="Ruby" className="language-icon-img" noZoom />
             </a>
           </div>
         </div>
 
         <div className="community-card"> 
-          <img className="m-0 dark:hidden" src="./images/github-light.svg" alt="Github Preview" noZoom/>
-          <img className="m-0 hidden dark:block" src="./images/github-dark.svg" alt="Github Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:7b920cf4-c7a3-41ca-82de-29b0bac668b9" alt="Github Preview" noZoom/>
+          <img className="m-0 hidden dark:block" src="file:27ee7e26-de67-44ad-90b6-00e39418aedb" alt="Github Preview" noZoom />
 
           <h3 className="community-card-title">Github</h3>
           <p className="community-card-description">
@@ -281,8 +281,8 @@ import { FernFooter } from "../../../components/FernFooter";
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/slack-light.svg" alt="Discord Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/slack-dark.svg" alt="Discord Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:c58ed5a7-f4b4-4aa2-af24-8541cfb86054" alt="Discord Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:5130e052-aed2-415b-b24f-ee03d8258e99" alt="Discord Preview" noZoom />
 
           <h3 className="community-card-title">Slack</h3>
           <p className="community-card-description">
@@ -294,8 +294,8 @@ import { FernFooter } from "../../../components/FernFooter";
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/x-light.svg" alt="Twitter Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/x-dark.svg" alt="Twitter Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:e5364668-3032-4ec7-a5dd-5628561394be" alt="Twitter Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:ed6e6848-a81d-4966-8962-358b70a45dbb" alt="Twitter Preview" noZoom />
 
           <h3 className="community-card-title">
             <span className="twitter-strikethrough">Twitter</span> X
@@ -321,15 +321,15 @@ import { FernFooter } from "../../../components/FernFooter";
       
       <div className="help-buttons">
         <a className="fern-button outlined normal gap-2 a-btn" href="https://github.com/fern-api/fern/issues">
-          <img src="./images/github-light.svg" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/github-dark.svg" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:7b920cf4-c7a3-41ca-82de-29b0bac668b9" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:27ee7e26-de67-44ad-90b6-00e39418aedb" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
 
           File a Github issue
         </a>
 
         <a className="fern-button outlined normal gap-2 a-btn" href="mailto:support@buildwithfern.com">
-          <img src="./images/email-light.svg" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/email-dark.svg" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:9db04f07-1a05-4d80-a0f4-5ba07edaa771" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:23ff1004-05f4-4187-ad19-59b9d7e001e4" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
 
           Email us
         </a>

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -1,9 +1,10 @@
 ---
-title: Build with Fern
+title: Build with Fe
 description: Explore our guides for how to generate SDKs and Docs with Fern.
 slug: /
 hide-toc: true
 layout: custom
+subtitle: aaa
 ---
 
 import { FernFooter } from "../../../components/FernFooter";


### PR DESCRIPTION

This PR updates all image source paths in the welcome.mdx file to use file IDs instead of relative paths. The change affects various icons and images throughout the page, including language logos, arrow icons, and social media images. This modification likely supports a new asset management system or visual editor functionality while maintaining the same visual appearance of the page.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)