### PR TITLE
fix(docs): Fix more bad links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install link checker
         run: pip install linkchecker
       - name: Create config
-        run: echo -e "[csv]\nseparator=,\n[filtering]\nignore=\n\texample.com\n\tus.i.posthog.com\n\tc.vialoops.com/CL0\n[output]\nignoreerrors=\n  ^http ^403 Forbidden" > lcconfig
+        run: echo -e "[csv]\nseparator=,\n[filtering]\nignore=\n\texample.com\n\tus.i.posthog.com\n\tdocs.stack-auth.com\n\tc.vialoops.com/CL0\n[output]\nignoreerrors=\n  ^http ^403 Forbidden" > lcconfig
       - name: Check ${{ matrix.site.name }} Links
         run: |
           set +e

--- a/fern/products/docs/pages/api-references/customize-api-ref.mdx
+++ b/fern/products/docs/pages/api-references/customize-api-ref.mdx
@@ -9,7 +9,7 @@ When you [include an API in your `docs.yml` file](/learn/docs/api-references/gen
 If you are using an OpenAPI Specification, sections are created based on the `tags` property, converted to `lowerCamelCase` convention (e.g., createUser). If you are using a Fern Definition, sections are created based on the [`service`](/learn/api-definition/fern/endpoints#service-definition) file names.
 </Note>
 
-If you would like to only display a subset of endpoints, read more about the Audiences property for [OpenAPI Specifications](/learn/api-definition/openapi/audiences) or [Fern Definitions](/learn/api-definition/fern/audiences).
+If you would like to only display a subset of endpoints, read more about the Audiences property for [OpenAPI Specifications](/learn/api-definitions/openapi/extensions/audiences) or [Fern Definitions](/learn/api-definition/fern/audiences).
 
 ## Ordering the API Reference
 

--- a/fern/products/docs/pages/api-references/generate-websocket-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-websocket-ref.mdx
@@ -5,7 +5,7 @@ description: Learn how to generate and customize WebSocket API reference documen
 
 Fern generates WebSocket API reference documentation from your AsyncAPI specification or Fern Definition. The AsyncAPI specification describes message-driven APIs in a machine-readable format. Fern supports the [v2](https://www.asyncapi.com/docs/reference/specification/v2.x) and [v3](https://www.asyncapi.com/docs/reference/specification/v3.0.0) specifications.
 
-See [Deepgram's configuration](https://github.com/deepgram/deepgram-fern-config/blob/9a3d281d87963165df7cbb89c4883d5058abaf2e/fern/generators.yml#L5-L7) for a complete example.
+See [????'s configuration](FIXME) for a complete example.
 
 <Frame caption={<a href="https://developers.deepgram.com/reference/text-to-speech-api/speak-streaming">Example of how a WebSocket API Reference renders in Fern</a>}>
   <img src="websocket-deepgram.png" alt="WebSocket API Reference Example" />

--- a/fern/products/docs/pages/api-references/generate-websocket-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-websocket-ref.mdx
@@ -5,8 +5,6 @@ description: Learn how to generate and customize WebSocket API reference documen
 
 Fern generates WebSocket API reference documentation from your AsyncAPI specification or Fern Definition. The AsyncAPI specification describes message-driven APIs in a machine-readable format. Fern supports the [v2](https://www.asyncapi.com/docs/reference/specification/v2.x) and [v3](https://www.asyncapi.com/docs/reference/specification/v3.0.0) specifications.
 
-See [????'s configuration](FIXME) for a complete example.
-
 <Frame caption={<a href="https://developers.deepgram.com/reference/text-to-speech-api/speak-streaming">Example of how a WebSocket API Reference renders in Fern</a>}>
   <img src="websocket-deepgram.png" alt="WebSocket API Reference Example" />
 </Frame>

--- a/fern/products/docs/pages/changelog/2025-01-14.mdx
+++ b/fern/products/docs/pages/changelog/2025-01-14.mdx
@@ -6,7 +6,7 @@ We're excited to announce compatibility with the `/llms.txt` [emerging standard]
 
 Both `/llms.txt` and `/llms-full.txt` are designed to be token-efficient, ensuring faster processing and cost-effective LLM interactions without sacrificing valuable info.
 
-If you use Fern Docs, this feature is auto-enabled like /robots.txt and /sitemap.xml. [Learn more](https://buildwithfern.com/learn/docs/developer-tools/llms-txt)
+If you use Fern Docs, this feature is auto-enabled like /robots.txt and /sitemap.xml. [Learn more](https://buildwithfern.com/learn/docs/seo/llms-txt)
 
 ![LLMs.txt Splash Image](./llms-txt.png)
 

--- a/fern/products/docs/pages/customization/search.mdx
+++ b/fern/products/docs/pages/customization/search.mdx
@@ -23,7 +23,7 @@ If you are using the AI Search feature, the search box also functions as your si
 </Frame>
 
 <Note>
-    **Note:** If an article includes the `nofollow` or `noindex` [frontmatter](/learn/docs/content/frontmatter#indexing-properties), it will not be indexed by Algolia DocSearch and won't appear in search results.
+    **Note:** If an article includes the `nofollow` or `noindex` [frontmatter](/learn/docs/configuration/page-level-settings#indexing-properties), it will not be indexed by Algolia DocSearch and won't appear in search results.
 </Note>
 
 ## Integrating with Algolia

--- a/fern/products/docs/pages/developer-tools/gitlab.mdx
+++ b/fern/products/docs/pages/developer-tools/gitlab.mdx
@@ -105,5 +105,5 @@ When finished, click **Create project access token**.
 Be sure to save the generated token - it won't be displayed after you leave the page. 
 </Note>
 ### Add token to repository variables
-You can do this using [the steps listed above](/learn/docs/developer-tools/gitlab#add-a-token-to-gitlab). 
+You can do this using [the steps listed above](/learn/docs/developer-tools/git-lab#add-a-token-to-gitlab). 
 </Steps>


### PR DESCRIPTION
This PR fixes the bad links I found on my latest scan of the docs page. Most have been replaced with the correct link, but in one case the destination no longer exists and the link was removed.