### PR TITLE
fix: Add appropriate audiences to `fai` API definition.

### DIFF
--- a/fern/apis/fai/definition/analytics.yml
+++ b/fern/apis/fai/definition/analytics.yml
@@ -11,6 +11,8 @@ service:
       docs: Retrieve the usage histogram analytics for a given period
       path: /histogram/{domain}
       method: GET
+      audiences:
+        - internal
       path-parameters:
         domain: string
       request:
@@ -33,6 +35,8 @@ service:
       docs: Retrieve the insights for a given period
       path: /insights/{domain}
       method: GET
+      audiences:
+        - internal
       path-parameters:
         domain: string
       request:

--- a/fern/apis/fai/definition/chat.yml
+++ b/fern/apis/fai/definition/chat.yml
@@ -11,6 +11,8 @@ service:
       docs: Create a docs chat completion for a given domain
       path: /{domain}
       method: POST
+      audiences:
+        - customers
       path-parameters:
         domain: string
       request:

--- a/fern/apis/fai/definition/conversations.yml
+++ b/fern/apis/fai/definition/conversations.yml
@@ -11,6 +11,8 @@ service:
       docs: Retrieve a complete conversation by conversation id
       path: /{domain}/{conversation_id}
       method: GET
+      audiences:
+        - customers
       path-parameters:
         domain: string
         conversation_id: string

--- a/fern/apis/fai/definition/index.yml
+++ b/fern/apis/fai/definition/index.yml
@@ -11,6 +11,8 @@ service:
       docs: Index a document for a given domain
       path: /{domain}
       method: POST
+      audiences:
+        - customers
       path-parameters:
         domain: string
       request:
@@ -27,7 +29,7 @@ service:
             context:
               type: list<string>
               docs: The context of the document, as a list of strings, that will be indexed.
-            content:
+            document:
               type: string
               docs: The content of the document that will be returned in the tool response
       errors:
@@ -54,6 +56,8 @@ service:
       docs: Update a document for a given domain
       path: /{domain}/update
       method: POST
+      audiences:
+        - customers
       path-parameters:
         domain: string
       request:
@@ -68,10 +72,28 @@ service:
           context:
             type: list<string>
             docs: The context of the document, as a list of strings, that will be indexed.
-          content:
+          document:
             type: string
             docs: The content of the document that will be returned in the tool response. If not provided, the document will be removed from the index.
       response: ContextResponse
+      errors:
+        - commons.BadRequestError
+        - commons.InternalError
+
+    syncToQueryIndex:
+      docs: Sync an index with the query index
+      path: /{domain}/sync
+      method: POST
+      audiences:
+        - internal
+      path-parameters:
+        domain: string
+      request:
+        name: SyncIndexRequest
+        query-parameters:
+          index_name:
+            type: string
+            docs: The name of the index to sync
       errors:
         - commons.BadRequestError
         - commons.InternalError
@@ -83,7 +105,7 @@ types:
       domain: string
       context_id: string
       context: list<string>
-      content: string
+      document: string
       is_active: boolean
       created_at: datetime
       updated_at: datetime

--- a/fern/apis/fai/definition/queries.yml
+++ b/fern/apis/fai/definition/queries.yml
@@ -12,6 +12,8 @@ service:
       docs: Log a new query to the FAI DB
       path: /queries
       method: POST
+      audiences:
+        - internal
       request:
         name: CreateQueryRequest
         body:
@@ -34,6 +36,8 @@ service:
       docs: Retrieve all paginated recent queries
       path: /queries/{domain}
       method: GET
+      audiences:
+        - internal
       path-parameters:
         domain:
           type: string

--- a/fern/products/ask-fern/ask-fern.yml
+++ b/fern/products/ask-fern/ask-fern.yml
@@ -19,12 +19,8 @@ navigation:
     api-name: fai
     icon: fa-regular fa-pro
     paginated: true
+    audiences:
+      - customers
     layout:
       - page: Overview
         path: ./pages/getting-started/api-get-started.mdx
-      - chat: 
-        - endpoint: chat.chatCompletion
-      - index:
-        - endpoint: index.indexDocument
-        - endpoint: index.getDocument
-        - endpoint: index.updateDocument


### PR DESCRIPTION
This PR appropriately distinguishes between `customer` and `internal` API endpoints.