### PR TITLE
Fix bad links

### DIFF
--- a/fern/products/docs/pages/getting-started/overview.mdx
+++ b/fern/products/docs/pages/getting-started/overview.mdx
@@ -31,7 +31,7 @@ subtitle: A website builder for beautiful agent and developer-friendly docs.
       </div>
     </a>
     
-    <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/customization/what-is-docs-yml">
+    <a class="fern-card interactive not-prose rounded-3 relative block border p-6 text-base" href="/docs/configuration/what-is-docs-yml">
       <div class="flex items-start flex-col space-y-3">
         <img class="mx-auto dark:hidden" alt="Configure with ease" src="./images/configure.png" />
         <img class="mx-auto hidden dark:block" alt="Configure with ease" src="./images/configure-dark.png" />

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -187,7 +187,7 @@ import { FernFooter } from "../../../components/FernFooter";
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
-          <a className="fern-button minimal normal gap-1 a-btn" href="/ask-fern/configuration/custom-prompting">
+          <a className="fern-button minimal normal gap-1 a-btn" href="/ask-fern/configuration/custom-prompts">
             Configure
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />


### PR DESCRIPTION
Bad link on docs home page for "Configure"
<img width="538" height="372" alt="Screenshot 2025-09-08 at 7 25 37 AM" src="https://github.com/user-attachments/assets/ed9d8b96-7020-47df-b541-584f282febeb" />

Bad link from overview "Configure with ease"
<img width="797" height="624" alt="Screenshot 2025-09-08 at 7 25 32 AM" src="https://github.com/user-attachments/assets/afb6a3b5-85a7-4b87-af66-95a48d62c4ed" />
