### PR TITLE
Add Microsoft Teams location support to Ask Fern configuration

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -15,6 +15,7 @@ ai-search:
     - docs
     - slack
     - discord
+    - teams
 ```
 
 ### Available locations
@@ -29,6 +30,10 @@ ai-search:
 
 <ParamField path="discord" type="string">
   Enables Ask Fern in Discord. This allows your community to get AI-powered answers in your Discord server.
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. Users can get AI-powered answers directly within your Teams workspace.
 </ParamField>
 
 ## Datasources (coming soon)


### PR DESCRIPTION
## Summary

This PR adds documentation for Microsoft Teams as a supported location in the Ask Fern configuration.

## Changes

- Added `teams` to the list of available locations in the configuration example
- Added documentation for the `teams` parameter field explaining that it enables Ask Fern in Microsoft Teams workspaces

## Justification

Microsoft Teams is a widely-used collaboration platform, and adding it as a supported location expands Ask Fern's reach to users who primarily work within Teams. This documentation update ensures users are aware they can enable AI-powered answers directly within their Teams workspace.