### PR TITLE
fix: x-fern-examples documentation bug

### DIFF
--- a/fern/products/api-def/openapi-pages/extensions/examples.mdx
+++ b/fern/products/api-def/openapi-pages/extensions/examples.mdx
@@ -19,13 +19,13 @@ paths:
         - headers:
             custom_api_key: "capi_12345" # header defined using x-global-header extension
             userpool_id: "pool_67890"    # header defined using x-global-header extension
-        - path-parameters:
+          path-parameters:
             userId: user-1234
           response:
             body:
               name: Foo
               ssn: 1234
-        - path-parameters:
+          path-parameters:
             userId: user-4567
           response:
             body:

--- a/fern/products/api-def/openapi-pages/extensions/examples.mdx
+++ b/fern/products/api-def/openapi-pages/extensions/examples.mdx
@@ -25,7 +25,7 @@ paths:
             body:
               name: Foo
               ssn: 1234
-          path-parameters:
+        - path-parameters:
             userId: user-4567
           response:
             body:


### PR DESCRIPTION
- previously, `x-fern-examples` documentation showed using multiple entries for headers, path params, etc. under `x-fern-examples`
- they should all be under the same example entry

Before:
```
      x-fern-examples:
        - headers:
            custom_api_key: "capi_12345" # header defined using x-global-header extension
            userpool_id: "pool_67890"    # header defined using x-global-header extension
        - path-parameters:     # shouldn't be it's own array entry
            userId: user-1234
        - response:   # shouldn't be it's own array entry
            body:
              name: Foo
              ssn: 1234
        - path-parameters:   # shouldn't be it's own array entry
            userId: user-4567
        - response:   # shouldn't be it's own array entry
            body:
              name: Foo
              ssn: 4567
```

After: 

```
      x-fern-examples:
        - headers:
            custom_api_key: "capi_12345" # header defined using x-global-header extension
            userpool_id: "pool_67890"    # header defined using x-global-header extension
          path-parameters:
            userId: user-1234
          response:
            body:
              name: Foo
              ssn: 1234
        - path-parameters:
            userId: user-4567
          response:
            body:
              name: Foo
              ssn: 4567
```