### PR TITLE
refactor: update image paths to use file references

### DIFF
--- a/fern/learn/docs/seo/test-seo.mdx
+++ b/fern/learn/docs/seo/test-seo.mdx
@@ -1,0 +1,6 @@
+---
+title: test seo
+slug: test-seo
+---
+
+yo

--- a/fern/products/docs/pages/getting-started/overview.mdx
+++ b/fern/products/docs/pages/getting-started/overview.mdx
@@ -16,13 +16,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
   <CardGroup cols={2}>
     <a class="fern-card interactive not-prose relative block p-6 text-base" href="/docs/getting-started/quickstart">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Quickstart" src="./images/quickstart.png" />
-        <img class="mx-auto hidden dark:block" alt="Quickstart" src="./images/quickstart-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Quickstart" src="file:eb92f590-62b8-492d-9a04-e76d7a240352" />
+        <img class="mx-auto hidden dark:block" alt="Quickstart" src="file:b4fcc939-6fd7-4a81-a5c2-fb1a9a88cdd9" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:434d7606-784d-4281-a451-f86b84420dfb" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:9a03f175-6fb8-4761-bc5d-b443b556ae76" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Set up a documentation site in under 5 minutes.</p>
@@ -33,13 +33,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
     
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/customization/what-is-docs-yml">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Configure with ease" src="./images/configure.png" />
-        <img class="mx-auto hidden dark:block" alt="Configure with ease" src="./images/configure-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Configure with ease" src="file:5aa273d3-1afb-4507-b4e1-d78e5fd69b95" />
+        <img class="mx-auto hidden dark:block" alt="Configure with ease" src="file:e5ec1fcb-1347-4e61-bbd9-dbf76d3178a9" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Configure with ease
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:434d7606-784d-4281-a451-f86b84420dfb" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:9a03f175-6fb8-4761-bc5d-b443b556ae76" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Use one simple file to generate documentation that fits your brand.</p>
@@ -55,13 +55,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
   <CardGroup cols={2}>
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/writing-content/components/overview">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Flexible component library" src="./images/component-library.png" />
-        <img class="mx-auto hidden dark:block" alt="Flexible component library" src="./images/component-library-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Flexible component library" src="file:c0997470-465c-4e76-8e5d-021f4d3c33ab" />
+        <img class="mx-auto hidden dark:block" alt="Flexible component library" src="file:adcc2f5c-851b-4b9a-be2a-ae03c82f632d" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Flexible component library
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:434d7606-784d-4281-a451-f86b84420dfb" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:9a03f175-6fb8-4761-bc5d-b443b556ae76" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Use pre-built or custom React components for a polished look.</p>
@@ -72,13 +72,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
     
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/writing-content/visual-editor">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Visual Editor" src="./images/visual-editor.png" />
-        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="./images/visual-editor-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Visual Editor" src="file:2c83b83f-b209-404c-ad1b-0aee452c7f9c" />
+        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="file:f41e41da-c12c-48de-8580-a307517ad9ce" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Visual Editor
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:434d7606-784d-4281-a451-f86b84420dfb" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:9a03f175-6fb8-4761-bc5d-b443b556ae76" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Modify your documentation without touching code and publish to your GitHub.</p>
@@ -89,13 +89,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
 
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/api-references/generate-api-ref">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Visual Editor" src="./images/api-specs-light.png" />
-        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="./images/api-specs-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Visual Editor" src="file:7d9921e8-3b42-4804-b09d-08c1782d020e" />
+        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="file:dfb97ab5-aa99-47fa-99bc-a116fcfeb37f" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Bring your own API Spec
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:434d7606-784d-4281-a451-f86b84420dfb" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:9a03f175-6fb8-4761-bc5d-b443b556ae76" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>Use OpenAPI, AsyncAPI, gRPC, OpenRPC, and the Fern spec.</p>
@@ -106,13 +106,13 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
 
     <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/ask-fern/getting-started/what-is-ask-fern">
       <div class="flex items-start flex-col space-y-3">
