### PR TITLE
fix: Update reusable-markdown.mdx

### DIFF
--- a/fern/products/docs/pages/component-library/custom-components/reusable-markdown.mdx
+++ b/fern/products/docs/pages/component-library/custom-components/reusable-markdown.mdx
@@ -38,7 +38,7 @@ To use a snippet in your documentation, reference it by its file path (including
         ```jsx
         Peace lilies are easy to grow and relatively trouble-free.
 
-        <Markdown src="/snippets/peace-lily.mdx">
+        <Markdown src="/snippets/peace-lily.mdx" />
         ```
 
     </Tab>


### PR DESCRIPTION
<img width="1358" height="694" alt="CleanShot 2025-08-11 at 13 11 20@2x" src="https://github.com/user-attachments/assets/48cd5d99-551e-4ab3-989d-65b54be1a74d" />
This is missing a backwards slash '/'