### PR TITLE
refactor: Update image paths to use file references

### DIFF
--- a/fern/products/docs/pages/getting-started/overview.mdx
+++ b/fern/products/docs/pages/getting-started/overview.mdx
@@ -123,4 +123,4 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
   </CardGroup> 
 </div>
 
-helooooo
+helooooo test test test

--- a/fern/products/docs/pages/getting-started/overview.mdx
+++ b/fern/products/docs/pages/getting-started/overview.mdx
@@ -16,13 +16,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
   <CardGroup cols={2}>
     <a class="fern-card interactive not-prose relative block p-6 text-base" href="/docs/getting-started/quickstart">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Quickstart" src="./images/quickstart.png" />
-        <img class="mx-auto hidden dark:block" alt="Quickstart" src="./images/quickstart-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Quickstart" src="file:6d3767c0-2570-4070-a8c2-57b2ccc4611e" />
+        <img class="mx-auto hidden dark:block" alt="Quickstart" src="file:d72b95c9-19bd-451c-ac1e-addd33b5d412" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:dd7e057b-ee5e-4083-a5ae-a351fdab8b13" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:f26f1749-790f-46e9-b494-cf1edea12782" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Set up a documentation site in under 5 minutes.</p>
@@ -33,13 +33,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
     
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/customization/what-is-docs-yml">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Configure with ease" src="./images/configure.png" />
-        <img class="mx-auto hidden dark:block" alt="Configure with ease" src="./images/configure-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Configure with ease" src="file:ef7fb273-2cb9-4c91-b81a-a2425da8cb1e" />
+        <img class="mx-auto hidden dark:block" alt="Configure with ease" src="file:8aaae53a-9d46-4ee9-8bbc-f035812d6d9b" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Configure with ease
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:dd7e057b-ee5e-4083-a5ae-a351fdab8b13" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:f26f1749-790f-46e9-b494-cf1edea12782" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Use one simple file to generate documentation that fits your brand.</p>
@@ -55,13 +55,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
   <CardGroup cols={2}>
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/writing-content/components/overview">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Flexible component library" src="./images/component-library.png" />
-        <img class="mx-auto hidden dark:block" alt="Flexible component library" src="./images/component-library-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Flexible component library" src="file:50eb04b6-98a7-41ca-9803-1cb934718f85" />
+        <img class="mx-auto hidden dark:block" alt="Flexible component library" src="file:522ccc51-fdbc-4855-bcb6-f024777852da" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Flexible component library
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:dd7e057b-ee5e-4083-a5ae-a351fdab8b13" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:f26f1749-790f-46e9-b494-cf1edea12782" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Use pre-built or custom React components for a polished look.</p>
@@ -72,13 +72,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
     
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/writing-content/visual-editor">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Visual Editor" src="./images/visual-editor.png" />
-        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="./images/visual-editor-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Visual Editor" src="file:25771869-3434-43a0-a37b-9d7140c21fa8" />
+        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="file:ea1090c9-fa6b-417a-9c65-90827585e604" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Visual Editor
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:dd7e057b-ee5e-4083-a5ae-a351fdab8b13" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:f26f1749-790f-46e9-b494-cf1edea12782" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Modify your documentation without touching code and publish to your GitHub.</p>
@@ -89,13 +89,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
 
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/api-references/generate-api-ref">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Visual Editor" src="./images/api-specs-light.png" />
-        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="./images/api-specs-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Visual Editor" src="file:58acc320-db15-4bd1-98b9-ffdbe54b4f59" />
+        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="file:558827ec-763c-403d-a467-5a4bc45c6a67" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Bring your own API Spec
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:dd7e057b-ee5e-4083-a5ae-a351fdab8b13" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:f26f1749-790f-46e9-b494-cf1edea12782" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Use OpenAPI, AsyncAPI, gRPC, OpenRPC, and the Fern spec.</p>
@@ -106,13 +106,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
 
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/ask-fern/getting-started/what-is-ask-fern">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Visual Editor" src="./images/ask-fern-light.png" />
-        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="./images/ask-fern-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Visual Editor" src="file:e8c2bdbf-6006-458f-acdb-76e66265aa40" />
+        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="file:6bebf8e0-6c0a-4631-9ced-fb685045f354" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Ask Fern
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:dd7e057b-ee5e-4083-a5ae-a351fdab8b13" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:f26f1749-790f-46e9-b494-cf1edea12782" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>A personalized chatbot that can answer questions about your documentation.</p>
@@ -122,3 +122,5 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
     </a>
   </CardGroup> 
 </div>
+
+helooooo

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -50,8 +50,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/sdks/overview/introduction">
             SDKs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             Generate client libraries in multiple languages.