-        <img class="mx-auto dark:hidden" alt="Visual Editor" src="./images/ask-fern-light.png" />
-        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="./images/ask-fern-dark.png" />
+        <img class="mx-auto dark:hidden" alt="Visual Editor" src="file:2db0e037-5f73-4643-a84e-6851b89c787b" />
+        <img class="mx-auto hidden dark:block" alt="Visual Editor" src="file:563ccc3d-c17e-43a7-accc-c4855c38bbf7" />
         <div class="w-full space-y-1 overflow-hidden">
           <div class="text-(color:--grayscale-a12) text-body text-base font-semibold card-title">
             Ask Fern
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
+            <img src="file:434d7606-784d-4281-a451-f86b84420dfb" alt="Arrow right light" className="arrow-right dark:hidden m-0" noZoom />
+            <img src="file:9a03f175-6fb8-4761-bc5d-b443b556ae76" alt="Arrow right light" className="arrow-right hidden dark:block m-0" noZoom />
           </div>
           <div class="text-(color:--grayscale-a11) font-light">
             <p>A personalized chatbot that can answer questions about your documentation.</p>

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -50,8 +50,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/sdks/overview/introduction">
             SDKs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             Generate client libraries in multiple languages.
@@ -70,31 +70,31 @@ import { FernFooter } from "../../../components/FernFooter";
           <span className="language-icons-label">Get started with:</span>
           {/* TypeScript */}
           <a className="language-icon" href="/sdks/generators/typescript/quickstart">
-            <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
+            <img src="file:f8f127f1-5f70-438a-9550-9faa6b6f0f04" alt="TypeScript" className="language-icon-img" noZoom />
           </a>
           {/* Python */}
           <a className="language-icon" href="/sdks/generators/python/quickstart">
-            <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
+            <img src="file:f9f92d98-142e-4b1a-8f4a-edc7dab7d76d" alt="Python" className="language-icon-img" noZoom />
           </a> 
           {/* Go */}
           <a className="language-icon" href="/sdks/generators/go/quickstart">
-            <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
+            <img src="file:c770e75d-5490-4abe-9c58-080dbde8cc5d" alt="Go" className="language-icon-img" noZoom />
           </a>
           {/* Java */}
           <a className="language-icon" href="/sdks/generators/java/quickstart">
-            <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
+            <img src="file:eed4ed4e-debc-482d-9eb4-79c7b32a3e03" alt="Java" className="language-icon-img" noZoom />
           </a>
           {/* C# */}
           <a className="language-icon" href="/sdks/generators/csharp/quickstart">
-            <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
+            <img src="file:e622f997-4136-4b82-8a37-895e460f9f9f" alt="C#" className="language-icon-img" noZoom />
           </a>
           {/* PHP */}
           <a className="language-icon" href="/sdks/generators/php/quickstart">
-            <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
+            <img src="file:0557175f-b776-413d-9ee5-402d8255de61" alt="PHP" className="language-icon-img" noZoom />
           </a>
           {/* Ruby */}
           <a className="language-icon" href="/sdks/generators/ruby/quickstart">
-            <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
+            <img src="file:90d41b77-1028-4118-9c75-b1c0fbb1b1eb" alt="Ruby" className="language-icon-img" noZoom />
           </a>
         </div>
 
@@ -102,18 +102,18 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/sdks/overview/introduction">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="/sdks/overview/quickstart">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -123,8 +123,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/docs/getting-started/overview">
             Docs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             A beautiful, interactive documentation website.
@@ -141,38 +141,38 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons-vertical">
           <a className="fern-button filled normal primary gap-1 w-fit a-btn" href="/docs/getting-started/overview">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right" className="hidden dark:block" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right" className="dark:hidden" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/getting-started/quickstart">
             Quickstart
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/writing-content/components/overview">
             See all available components
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/api-references/generate-api-ref">
             Bring your own API spec
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/authentication/rbac">
             Control role-based access
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/self-hosted/overview"> 
             Self host your docs
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="https://buildwithfern.com/showcase#docs-customers.alldocs-features">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -182,8 +182,8 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="card-header">
           <a className="card-title" href="/ask-fern/getting-started/what-is-ask-fern">
             Ask Fern
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden m-0" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden m-0" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block m-0" noZoom />
           </a>
           <p className="card-description">
             AI Search that lets users find answers in your documentation instantly.
