### PR TITLE
docs: Update TypeScript SDK quickstart with expanded setup instructions

### DIFF
--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -3,13 +3,29 @@ title: TypeScript Quickstart
 description: Get started quickly with the Fern TypeScript SDK.
 ---
 
-Generate a TypeScript SDK by following the instructions on this page. 
+Generate a TypeScript SDK by following the instructions on this page.
 
-<Markdown src="/products/sdks/snippets/setup-fern-folder-callout.mdx"/>
+This is a quickstart.
+
+<Info>
+  This page assumes that you have:
+
+  * An initialized `fern` folder on your local machine. See [Set up the `fern`
+    folder](/sdks/overview/quickstart).
+  * A GitHub repository for your SDK. See [Project Structure](/sdks/overview/github).
+</Info>
 
 <Steps>
 
- <Markdown src="/products/sdks/snippets/pass-fern-check.mdx"/>
+   ### Pass `fern check`
+ 
+   Run `fern check` to ensure that your API definition is valid. If there are any errors,
+   fix them before proceeding.
+ 
+   <Note>
+     If you're using an OpenAPI Specification, check out all of our 
+     [supported extensions](/learn/api-definition/openapi/extensions).
+   </Note>
 
 ## Add the SDK generator
 
@@ -32,7 +48,7 @@ This command adds the following `group` to `generators.yml`:
   ts-sdk: # group name
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: <Markdown src="/snippets/version-number-ts.mdx"/>
+        version: 2.6.8
         output:
           location: local-file-system
           path: ../sdks/typescript
@@ -45,7 +61,7 @@ This command adds the following `group` to `generators.yml`:
   fern generate --group ts-sdk
   ```
 
-  <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
+   This creates a `sdks` folder in your current directory. The resulting folder structure looks like this:
 
 ```bash
 fern/ # created by fern init


### PR DESCRIPTION
This PR enhances the TypeScript SDK quickstart documentation by replacing generic markdown imports with detailed, inline instructions. Key changes include:
- Added prerequisite information about fern folder setup and GitHub repository requirements
- Expanded the 'fern check' section with specific instructions and OpenAPI notes
- Updated the TypeScript SDK version number to 2.6.8
- Added explicit folder structure examples and removed generic snippets
- Improved overall readability with more detailed, self-contained documentation

These changes make the quickstart guide more standalone and easier to follow for new users.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)