@@ -70,31 +70,31 @@ import { FernFooter } from "../../../components/FernFooter";
           <span className="language-icons-label">Get started with:</span>
           {/* TypeScript */}
           <a className="language-icon" href="/sdks/generators/typescript/quickstart">
-            <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
+            <img src="file:c7670b7d-14a0-4630-8354-60fd40cef5ed" alt="TypeScript" className="language-icon-img" noZoom />
           </a>
           {/* Python */}
           <a className="language-icon" href="/sdks/generators/python/quickstart">
-            <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
+            <img src="file:3948b4f9-0b06-4897-8d66-c6c2cf272dc4" alt="Python" className="language-icon-img" noZoom />
           </a> 
           {/* Go */}
           <a className="language-icon" href="/sdks/generators/go/quickstart">
-            <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
+            <img src="file:ca16cf62-0061-4678-9f97-9cbd2ecaad2d" alt="Go" className="language-icon-img" noZoom />
           </a>
           {/* Java */}
           <a className="language-icon" href="/sdks/generators/java/quickstart">
-            <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
+            <img src="file:ac32cfb8-c77b-4cbf-a197-9baa4ec03418" alt="Java" className="language-icon-img" noZoom />
           </a>
           {/* C# */}
           <a className="language-icon" href="/sdks/generators/csharp/quickstart">
-            <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
+            <img src="file:0e9f864d-c00f-4276-a43d-71e088f73374" alt="C#" className="language-icon-img" noZoom />
           </a>
           {/* PHP */}
           <a className="language-icon" href="/sdks/generators/php/quickstart">
-            <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
+            <img src="file:ac1f3cd7-3731-4c6b-926e-43b75c645889" alt="PHP" className="language-icon-img" noZoom />
           </a>
           {/* Ruby */}
           <a className="language-icon" href="/sdks/generators/ruby/quickstart">
-            <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
+            <img src="file:0b93a2c5-83e9-4e00-aff4-1f7b9dbe66d2" alt="Ruby" className="language-icon-img" noZoom />
           </a>
         </div>
 
@@ -102,18 +102,18 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/sdks/overview/introduction">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="/sdks/overview/quickstart">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -123,8 +123,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/docs/getting-started/overview">
             Docs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             A beautiful, interactive documentation website.
@@ -141,38 +141,38 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons-vertical">
           <a className="fern-button filled normal primary gap-1 w-fit a-btn" href="/docs/getting-started/overview">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right" className="hidden dark:block" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right" className="dark:hidden" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/quickstart">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/writing-content/components/overview">
             See all available components
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/api-references/generate-api-ref">
             Bring your own API spec
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/authentication/rbac">
             Control role-based access
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/self-hosted/overview"> 
             Self host your docs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="https://buildwithfern.com/showcase#docs-customers.alldocs-features">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -182,8 +182,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/ask-fern/getting-started/what-is-ask-fern">
             Ask Fern
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             AI Search that lets users find answers in your documentation instantly.
@@ -200,18 +200,18 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/ask-fern/getting-started/what-is-ask-fern">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="/ask-fern/configuration/custom-prompting">
             Configure
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase#ask-fern-customers">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:867c820d-31c8-446d-a483-c02253bc97c2" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:9d74350d-05b7-42eb-a08f-a4691614143a" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -225,8 +225,8 @@ import { FernFooter } from "../../../components/FernFooter";
       
       <div className="community-grid">
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/changelog-light.svg" alt="Changelog Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/changelog-dark.svg" alt="Changelog Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:571a090b-6b3c-4f44-8234-872fb35d6f21" alt="Changelog Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:7658de32-2b82-4336-921d-04133bfd18f9" alt="Changelog Preview" noZoom />
 
           <h3 className="community-card-title">Changelog</h3>
           <p className="community-card-description">
@@ -234,41 +234,41 @@ import { FernFooter } from "../../../components/FernFooter";
           </p>
           <div className="flex flex-row gap-2 flex-wrap items-center">
             <a className="language-icon" href="/docs/changelog">
-              <img src="./images/fern-logo.svg" alt="Docs" className="language-icon-img" noZoom />
+              <img src="file:3a707895-12b0-4033-9334-a3c9b462b65d" alt="Docs" className="language-icon-img" noZoom />
             </a>
             <a className="language-icon" href="/sdks/generators/typescript/changelog">
-              <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
+              <img src="file:c7670b7d-14a0-4630-8354-60fd40cef5ed" alt="TypeScript" className="language-icon-img" noZoom />
             </a>
             {/* Python */}
             <a className="language-icon" href="/sdks/generators/python/changelog">
