### PR TITLE
Expand README guide (SDKs)

### DIFF
--- a/fern/products/sdks/guides/configure-readme.mdx
+++ b/fern/products/sdks/guides/configure-readme.mdx
@@ -6,23 +6,10 @@ description: Guide to configuring the README in your SDK
 By default, the README for your SDKs is generated programmatically. You can override this by configuring the `readme` section in `generators.yml` to control the content and structure of generated README files across all your SDKs. 
 You can add custom introductions, showcase key endpoints, and organize your SDK documentation with feature sections.
 
-```yaml title="generators.yml"
-readme:
-  introduction: "Welcome to our API"
-  apiReferenceLink: "https://docs.example.com"
-  apiName: "Example Product"
-  disabledSections:
-    - "contributing"
-  defaultEndpoint:
-    method: "POST"
-    path: "/users"
-  features:
-    authentication:
-      - method: "POST"
-        path: "/auth/login"
-    users:
-      - method: "GET"
-        path: "/users"
-```    
+## Configuration options
 
-For more detailed information on `readme` configuration, see the [`generators.yml` documentation](/sdks/reference/generators-yml#readme)
+<Markdown src="/products/sdks/snippets/readme-options.mdx" />
+
+## Additional customization
+
+If you want to customize the README further than the allowed configuration options, you can [manually modify the readme](/products/sdks/custom-code.mdx), then add it to your `.fernignore` file so it doesn't get overwritten on regenerations.

--- a/fern/products/sdks/guides/configure-readme.mdx
+++ b/fern/products/sdks/guides/configure-readme.mdx
@@ -3,8 +3,8 @@ title: Customize README
 description: Guide to configuring the README in your SDK
 ---
 
-By default, the README for your SDKs is generated programmatically. You can override this by configuring the `readme` section in `generators.yml` to control the content and structure of generated README files across all your SDKs. 
-You can add custom introductions, showcase key endpoints, and organize your SDK documentation with feature sections.
+By default, the README for your SDKs is generated programmatically. You can customize the content and structure of these README files across all of your SDKs by configuring the `readme` section in `generators.yml`.
+
 
 ## Configuration options
 
@@ -12,4 +12,4 @@ You can add custom introductions, showcase key endpoints, and organize your SDK 
 
 ## Additional customization
 
-If you want to customize the README further than the allowed configuration options, you can [manually modify the readme](/products/sdks/custom-code.mdx), then add it to your `.fernignore` file so it doesn't get overwritten on regenerations.
+For customization beyond these configuration options, you can [manually modify the README](/products/sdks/custom-code.mdx) and add it to your `.fernignore` file to prevent it from being overwritten during regeneration.

--- a/fern/products/sdks/reference/generators-yml-reference.mdx
+++ b/fern/products/sdks/reference/generators-yml-reference.mdx
@@ -330,74 +330,10 @@ metadata:
 </ParamField>
 
 ## readme
+
 Controls what goes into the generated README files across all SDKs, allowing you to customize the content and structure of your SDK documentation.
 
-```yaml
-readme:
-  bannerLink: "https://example.com/banner"
-  introduction: "Welcome to our API"
-  apiReferenceLink: "https://docs.example.com"
-  apiName: "Example Product"
-  disabledSections:
-    - "contributing"
-  defaultEndpoint:
-    method: "POST"
-    path: "/users"
-    stream: false
-  features:
-    authentication:
-      - method: "POST"
-        path: "/auth/login"
-      - "GET /auth/profile"
-    users:
-      - method: "GET"
-        path: "/users"
-      - method: "POST"
-        path: "/users"
-```
-
-<ParamField path="bannerLink" type="string" required={false} toc={true}>
-  URL for a banner image or link that appears at the top of the README.
-</ParamField>
-
-<ParamField path="introduction" type="string" required={false} toc={true}>
-  Custom introduction text that appears at the beginning of the README.
-</ParamField>
-
-<ParamField path="apiReferenceLink" type="string" required={false} toc={true}>
-  URL to your external API documentation or reference guide.
-</ParamField>
-
-<ParamField path="apiName" type="string" required={false} toc={true}>
-  Name of the API that appears in the README. Will appear as `Your Api Name SDK` or `Your Api Name API` throughout the README. Defaults to organization name if not set.
-</ParamField>
-
-<ParamField path="disabledSections" type="string[]" required={false} toc={true}>
-  Sections to disable in the README. Supported values: `"contributing"`.
-</ParamField>
-
-<ParamField path="defaultEndpoint" type="ReadmeEndpointSchema" required={false} toc={true}>
-  Specifies which endpoint's code snippet to showcase as the primary example in the README.
-</ParamField>
-
-<ParamField path="features" type="map<string, list<ReadmeEndpointSchema>>" required={false} toc={true}>
-  Groups endpoints by feature name for organized README sections. Each feature becomes a section in the README with example code snippets for the listed endpoints.
-</ParamField>
-
-### defaultEndpoint
-Specifies which endpoint's code snippet to showcase as the primary example in the README.
-
-<ParamField path="method" type="string" required={true} toc={true}>
-  HTTP method of the default endpoint (e.g., `GET`, `POST`, `PUT`, `DELETE`).
-</ParamField>
-
-<ParamField path="path" type="string" required={true} toc={true}>
-  Endpoint path for the default example (e.g., `/users`, `/auth/login`).
-</ParamField>
-
-<ParamField path="stream" type="boolean" required={false} default="false" toc={true}>
-  Whether the endpoint is a streaming endpoint. Defaults to `false`.
-</ParamField>
+<Markdown src="/products/sdks/snippets/readme-options.mdx" />
 
 ## default-group
 Which group to use when none is specified.

--- a/fern/products/sdks/snippets/readme-options.mdx
+++ b/fern/products/sdks/snippets/readme-options.mdx
@@ -47,20 +47,21 @@ readme:
 </ParamField>
 
 <ParamField path="features" type="map<string, list<ReadmeEndpointSchema>>" required={false} toc={true}>
-  Groups endpoints by feature name for organized README sections. Each feature becomes a section in the README with example code snippets for the listed endpoints.
+  Organizes endpoints into named feature sections within the README. Each feature creates a dedicated section with example code snippets for the specified endpoints.
 </ParamField>
 
-### defaultEndpoint
+### Endpoint configuration
+
 Specifies which endpoint's code snippet to showcase as the primary example in the README.
 
-<ParamField path="method" type="string" required={true} toc={true}>
+<ParamField path="defaultEndpoint.method" type="string" required={true} toc={true}>
   HTTP method of the default endpoint (e.g., `GET`, `POST`, `PUT`, `DELETE`).
 </ParamField>
 
-<ParamField path="path" type="string" required={true} toc={true}>
+<ParamField path="defaultEndpoint.path" type="string" required={true} toc={true}>
   Endpoint path for the default example (e.g., `/users`, `/auth/login`).
 </ParamField>
 
-<ParamField path="stream" type="boolean" required={false} default="false" toc={true}>
+<ParamField path="defaultEndpoint.stream" type="boolean" required={false} default="false" toc={true}>
   Whether the endpoint is a streaming endpoint. Defaults to `false`.
 </ParamField>

--- a/fern/products/sdks/snippets/readme-options.mdx
+++ b/fern/products/sdks/snippets/readme-options.mdx
@@ -1,0 +1,66 @@
+```yaml
+readme:
+  bannerLink: "https://example.com/banner"
+  introduction: "Welcome to our API"
+  apiReferenceLink: "https://docs.example.com"
+  apiName: "Example Product"
+  disabledSections:
+    - "contributing"
+  defaultEndpoint:
+    method: "POST"
+    path: "/users"
+    stream: false
+  features:
+    authentication:
+      - method: "POST"
+        path: "/auth/login"
+      - "GET /auth/profile"
+    users:
+      - method: "GET"
+        path: "/users"
+      - method: "POST"
+        path: "/users"
+```
+
+<ParamField path="bannerLink" type="string" required={false} toc={true}>
+  URL for a banner image or link that appears at the top of the README.
+</ParamField>
+
+<ParamField path="introduction" type="string" required={false} toc={true}>
+  Custom introduction text that appears at the beginning of the README.
+</ParamField>
+
+<ParamField path="apiReferenceLink" type="string" required={false} toc={true}>
+  URL to your external API documentation or reference guide.
+</ParamField>
+
+<ParamField path="apiName" type="string" required={false} toc={true}>
+  Name of the API that appears in the README. Will appear as `Your Api Name SDK` or `Your Api Name API` throughout the README. Defaults to organization name if not set.
+</ParamField>
+
+<ParamField path="disabledSections" type="string[]" required={false} toc={true}>
+  Sections to disable in the README. Supported values: `"contributing"`.
+</ParamField>
+
+<ParamField path="defaultEndpoint" type="ReadmeEndpointSchema" required={false} toc={true}>
+  Specifies which endpoint's code snippet to showcase as the primary example in the README.
+</ParamField>
+
+<ParamField path="features" type="map<string, list<ReadmeEndpointSchema>>" required={false} toc={true}>
+  Groups endpoints by feature name for organized README sections. Each feature becomes a section in the README with example code snippets for the listed endpoints.
+</ParamField>
+
+### defaultEndpoint
+Specifies which endpoint's code snippet to showcase as the primary example in the README.
+
+<ParamField path="method" type="string" required={true} toc={true}>
+  HTTP method of the default endpoint (e.g., `GET`, `POST`, `PUT`, `DELETE`).
+</ParamField>
+
+<ParamField path="path" type="string" required={true} toc={true}>
+  Endpoint path for the default example (e.g., `/users`, `/auth/login`).
+</ParamField>
+
+<ParamField path="stream" type="boolean" required={false} default="false" toc={true}>
+  Whether the endpoint is a streaming endpoint. Defaults to `false`.
+</ParamField>


### PR DESCRIPTION
-Move configuration options into a snippet and include it on README guide and generators.yml reference.