### PR TITLE
chore: document global config options

### DIFF
--- a/fern/products/docs/pages/customization/frontmatter.mdx
+++ b/fern/products/docs/pages/customization/frontmatter.mdx
@@ -176,6 +176,8 @@ max-toc-depth: 3
 ## Navigation links
 <ParamField path="hide-nav-links" type="boolean" required={false} default={false}>
   Controls the conditional rendering of the navigation links (previous, next) at the bottom of the page. Set to true to disable this feature.
+  
+  This can be set globally in the [global configuration](/learn/docs/configuration/what-is-docs-yml#layout-configuration).
 </ParamField>
 
 <CodeBlock title="Example hide-nav-links">
@@ -194,6 +196,8 @@ hide-nav-links: true
 ## On-page feedback
 <ParamField path="hide-feedback" type="boolean" required={false} default={false}>
   Controls the conditional rendering of the on-page feedback form at the bottom of the page. Set to true to disable this feature.
+  
+  This can be set globally in the [global configuration](/learn/docs/configuration/what-is-docs-yml#layout-configuration).
 </ParamField>
 
 <CodeBlock title="Example hide-feedback">

--- a/fern/products/docs/pages/customization/global-configuration.mdx
+++ b/fern/products/docs/pages/customization/global-configuration.mdx
@@ -402,6 +402,8 @@ layout:
   searchbar-placement: header
   tabs-placement: header
   content-alignment: left
+  hide-nav-links: true
+  hide-feedback: true
 ```
 
 <ParamField path="layout.header-height" type="string" required={false}>
@@ -444,6 +446,14 @@ layout:
 <ParamField path="layout.disable-header" type="boolean" required={false}>
   If set to true, the header will not be rendered. Instead, the logo will be rendered as part of the sidebar,
   and a 1px border will separate the sidebar from the content.
+</ParamField>
+
+<ParamField path="layout.hide-nav-links" type="boolean" required={false}>
+  If set to true, the navigation links (previous, next) at the bottom of the page will not be rendered. This can be overridden on a per-page basis using the [frontmatter](/learn/docs/configuration/page-level-settings#navigation-links).
+</ParamField>
+
+<ParamField path="layout.hide-feedback" type="boolean" required={false}>
+  If set to true, the feedback form will not be rendered. This can be overridden on a per-page basis using the [frontmatter](/learn/docs/configuration/page-level-settings#on-page-feedback).
 </ParamField>
 
 ## GitHub configuration


### PR DESCRIPTION
globally hide the feedback or nav links