@@ -200,18 +200,18 @@ import { FernFooter } from "../../../components/FernFooter";
         <div className="action-buttons">
           <a className="fern-button filled normal primary gap-1 a-btn" href="/ask-fern/getting-started/what-is-ask-fern">
             Introduction
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="/ask-fern/configuration/custom-prompting">
             Configure
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal gap-1 a-btn" href="https://buildwithfern.com/showcase#ask-fern-customers">
             Customers
-            <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
-            <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
+            <img src="file:acb1790d-c915-470c-aab3-f6682c15a6be" alt="Arrow right light" className="dark:hidden" noZoom />
+            <img src="file:8aa80036-c778-4565-9169-3c4655ce6cc6" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
         </div>
       </div>
@@ -225,8 +225,8 @@ import { FernFooter } from "../../../components/FernFooter";
       
       <div className="community-grid">
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/changelog-light.svg" alt="Changelog Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/changelog-dark.svg" alt="Changelog Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:4c6c0dc3-cc6b-4734-8a99-5ac0f6afce32" alt="Changelog Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:0a42c64a-ee09-4f44-9b28-92bc95c398c1" alt="Changelog Preview" noZoom />
 
           <h3 className="community-card-title">Changelog</h3>
           <p className="community-card-description">
@@ -234,41 +234,41 @@ import { FernFooter } from "../../../components/FernFooter";
           </p>
           <div className="flex flex-row gap-2 flex-wrap items-center">
             <a className="language-icon" href="/docs/changelog">
-              <img src="./images/fern-logo.svg" alt="Docs" className="language-icon-img" noZoom />
+              <img src="file:24ccd6f8-9702-4e45-b51e-9821b78f8168" alt="Docs" className="language-icon-img" noZoom />
             </a>
             <a className="language-icon" href="/sdks/generators/typescript/changelog">
-              <img src="./images/ts-logo.svg" alt="TypeScript" className="language-icon-img" noZoom />
+              <img src="file:f8f127f1-5f70-438a-9550-9faa6b6f0f04" alt="TypeScript" className="language-icon-img" noZoom />
             </a>
             {/* Python */}
             <a className="language-icon" href="/sdks/generators/python/changelog">
-              <img src="./images/python-logo.svg" alt="Python" className="language-icon-img" noZoom />
+              <img src="file:f9f92d98-142e-4b1a-8f4a-edc7dab7d76d" alt="Python" className="language-icon-img" noZoom />
             </a> 
             {/* Go */}
             <a className="language-icon" href="/sdks/generators/go/changelog">
-              <img src="./images/go-logo.svg" alt="Go" className="language-icon-img" noZoom />
+              <img src="file:c770e75d-5490-4abe-9c58-080dbde8cc5d" alt="Go" className="language-icon-img" noZoom />
             </a>
             {/* Java */}
             <a className="language-icon" href="/sdks/generators/java/changelog">
-              <img src="./images/java-logo.svg" alt="Java" className="language-icon-img" noZoom />
+              <img src="file:eed4ed4e-debc-482d-9eb4-79c7b32a3e03" alt="Java" className="language-icon-img" noZoom />
             </a>
             {/* C# */}
             <a className="language-icon" href="/sdks/generators/csharp/changelog">
-              <img src="./images/csharp-logo.svg" alt="C#" className="language-icon-img" noZoom />
+              <img src="file:e622f997-4136-4b82-8a37-895e460f9f9f" alt="C#" className="language-icon-img" noZoom />
             </a>
             {/* PHP */}
             <a className="language-icon" href="/sdks/generators/php/changelog">
-              <img src="./images/php-logo.svg" alt="PHP" className="language-icon-img" noZoom />
+              <img src="file:0557175f-b776-413d-9ee5-402d8255de61" alt="PHP" className="language-icon-img" noZoom />
             </a>
             {/* Ruby */}
             <a className="language-icon" href="/sdks/generators/ruby/changelog">