-              <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
+              <img src="file:3948b4f9-0b06-4897-8d66-c6c2cf272dc4" alt="Python" className="language-icon-img" noZoom />
             </a> 
             {/* Go */}
             <a className="language-icon" href="/sdks/generators/go/changelog">
-              <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
+              <img src="file:ca16cf62-0061-4678-9f97-9cbd2ecaad2d" alt="Go" className="language-icon-img" noZoom />
             </a>
             {/* Java */}
             <a className="language-icon" href="/sdks/generators/java/changelog">
-              <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
+              <img src="file:ac32cfb8-c77b-4cbf-a197-9baa4ec03418" alt="Java" className="language-icon-img" noZoom />
             </a>
             {/* C# */}
             <a className="language-icon" href="/sdks/generators/csharp/changelog">
-              <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
+              <img src="file:0e9f864d-c00f-4276-a43d-71e088f73374" alt="C#" className="language-icon-img" noZoom />
             </a>
             {/* PHP */}
             <a className="language-icon" href="/sdks/generators/php/changelog">
-              <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
+              <img src="file:ac1f3cd7-3731-4c6b-926e-43b75c645889" alt="PHP" className="language-icon-img" noZoom />
             </a>
             {/* Ruby */}
             <a className="language-icon" href="/sdks/generators/ruby/changelog">
-              <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
+              <img src="file:0b93a2c5-83e9-4e00-aff4-1f7b9dbe66d2" alt="Ruby" className="language-icon-img" noZoom />
             </a>
           </div>
         </div>
 
         <div className="community-card"> 
-          <img className="m-0 dark:hidden" src="./images/github-light.svg" alt="Github Preview" noZoom/>
-          <img className="m-0 hidden dark:block" src="./images/github-dark.svg" alt="Github Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:621676e6-8e17-4235-923b-30f0b9c423a1" alt="Github Preview" noZoom/>
+          <img className="m-0 hidden dark:block" src="file:f9b6e547-50c8-433b-bc3b-ae9514bb33db" alt="Github Preview" noZoom />
 
           <h3 className="community-card-title">Github</h3>
           <p className="community-card-description">
@@ -280,8 +280,8 @@ import { FernFooter } from "../../../components/FernFooter";
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/slack-light.svg" alt="Slack Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/slack-dark.svg" alt="Slack Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:386c19c5-1fac-4b4a-bee3-b4e66076eae8" alt="Slack Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:bedbca05-fe81-4950-b978-079460861380" alt="Slack Preview" noZoom />
 
           <h3 className="community-card-title">Slack</h3>
           <p className="community-card-description">
@@ -293,8 +293,8 @@ import { FernFooter } from "../../../components/FernFooter";
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/x-light.svg" alt="Twitter Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/x-dark.svg" alt="Twitter Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:902f82cb-beb4-4e0a-af6e-2ad5c37b7c0a" alt="Twitter Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:2c0f81f2-8c0b-4c7c-a0b3-d0239a5b6cf7" alt="Twitter Preview" noZoom />
 
           <h3 className="community-card-title">
             <span className="twitter-strikethrough">Twitter</span> X
@@ -320,21 +320,21 @@ import { FernFooter } from "../../../components/FernFooter";
       
       <div className="help-buttons">
         <a className="fern-button outlined normal gap-2 a-btn" href="https://github.com/fern-api/fern/issues">
-          <img src="./images/github-light.svg" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/github-dark.svg" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:621676e6-8e17-4235-923b-30f0b9c423a1" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:f9b6e547-50c8-433b-bc3b-ae9514bb33db" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
 
           File a Github issue
         </a>
 
         <a className="fern-button outlined normal gap-2 a-btn" href="mailto:support@buildwithfern.com">
-          <img src="./images/email-light.svg" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/email-dark.svg" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:d9f98e1e-d185-42c9-9ae5-89d52eea0c8f" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:9a97ba48-9f47-4060-ac4a-3f8ff50a2fd5" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
 
           Email us
         </a>
         <a className="fern-button outlined normal gap-2 a-btn" href="https://buildwithfern.com/book-demo">
-          <img src="./images/email-light.svg" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/email-dark.svg" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:d9f98e1e-d185-42c9-9ae5-89d52eea0c8f" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:9a97ba48-9f47-4060-ac4a-3f8ff50a2fd5" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
 
           Book a demo
         </a>


### PR DESCRIPTION

This PR updates all image source paths across documentation pages to use file references instead of relative paths. The changes affect both the getting-started overview page and welcome page, converting image paths from the ./images/ directory to use file: references. This refactoring improves asset management and ensures consistent image loading across the documentation site.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)