### PR TITLE
docs: The documentation was updated to change the slash command from `/configure` to `/fern` throughout the Configura...

### DIFF
--- a/fern/products/ask-fern/pages/features/slack-app.mdx
+++ b/fern/products/ask-fern/pages/features/slack-app.mdx
@@ -49,18 +49,18 @@ Once you've installed it in your workspace, add the bot to customer Slack channe
 
 ## Configuration
 
-Customize the bot's behavior to match your workflow needs.
+Use the `/fern` slash command to configure the Ask Fern bot's behavior and match your workflow needs.
 
 ### Bot settings per channel
 
-Use the `/configure` slash command in any channel to adjust the settings:
+Use the `/fern` slash command in any channel to adjust the settings:
 
 | Command | Description | Example |
 |---------|-------------|---------|
-| **respond_to** | Controls whether the Ask Fern bot responds to all messages (`all`), reponds only when directly mentioned with `@Ask Fern` (`mentions_only`), or determines when to respond to messages depending on context (`auto`). Set to `auto` by default. | `/configure respond_to all` |
-| **roles** | Specifies which RBAC roles (comma-separated) should be used to filter Ask Fern responses (if you have [role-based access control](/docs/authentication/rbac) configured) | `/configure roles developer,admin` |
-| **show** | Show the current settings | `/configure show` |
-| **help** | Get help with Ask Fern slash commands | `/configure help` |
+| **respond_to** | Controls whether the Ask Fern bot responds to all messages (`all`), reponds only when directly mentioned with `@Ask Fern` (`mentions_only`), or determines when to respond to messages depending on context (`auto`). Set to `auto` by default. | `/fern respond_to all` |
+| **roles** | Specifies which RBAC roles (comma-separated) should be used to filter Ask Fern responses (if you have [role-based access control](/docs/authentication/rbac) configured) | `/fern roles developer,admin` |
+| **show** | Show the current settings | `/fern show` |
+| **help** | Get help with Ask Fern slash commands | `/fern help` |
 
 <Frame caption="After configuring respond_to all, bot responds to messages even when not directly mentioned">
   <img src="/products//ask-fern/pages/assets/respond-all-slack.png" alt="Respond all setting in Slack" />
@@ -164,4 +164,3 @@ sequenceDiagram
     F->>F: Store question and answer for analytics
 ```
 </Accordion>
-


### PR DESCRIPTION
The documentation was updated to change the slash command from `/configure` to `/fern` throughout the Configuration section. This change affects all command examples in the bot settings table (e.g., `/configure respond_to all` became `/fern respond_to all`) and updates the introductory text to reflect the new command syntax. This streamlines the user experience by providing a more concise and brand-specific command for configuring the Ask Fern bot.

Slack thread: https://buildwithfern.slack.com/archives/C09GYA669MG/p1760552476260129?thread_ts=1760552476.260129&cid=C09GYA669MG

**Source:** Created via Ask Fern Slack app (context `b93b27b5-41f8-4980-ae85-70694019ec0d`)
