### PR TITLE
one more link fix

### DIFF
--- a/fern/products/docs/pages/customization/user-feedback.mdx
+++ b/fern/products/docs/pages/customization/user-feedback.mdx
@@ -25,7 +25,7 @@ Allow users to open directly to the current page in your GitHub repository and s
 <img src="./edit-this-page.png" />
 </Frame>
 
-You can configure this feature for the entire site in the [global configuration](/learn/docs/getting-started/global-configuration#instances-configuration), or for an individual page in the [frontmatter of that page](/learn/docs/content/frontmatter#edit-this-page). 
+You can configure this feature for the entire site in the [global configuration](/learn/docs/getting-started/global-configuration#instances-configuration), or for an individual page in the [frontmatter of that page](/learn/docs/configuration/page-level-settings#edit-this-page). 
 
 <Note>
 This feature works in preview links but does not work in local development.


### PR DESCRIPTION
Latest link turned up by [the link checking](https://github.com/fern-api/docs/actions/runs/17098365593/job/48488143867) CI.