### PR TITLE
chore: add health endpoint, use real component

### DIFF
--- a/fern/apis/public-api/definition/health.yml
+++ b/fern/apis/public-api/definition/health.yml
@@ -1,0 +1,15 @@
+service:
+  base-path: /
+  auth: false
+  audiences:
+    - external
+  endpoints:
+    health:
+      method: GET
+      display-name: Health
+      path: health
+      docs: Check the health of the SDK generation service. The response will be "OK" if the service is healthy.
+      response: string
+      examples:
+        - response:
+            body: "OK"

--- a/fern/products/docs/pages/component-library/default-components/runnable-endpoint.mdx
+++ b/fern/products/docs/pages/component-library/default-components/runnable-endpoint.mdx
@@ -7,8 +7,11 @@ The `<RunnableEndpoint>` component enables users to make real HTTP requests to y
 
 <Tabs>
 <Tab title="Example">
+This endpoint returns the health of `api.buildwithfern.com`.
+<RunnableEndpoint endpoint="GET /health" />
 
-![Runnable Endpoint component example](runnable-endpoint.png)
+This endpoint returns the document for a given domain. It requires authentication, and a `domain` path parameter.
+<RunnableEndpoint endpoint="GET /document/{domain}" />
 
 </Tab>
 <Tab title="Markdown">


### PR DESCRIPTION
the health endpoint will return a 200, the fai endpoint will really fail, but if a user has their api key they can run it