### PR TITLE
Chore(docs): Fix more bad links

### DIFF
--- a/fern/products/api-def/asyncapi-pages/extensions/overview.md
+++ b/fern/products/api-def/asyncapi-pages/extensions/overview.md
@@ -11,13 +11,13 @@ The table below shows all available extensions and links to detailed documentati
 
 | Extension | Description |
 | --- | --- |
-| [`x-fern-ignore`](./ignore) | Skip reading specific operations, channels, or schemas |
-| [`x-fern-examples`](./examples) | Provide additional examples for better SDK documentation |
+| [`x-fern-ignore`](./ignoring-elements) | Skip reading specific operations, channels, or schemas |
+| [`x-fern-examples`](./request-response-examples) | Provide additional examples for better SDK documentation |
 | [`x-fern-pagination`](./pagination) | Configure pagination for operations that return multiple results |
-| [`x-fern-retry`](./retry) | Configure retry behavior for operations |
-| [`x-fern-streaming`](./streaming) | Mark operations as streaming for appropriate SDK generation |
+| [`x-fern-retry`](./retry-behavior) | Configure retry behavior for operations |
+| [`x-fern-streaming`](./streaming-operations) | Mark operations as streaming for appropriate SDK generation |
 | [`x-fern-error-handling`](./error-handling) | Configure error handling for operations |
-| [`x-fern-server-name`](./server-name) | Specify custom names for servers |
+| [`x-fern-server-name`](./server-names) | Specify custom names for servers |
 | [`x-fern-availability`](./availability) | Mark features as available in specific SDK versions |
 
 <Note title="Request a new extension">

--- a/fern/products/api-def/grpc-pages/extensions/overview.md
+++ b/fern/products/api-def/grpc-pages/extensions/overview.md
@@ -11,17 +11,17 @@ The table below shows all available extensions and links to detailed documentati
 
 | Extension | Description |
 | --- | --- |
-| [`x-fern-ignore`](./ignore) | Skip reading specific services, methods, or messages |
-| [`x-fern-examples`](./examples) | Provide additional examples for better SDK documentation |
+| [`x-fern-ignore`](./ignoring-elements) | Skip reading specific services, methods, or messages |
+| [`x-fern-examples`](./request-response-examples) | Provide additional examples for better SDK documentation |
 | [`x-fern-pagination`](./pagination) | Configure pagination for methods that return lists |
-| [`x-fern-retry`](./retry) | Configure retry behavior for methods |
-| [`x-fern-timeout`](./timeout) | Configure timeout settings for methods |
+| [`x-fern-retry`](./retry-behavior) | Configure retry behavior for methods |
+| [`x-fern-timeout`](./timeout-settings) | Configure timeout settings for methods |
 | [`x-fern-error-handling`](./error-handling) | Configure error handling for methods |
 | [`x-fern-availability`](./availability) | Mark features as available in specific SDK versions |
-| [`x-fern-streaming`](./streaming) | Mark methods as streaming for appropriate SDK generation |
-| [`x-fern-server-name`](./server-name) | Specify custom names for different server environments |
+| [`x-fern-streaming`](./streaming-operations) | Mark methods as streaming for appropriate SDK generation |
+| [`x-fern-server-name`](./server-names) | Specify custom names for different server environments |
 | [`x-fern-base-path`](./base-path) | Configure base paths for generated SDK clients |
-| [`x-fern-sdk-group-name`](./sdk-group-name) | Group related services in the SDK |
+| [`x-fern-sdk-group-name`](./sdk-group-names) | Group related services in the SDK |
 | [`x-fern-union-naming`](./union-naming) | Configure naming for oneof fields in SDKs |
 | [`x-fern-validation`](./validation) | Add validation rules for message fields |
 

--- a/fern/products/api-def/openrpc-pages/extensions/overview.md
+++ b/fern/products/api-def/openrpc-pages/extensions/overview.md
@@ -11,17 +11,17 @@ The table below shows all available extensions and links to detailed documentati
 
 | Extension | Description |
 | --- | --- |