-              <img src="./images/ruby-logo.svg" alt="Ruby" className="language-icon-img" noZoom />
+              <img src="file:90d41b77-1028-4118-9c75-b1c0fbb1b1eb" alt="Ruby" className="language-icon-img" noZoom />
             </a>
           </div>
         </div>
 
         <div className="community-card"> 
-          <img className="m-0 dark:hidden" src="./images/github-light.svg" alt="Github Preview" noZoom/>
-          <img className="m-0 hidden dark:block" src="./images/github-dark.svg" alt="Github Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:32ffac98-fb46-422a-a8b3-520a55112964" alt="Github Preview" noZoom/>
+          <img className="m-0 hidden dark:block" src="file:fa5d7393-30a3-4fde-9920-6b7a7d7d5428" alt="Github Preview" noZoom />
 
           <h3 className="community-card-title">Github</h3>
           <p className="community-card-description">
@@ -280,8 +280,8 @@ import { FernFooter } from "../../../components/FernFooter";
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/slack-light.svg" alt="Slack Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/slack-dark.svg" alt="Slack Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:3f35b5f8-7f21-4887-bbe9-dc55be934dca" alt="Slack Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:b6a5a8da-d7bd-4dd4-a110-e29744b22445" alt="Slack Preview" noZoom />
 
           <h3 className="community-card-title">Slack</h3>
           <p className="community-card-description">
@@ -293,8 +293,8 @@ import { FernFooter } from "../../../components/FernFooter";
         </div>
 
         <div className="community-card">
-          <img className="m-0 dark:hidden" src="./images/x-light.svg" alt="Twitter Preview" noZoom />
-          <img className="m-0 hidden dark:block" src="./images/x-dark.svg" alt="Twitter Preview" noZoom />
+          <img className="m-0 dark:hidden" src="file:06d1f16f-1efe-49bd-8223-82e6788c7ec8" alt="Twitter Preview" noZoom />
+          <img className="m-0 hidden dark:block" src="file:604f662a-02e8-45ab-ad47-dc94c7115132" alt="Twitter Preview" noZoom />
 
           <h3 className="community-card-title">
             <span className="twitter-strikethrough">Twitter</span> X
@@ -320,21 +320,21 @@ import { FernFooter } from "../../../components/FernFooter";
       
       <div className="help-buttons">
         <a className="fern-button outlined normal gap-2 a-btn" href="https://github.com/fern-api/fern/issues">
-          <img src="./images/github-light.svg" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/github-dark.svg" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:32ffac98-fb46-422a-a8b3-520a55112964" alt="Github" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:fa5d7393-30a3-4fde-9920-6b7a7d7d5428" alt="Github" className="h-4 w-4 hidden dark:block" noZoom />
 
           File a Github issue
         </a>
 
         <a className="fern-button outlined normal gap-2 a-btn" href="mailto:support@buildwithfern.com">
-          <img src="./images/email-light.svg" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/email-dark.svg" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:24a4227e-50e8-41c3-b6f6-16ea38526dfc" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:4af1a7b0-ccfb-4ca5-af7b-b27ffea747da" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
 
           Email us
         </a>
         <a className="fern-button outlined normal gap-2 a-btn" href="https://buildwithfern.com/book-demo">
-          <img src="./images/email-light.svg" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
-          <img src="./images/email-dark.svg" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
+          <img src="file:24a4227e-50e8-41c3-b6f6-16ea38526dfc" alt="Email" className="h-4 w-4 dark:hidden" noZoom />
+          <img src="file:4af1a7b0-ccfb-4ca5-af7b-b27ffea747da" alt="Email" className="h-4 w-4 hidden dark:block" noZoom />
 
           Book a demo
         </a>


### PR DESCRIPTION

This PR updates image source paths across multiple MDX files to use file references instead of relative paths. The changes replace all `./images/` paths with `file:` references, maintaining the same image functionality while improving asset management. This refactoring affects the overview, welcome, and SEO test pages.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)