### PR TITLE
Fix more bad links

### DIFF
--- a/fern/products/ask-fern/pages/getting-started/what-is-ask-fern.mdx
+++ b/fern/products/ask-fern/pages/getting-started/what-is-ask-fern.mdx
@@ -43,7 +43,7 @@ Ask Fern is Fern's AI Search feature that indexes your documentation and provide
   <Card 
     title="Guidance" 
     icon="regular fa-question-circle"
-    href="/learn/ask-fern/features/guidance" 
+    href="/learn/ask-fern/configuration/guidance" 
     >
     Add custom FAQs to Ask Fern. 
   </Card>

--- a/fern/products/ask-fern/pages/getting-started/what-is-ask-fern.mdx
+++ b/fern/products/ask-fern/pages/getting-started/what-is-ask-fern.mdx
@@ -27,7 +27,7 @@ Ask Fern is Fern's AI Search feature that indexes your documentation and provide
   <Card 
     title="Custom prompting"
     icon="regular book-open"
-    href="/learn/ai-search/custom-prompting"
+    href="/learn/ask-fern/configuration/custom-prompts"
   >
     Tailor Ask Fern behavior to your users' needs. 
   </Card>

--- a/fern/products/ask-fern/pages/getting-started/what-is-ask-fern.mdx
+++ b/fern/products/ask-fern/pages/getting-started/what-is-ask-fern.mdx
@@ -51,7 +51,7 @@ Ask Fern is Fern's AI Search feature that indexes your documentation and provide
   <Card 
     title="Documents" 
     icon="regular file-alt"
-    href="/learn/ask-fern/features/documents" 
+    href="/learn/ask-fern/configuration/documents" 
     >
     Add custom documents to Ask Fern. 
   </Card>

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -203,7 +203,7 @@ import { FernFooter } from "../../../components/FernFooter";
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
-          <a className="fern-button minimal normal gap-1 a-btn" href="/ask-fern/configuration/custom-prompting">
+          <a className="fern-button minimal normal gap-1 a-btn" href="/ask-fern/configuration/custom-prompts">
             Configure
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />


### PR DESCRIPTION
Issues found during an ad-hoc scan this AM: https://github.com/fern-api/docs/actions/runs/17127698379/job/48583328299

- "Configure" link here
<img width="469" height="306" alt="Screenshot 2025-08-21 at 9 08 53 AM" src="https://github.com/user-attachments/assets/059d4de8-9b3a-400c-9f11-97f1fec3fc76" />

- "Guidance" and "Documents" links here
<img width="660" height="190" alt="Screenshot 2025-08-21 at 9 11 21 AM" src="https://github.com/user-attachments/assets/97e94023-767f-49f3-b65c-5d89b36257ab" />

- "Custom Prompting" link here
<img width="328" height="196" alt="Screenshot 2025-08-21 at 9 13 46 AM" src="https://github.com/user-attachments/assets/e976b049-fe39-44ee-a720-5d10048be717" />
