### PR TITLE
Add Microsoft Teams location to Ask Fern configuration documentation

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -15,6 +15,7 @@ ai-search:
     - docs
     - slack
     - discord
+    - teams
 ```
 
 ### Available locations
@@ -29,6 +30,10 @@ ai-search:
 
 <ParamField path="discord" type="string">
   Enables Ask Fern in Discord. This allows your community to get AI-powered answers in your Discord server.
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. Users can interact with Ask Fern directly within your Teams workspace.
 </ParamField>
 
 ## Datasources (coming soon)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Microsoft Teams location in Ask Fern configuration.

## Changes

- Added `teams` to the list of available locations in the configuration example
- Added a new parameter field documenting the Teams location option
- Provides clear description that Teams integration allows users to interact with Ask Fern directly within their Teams workspace

## Justification

Microsoft Teams is a widely-used collaboration platform in enterprise environments. Documenting the Teams location option ensures users are aware they can enable Ask Fern in their Teams workspace, providing consistency with other documented locations like Slack and Discord.