### PR TITLE
Add reference to Audiences for filtering API endpoints in API Reference docs

### DIFF
--- a/fern/products/docs/pages/api-references/generate-api-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-api-ref.mdx
@@ -44,3 +44,8 @@ navigation:
   - api: Garden
     api-name: garden-api
 ```
+
+### Include only specific APIs Endpoints
+To display specific APIs Endpoints, use [Audiences](/learn/docs/api-references/audiences).
+
+

--- a/fern/products/docs/pages/api-references/generate-api-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-api-ref.mdx
@@ -20,7 +20,7 @@ navigation:
 | ---------------- | ------------------------------------------------------------------------------------------------------- |
 | `api` (required) | Title of the API Reference Section                                                                      |
 | `api-name`       | Name of the API we are referencing, if there are [multiple APIs](#include-more-than-one-api-reference)  |
-| `audiences`      | List of [audiences](/learn/api-definition/fern/audiences) to filter the API Reference for               |
+| `audiences`      | List of [audiences](/docs/api-references/audiences) that determines which endpoints, schemas, and properties are displayed in your API Reference          |
 | `display-errors` | Displays error schemas in the API References                                                            |
 | `snippets`       | Enable [generated SDK code snippets](/learn/api-reference/snippets/get) in your API Reference            |
 | `summary`        | Relative path to the Markdown file; the summary is displayed at the top of the API section              |
@@ -44,8 +44,5 @@ navigation:
   - api: Garden
     api-name: garden-api
 ```
-
-### Include only specific API Endpoints
-To display specific API Endpoints in your API reference, use [Audiences](/learn/docs/api-references/audiences).
 
 

--- a/fern/products/docs/pages/api-references/generate-api-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-api-ref.mdx
@@ -45,7 +45,7 @@ navigation:
     api-name: garden-api
 ```
 
-### Include only specific APIs Endpoints
-To display specific APIs Endpoints, use [Audiences](/learn/docs/api-references/audiences).
+### Include only specific API Endpoints
+To display specific API Endpoints in your API reference, use [Audiences](/learn/docs/api-references/audiences).
 
 


### PR DESCRIPTION
This PR adds a short mention of using Audiences to include only specific API endpoints in the API Reference documentation. 

While the `audiences` property is mentioned in the configuration table, its primary use case for filtering endpoints isn't highlighted.

This change improves the user journey by proactively addressing the common question, "How do I show only some of my endpoints?" at a logical point in the documentation.