### PR TITLE
(sdks) Swift documentation updates – new enableWireTests option, fix version number

### DIFF
--- a/fern/products/sdks/guides/testing.mdx
+++ b/fern/products/sdks/guides/testing.mdx
@@ -19,13 +19,14 @@ Fern generates unit tests for all SDK languages. They verify individual methods 
 
 Mock server (wire) tests run your SDK against a mock server generated from your API definition. They verify that the SDK sends HTTP requests and receives HTTP responses as expected. These tests are generated for all endpoints in a service.
 
-Mock server tests are available for TypeScript, Go, and Java. Configure mock server tests in your `generators.yml`:
+Mock server tests are available for TypeScript, Go, Java, and Swift. Configure mock server tests in your `generators.yml`:
 
 | Language | Configuration | Default |
 |----------|---------------|---------|
 | TypeScript | [`generateWireTests`](/sdks/generators/typescript/configuration#generatewiretests) | true |
 | Go | [`enableWireTests`](/sdks/generators/go/configuration#enablewiretests) | false |
 | Java | [`enable-wire-tests`](/sdks/generators/java/configuration#enablewiretests) | false |
+| Swift | [`enableWireTests`](/sdks/generators/swift/configuration#enablewiretests) | true |
 
 ## Integration tests
 

--- a/fern/products/sdks/overview/swift/configuration.mdx
+++ b/fern/products/sdks/overview/swift/configuration.mdx
@@ -5,7 +5,7 @@ description: Configuration options for the Fern Swift SDK.
 
 You can customize the behavior of the Swift SDK generator in `generators.yml`:
 
-```yaml {6-9} title="generators.yml"
+```yaml {6-10} title="generators.yml"
 groups:
   swift-sdk:
     generators:
@@ -15,6 +15,7 @@ groups:
           clientClassName: YourClientName
           environmentEnumName: YourCustomEnvironment
           moduleName: MyCustomModule
+          enableWireTests: false
 ```
 
 ## SDK Configuration Options
@@ -29,4 +30,8 @@ The name of the generated environment enum. This allows you to customize the enu
 
 <ParamField path="moduleName" type="string" required={false} toc={true}>
 The module name used in client code (e.g., `import MyCustomModule`). When provided, this name is used consistently across the library, product, and target.
+</ParamField>
+
+<ParamField path="enableWireTests" type="boolean" default="true" required={false} toc={true}>
+Generates [mock server (wire) tests](/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
 </ParamField>

--- a/fern/products/sdks/overview/swift/configuration.mdx
+++ b/fern/products/sdks/overview/swift/configuration.mdx
@@ -33,5 +33,5 @@ The module name used in client code (e.g., `import MyCustomModule`). When provid
 </ParamField>
 
 <ParamField path="enableWireTests" type="boolean" default="true" required={false} toc={true}>
-Generates [mock server (wire) tests](/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
+Generates [mock server (wire) tests](/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends the correct HTTP requests and correctly handles responses per the API spec.
 </ParamField>

--- a/fern/products/sdks/overview/swift/publishing-to-swift-package-manager.mdx
+++ b/fern/products/sdks/overview/swift/publishing-to-swift-package-manager.mdx
@@ -18,7 +18,7 @@ Publish your public-facing Fern Swift SDK as a Swift package distributed via Git
       swift-sdk:
         generators:
           - name: fernapi/fern-swift-sdk
-            version: 1.0.0
+            version: <Markdown src="/snippets/version-number-swift.mdx"/>
             github:
               repository: your-org/company-swift
     ```


### PR DESCRIPTION
relevant to: https://github.com/fern-api/fern/pull/9745