### PR TITLE
docs: The slash command for configuring the Ask Fern Slack bot was changed from `/configure` to `/fern` throughout the documentation, including all examples in the bot settings table. This change simplifies the command structure and likely aligns with a more streamlined user interface, making it easier for users to remember and use the configuration commands.

### DIFF
--- a/fern/products/ask-fern/pages/features/slack-app.mdx
+++ b/fern/products/ask-fern/pages/features/slack-app.mdx
@@ -53,14 +53,14 @@ Customize the bot's behavior to match your workflow needs.
 
 ### Bot settings per channel
 
-Use the `/configure` slash command in any channel to adjust the settings:
+Use the `/fern` slash command in any channel where you want to adjust settings:
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| **respond_to** | Controls whether the Ask Fern bot responds to all messages (`all`), reponds only when directly mentioned with `@Ask Fern` (`mentions_only`), or determines when to respond to messages depending on context (`auto`). Set to `auto` by default. | `/configure respond_to all` |
-| **roles** | Specifies which RBAC roles (comma-separated) should be used to filter Ask Fern responses (if you have [role-based access control](/docs/authentication/rbac) configured) | `/configure roles developer,admin` |
-| **show** | Show the current settings | `/configure show` |
-| **help** | Get help with Ask Fern slash commands | `/configure help` |
+| **respond_to** | Controls whether the Ask Fern bot responds to all messages (`all`), reponds only when directly mentioned with `@Ask Fern` (`mentions_only`), or determines when to respond to messages depending on context (`auto`). Set to `auto` by default. | `/fern respond_to all` |
+| **roles** | Specifies which RBAC roles (comma-separated) should be used to filter Ask Fern responses (if you have [role-based access control](/docs/authentication/rbac) configured) | `/fern roles developer,admin` |
+| **show** | Show the current settings | `/fern show` |
+| **help** | Get help with Ask Fern slash commands | `/fern help` |
 
 <Frame caption="After configuring respond_to all, bot responds to messages even when not directly mentioned">
   <img src="/products//ask-fern/pages/assets/respond-all-slack.png" alt="Respond all setting in Slack" />
@@ -164,4 +164,3 @@ sequenceDiagram
     F->>F: Store question and answer for analytics
 ```
 </Accordion>
-


### PR DESCRIPTION
The slash command for configuring the Ask Fern Slack bot was changed from `/configure` to `/fern` throughout the documentation, including all examples in the bot settings table. This change simplifies the command structure and likely aligns with a more streamlined user interface, making it easier for users to remember and use the configuration commands.

**Question:** How do I change the configurations for the Fern Slack app?

**Incorrect Response:**
use the /configure slash command in any channel where you want to adjust the settings.

**Ideal Response:**
use the /fern slash command in any channel where you want to adjust settings.

**File:** `fern/products/ask-fern/pages/features/slack-app.mdx`
**Source:** Slack Context `test-e663d6d5`