### PR TITLE
docs: Update TypeScript SDK publishing guide and image references

### DIFF
--- a/fern/products/sdks/overview/typescript/publishing-to-npm.mdx
+++ b/fern/products/sdks/overview/typescript/publishing-to-npm.mdx
@@ -3,12 +3,12 @@ title: Publishing to npm
 description: How to publish the Fern TypeScript SDK to npm.
 ---
 
-Publish your public-facing Fern TypeScript SDK to the [npm
-registry](https://www.npmjs.com/). After following the steps on this page,
-you'll have a versioned package published on npm.
+Publish your public-facing Fern TypeScript SDK to the [npm registry](https://www.npmjs.com/). After following the steps on this page, you'll have a versioned package published on npm.
+
+Deep made a change!!!
 
 <Frame>
-	<img src="assets/npm-packages.png" alt="Versioned package published on npm" />
+	<img src="file:3afaf258-4304-4245-8cef-fb9bd4909581" alt="Versioned package published on npm" />
 </Frame>
 
 <Info>
@@ -35,7 +35,7 @@ you'll have a versioned package published on npm.
 	      ts-sdk: # Group name for your TypeScript SDK
 	        generators:
 	          - name: fernapi/fern-typescript-sdk
-	            version: <Markdown src="/snippets/typescript-sdk-version.mdx"/>
+	            version: 2.5.0
 	            output:
 	              location: npm
 
@@ -52,7 +52,7 @@ groups:
   ts-sdk:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: <Markdown src="/snippets/typescript-sdk-version.mdx"/>
+        version: 2.5.0
         output:
           location: npm
           package-name: your-package-name
@@ -70,7 +70,7 @@ groups:
   ts-sdk:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: <Markdown src="/snippets/typescript-sdk-version.mdx"/>
+        version: 2.5.0
         output:
           location: npm
           package-name: your-package-name
@@ -89,7 +89,7 @@ groups:
   ts-sdk:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: <Markdown src="/snippets/typescript-sdk-version.mdx"/>
+        version: 2.5.0
         output:
           location: npm
           package-name: your-package-name
@@ -136,7 +136,7 @@ groups:
 	<Warning>Save your new token –  it won’t be displayed after you leave the page.</Warning>
 
 	<Frame>
-	<img src="assets/npm-automation-token.png" alt="Creating NPM Automation Token" />
+	<img src="file:fb37cb53-1eb0-4486-ab6a-248135d769f4" alt="Creating NPM Automation Token" />
 	</Frame>
 
   </Accordion>
@@ -152,7 +152,7 @@ groups:
 	<Warning>Save your new token –  it won’t be displayed after you leave the page.</Warning>
 
 	<Frame>
-	<img src="assets/granular-access-token.png" alt="Creating Granular Access Token" />
+	<img src="file:8a9eb374-127c-4f03-926a-6b987150edec" alt="Creating Granular Access Token" />
 	</Frame>
 
 	</Accordion>
@@ -177,7 +177,7 @@ Set up a release workflow via [GitHub Actions](https://docs.github.com/en/action
 	Open your Fern repository in GitHub. Click on the **Settings** tab in your repository. Then, under the **Security** section, open **Secrets and variables** > **Actions**. 
 
 	<Frame>
-	<img src="assets/github-secret.png" alt="Adding GitHub Repository Secret" />
+	<img src="file:18b8f1bc-85ca-4aa1-97ba-7b0dbe27bc88" alt="Adding GitHub Repository Secret" />
 	</Frame>
 
 	You can also use the url `https://github.com/<your-repo>/settings/secrets/actions`.
@@ -191,7 +191,7 @@ Set up a release workflow via [GitHub Actions](https://docs.github.com/en/action
 	1.    Click **Add secret**. 
 
 	<Frame>
-	<img src="assets/npm-token-secret.png" alt="NPM_TOKEN secret" />
+	<img src="file:33df8efe-2d45-4790-b612-7cdb57200877" alt="NPM_TOKEN secret" />
 	</Frame>
 
 	</Step>
@@ -205,7 +205,7 @@ Set up a release workflow via [GitHub Actions](https://docs.github.com/en/action
 	1.    Click **Add secret**. 
 
 	<Frame>
-	<img src="assets/npm-token-secret.png" alt="NPM_TOKEN secret" />
+	<img src="file:33df8efe-2d45-4790-b612-7cdb57200877" alt="NPM_TOKEN secret" />
 	</Frame>
 
 	</Step>
@@ -248,7 +248,7 @@ Set up a release workflow via [GitHub Actions](https://docs.github.com/en/action
     click **Run workflow**. 
 
 	<Frame>
-		<img src="assets/ts-sdk-release-action.png" alt="Running TS publish workflow" />
+		<img src="file:740c3de5-b652-47ef-b643-8026bfb3ced9" alt="Running TS publish workflow" />
 	</Frame>
 	
 	Once your workflow completes, log back into npm and
@@ -269,7 +269,7 @@ groups:
   ts-sdk:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: <Markdown src="/snippets/typescript-sdk-version.mdx"/>
+        version: 2.5.0
         output:
           location: npm
           package-name: name-of-your-package


### PR DESCRIPTION
This PR updates the TypeScript SDK publishing documentation by hardcoding the SDK version to 2.5.0 (removing dynamic version references) and updates all image references to use file IDs instead of asset paths. The content has been reformatted for better readability, including fixing line wrapping. A test change comment "Deep made a change!!!" has been added, which should be removed before merging.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)