### PR TITLE
Bump link checker timeout to reduce failures

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           set +e
           cat lcconfig
-          linkchecker https://${{ matrix.site.url }} --check-extern --no-status --no-warnings --threads 25 --config lcconfig -F csv/utf-8/link_report.csv
+          linkchecker https://${{ matrix.site.url }} --check-extern --no-status --no-warnings --threads 25 --timeout 120 --config lcconfig -F csv/utf-8/link_report.csv
 
           if [ $? -ne 0 ]; then
             echo "Bad links found. Please see report."


### PR DESCRIPTION
The linkchecker was often [timing out](https://github.com/fern-api/docs/actions/runs/17323096129/job/49180625006) on requests. Hoping avoid this by increasing the timeout.

Successful test run [here](https://github.com/fern-api/docs/actions/runs/17323678044/job/49182477650).