-| [`x-fern-ignore`](./ignore) | Skip reading specific methods or schemas |
-| [`x-fern-examples`](./examples) | Provide additional examples for better SDK documentation |
+| [`x-fern-ignore`](./ignoring-elements) | Skip reading specific methods or schemas |
+| [`x-fern-examples`](./request-response-examples) | Provide additional examples for better SDK documentation |
 | [`x-fern-pagination`](./pagination) | Configure pagination for methods that return multiple results |
-| [`x-fern-retry`](./retry) | Configure retry behavior for methods |
-| [`x-fern-timeout`](./timeout) | Configure timeout settings for methods |
+| [`x-fern-retry`](./retry-behavior) | Configure retry behavior for methods |
+| [`x-fern-timeout`](./timeout-settings) | Configure timeout settings for methods |
 | [`x-fern-error-handling`](./error-handling) | Configure error handling for methods |
 | [`x-fern-availability`](./availability) | Mark features as available in specific SDK versions |
-| [`x-fern-streaming`](./streaming) | Mark methods as streaming for appropriate SDK generation |
-| [`x-fern-server-name`](./server-name) | Specify custom names for servers |
+| [`x-fern-streaming`](./streaming-operations) | Mark methods as streaming for appropriate SDK generation |
+| [`x-fern-server-name`](./server-names) | Specify custom names for servers |
 | [`x-fern-base-path`](./base-path) | Configure base paths for generated SDK clients |
