### PR TITLE
chore: Update image paths to use file references in overview page

### DIFF
--- a/fern/products/docs/pages/getting-started/overview.mdx
+++ b/fern/products/docs/pages/getting-started/overview.mdx
@@ -16,13 +16,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
   <CardGroup cols={2}>
     <a class="fern-card interactive not-prose relative block p-6 text-base" href="/docs/getting-started/quickstart">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Quickstart" src="./images/quickstart.png" />
-        <img class="mx-auto hidden dark:block" alt="Quickstart" src="./images/quickstart-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Quickstart" src="file:7be83004-3c75-4b8a-bae8-449b4c4e82df" />
+        <img class="mx-auto hidden dark:block" alt="Quickstart" src="file:87329ee1-a2dd-48c5-8748-730a8b54492d" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:f9e34ebb-5b35-4e70-82ad-70ebd7575870" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:919c2e95-28de-48af-a221-b9cf4ccdc1a7" alt="Arrow left light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Set up a documentation site in under 5 minutes.</p>
@@ -33,13 +33,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
     
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/customization/what-is-docs-yml">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Configure with ease" src="./images/configure.png" />
-        <img class="mx-auto hidden dark:block" alt="Configure with ease" src="./images/configure-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Configure with ease" src="file:6295e809-3b19-45a7-a47b-d515e36a53ec" />
+        <img class="mx-auto hidden dark:block" alt="Configure with ease" src="file:0881ebde-e5ab-4f48-9107-362887743f07" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Configure with ease
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:f9e34ebb-5b35-4e70-82ad-70ebd7575870" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:919c2e95-28de-48af-a221-b9cf4ccdc1a7" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Use one simple file to generate documentation that fits your brand.</p>
@@ -55,13 +55,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
   <CardGroup cols={2}>
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/writing-content/components/overview">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Flexible component library" src="./images/component-library.png" />
-        <img class="mx-auto hidden dark:block" alt="Flexible component library" src="./images/component-library-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Flexible component library" src="file:1e71b671-a73b-45f3-8450-477711bb7f71" />
+        <img class="mx-auto hidden dark:block" alt="Flexible component library" src="file:60b7aae5-852c-44e4-a612-c6206cf3a374" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Flexible component library
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:f9e34ebb-5b35-4e70-82ad-70ebd7575870" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:919c2e95-28de-48af-a221-b9cf4ccdc1a7" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Use pre-built or custom React components for a polished look.</p>
@@ -72,13 +72,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
     
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/writing-content/visual-editor">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Visual Editor" src="./images/visual-editor.png" />
-        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="./images/visual-editor-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Visual Editor" src="file:343b3769-9832-4b7c-8936-94c0327b2cfa" />
+        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="file:19f792ef-fd53-46fa-97e9-dbe7cd265dd7" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Visual Editor
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:f9e34ebb-5b35-4e70-82ad-70ebd7575870" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:919c2e95-28de-48af-a221-b9cf4ccdc1a7" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Modify your documentation without touching code and publish to your GitHub.</p>
@@ -89,13 +89,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
 
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/api-references/generate-api-ref">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Visual Editor" src="./images/api-specs-light.png" />
-        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="./images/api-specs-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Visual Editor" src="file:6765bfd0-999b-4a47-b431-814767569d05" />
+        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="file:e29362eb-2c5e-46b9-a0de-1db3aa72b3ab" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Bring your own API Spec
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:f9e34ebb-5b35-4e70-82ad-70ebd7575870" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:919c2e95-28de-48af-a221-b9cf4ccdc1a7" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Use OpenAPI, AsyncAPI, gRPC, OpenRPC, and the Fern spec.</p>
@@ -106,13 +106,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
 
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/ask-fern/getting-started/what-is-ask-fern">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Visual Editor" src="./images/ask-fern-light.png" />
-        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="./images/ask-fern-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Visual Editor" src="file:e3b5e7d0-a599-4511-a915-6cfd8facd786" />
+        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="file:e5eb52a6-cee9-4d71-a0e3-cf6fe96c54b6" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Ask Fern
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:f9e34ebb-5b35-4e70-82ad-70ebd7575870" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:919c2e95-28de-48af-a221-b9cf4ccdc1a7" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>A personalized chatbot that can answer questions about your documentation.</p>


### PR DESCRIPTION

This PR updates all image source paths in the getting-started overview page from relative file paths (./images/*) to file reference IDs. This change affects all card images and arrow icons throughout the page, maintaining both light and dark mode variants. The update standardizes the image reference format across the documentation.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)