-| [`x-fern-sdk-group-name`](./sdk-group-name) | Group related methods in the SDK |
+| [`x-fern-sdk-group-name`](./sdk-group-names) | Group related methods in the SDK |
 
 <Note title="Request a new extension">
     If there's an extension you want that doesn't already exist, file an [issue](https://github.com/fern-api/fern/issues/new) to start a discussion about it.

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -364,7 +364,7 @@ hideOnThisPage: true
       run: fern generate --docs
     ```
 
-    See [the full example on GitHub](https://github.com/fern-api/fern/blob/main/.github/workflows/publish-docs.yml).
+    See [the full example on GitHub](https://github.com/fern-api/docs/blob/main/.github/workflows/publish-docs.yml).
 
   </Accordion>
 

--- a/fern/products/docs/pages/api-references/audiences.mdx
+++ b/fern/products/docs/pages/api-references/audiences.mdx
@@ -4,7 +4,7 @@ subtitle: Use audiences to filter the endpoints, schemas, and properties that ar
 ---
 
 Audiences are a useful tool for segmenting your API for different consumers. Common examples of audiences include `public` 
-and `beta`. You can configure audiences in both [the OpenAPI Specification](/learn/api-definition/openapi/audiences) as well as [the Fern Definition](/learn/api-definition/fern/audiences).
+and `beta`. You can configure audiences in both [the OpenAPI Specification](/learn/api-definitions/openapi/extensions/audiences) as well as [the Fern Definition](/learn/api-definition/fern/audiences).
 
 Once you've added audiences to your API Specification, you can filter to that audience by adding the `audience` property to the `api` object in your `docs.yml` navigation.
 

--- a/fern/products/docs/pages/api-references/generate-webhook-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-webhook-ref.mdx
@@ -55,7 +55,7 @@ api:
   path: openapi/openapi.yml
 ```
 
-You can read more about how to define webhooks in your OpenAPI specification [here](/learn/api-definition/openapi/webhooks).
+You can read more about how to define webhooks in your OpenAPI specification [here](/learn/api-definitions/openapi/endpoints/webhooks).
 </Tab>
 <Tab title="Fern Definition">
 ```bash

--- a/fern/products/docs/pages/authentication/sso.mdx
+++ b/fern/products/docs/pages/authentication/sso.mdx
@@ -12,7 +12,7 @@ Fern’s Single Sign-On (SSO) is an enterprise feature that lets your team secur
 When SSO is enabled for your organization, authenticated users of Fern can:
 
 - **Use the Visual Editor**: Make edits to your docs from the browser
-- **Send Authenticated Preview Links** Only authenticated users can view [preview links](docs/preview-publish/previewing-changes-locally)
+- **Send Authenticated Preview Links** Only authenticated users can view [preview links](/learn/docs/preview-publish/previewing-changes-locally)
 
 ## How it works
 

--- a/fern/products/docs/pages/component-library/default-components/endpoint-schema-snippet.mdx
+++ b/fern/products/docs/pages/component-library/default-components/endpoint-schema-snippet.mdx
@@ -123,5 +123,5 @@ to specify the path to the schema you want to reference. The available selectors
 <Warning>
   The EndpointSchemaSnippet component does not yet support rendering markdown-rich field descriptions.
   
-  See [request.endpoint.path](/docs/content/components/schema-snippet#request.endpoint.path) above for an example of a markdown-rich description that does not yet render as markdown.
+  See [request.endpoint.path](/learn/docs/writing-content/components/schema-snippet#request.endpoint.path) above for an example of a markdown-rich description that does not yet render as markdown.
 </Warning>

--- a/fern/products/docs/pages/developer-tools/gitlab.mdx
+++ b/fern/products/docs/pages/developer-tools/gitlab.mdx
@@ -2,7 +2,7 @@
 title: Hosting with GitLab
 ---
 
-To host your Fern docs using GitLab, you will need to [add a Fern token to your repository variables](/learn/docs/developer-tools/gitlab#add-a-token-to-gitlab). 
+To host your Fern docs using GitLab, you will need to [add a Fern token to your repository variables](/learn/docs/developer-tools/git-lab#add-a-token-to-gitlab). 
 
 <Accordion title="GitLab CI/CD configuration">
 The following GitLab CI/CD workflow will generate a preview link of your docs on merge request and publish your docs when updates are made to `main`. 

--- a/fern/products/sdks/guides/self-hosted.mdx
+++ b/fern/products/sdks/guides/self-hosted.mdx
@@ -12,7 +12,7 @@ Fern SDK generation runs on Fern's infrastructure by default. Self-hosting allow
 
 Self-hosting is typically required for organizations that operate without internet access, have strict compliance requirements, or need full control over their SDK generation process.
 
-When you self-host, you're responsible for server setup, security, maintenance, and deciding how to distribute your generated SDKs. Self-hosted SDK generation includes [all Fern SDK features](/sdks/capabilities.mdx).
+When you self-host, you're responsible for server setup, security, maintenance, and deciding how to distribute your generated SDKs. Self-hosted SDK generation includes [all Fern SDK features](/learn/sdks/overview/capabilities).
 
 <Warning>
 Unless you have specific requirements that prevent using Fern's default hosting, we recommend **using our managed cloud generation solution** for easier setup and maintenance.

--- a/fern/products/sdks/overview/typescript/configuration.mdx
+++ b/fern/products/sdks/overview/typescript/configuration.mdx
@@ -279,7 +279,7 @@ By default, names are based on the organization and API names in the Fern Defini
 </ParamField>
 
 <ParamField path="neverThrowErrors" type="boolean" default="false" toc={true}>
-  When enabled, the client doesn't throw errors when a non-200 response is received from the server. Instead, the response is wrapped in an [`ApiResponse`](packages/core-utilities/fetcher/src/APIResponse.ts).
+  When enabled, the client doesn't throw errors when a non-200 response is received from the server. Instead, the response is wrapped in an [`ApiResponse`](https://github.com/fern-api/fern/blob/main/seed/ts-sdk/alias/src/core/fetcher/APIResponse.ts).
 
   ```typescript
   const response = await client.callEndpoint(...);


### PR DESCRIPTION
I [re-ran the link scanner](https://github.com/fern-api/docs/actions/runs/17067614199/job/48388425773) after merging my changes from yesterday. This PR should fix the majority of the issues coming from this repo. I still need to work with others on the team to resolve bad links on other parts of the fern site. Once those are done I will re-run the link checker and working to operationalize periodic scanning/alerting.