### PR TITLE
Add Microsoft Teams location support to Ask Fern configuration

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -15,6 +15,7 @@ ai-search:
     - docs
     - slack
     - discord
+    - teams
 ```
 
 ### Available locations
@@ -29,6 +30,10 @@ ai-search:
 
 <ParamField path="discord" type="string">
   Enables Ask Fern in Discord. This allows your community to get AI-powered answers in your Discord server.
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. This allows your team to get AI-powered answers directly in your Teams workspace.
 </ParamField>
 
 ## Datasources (coming soon)


### PR DESCRIPTION
## Summary

This PR adds Microsoft Teams as a supported location for Ask Fern, enabling users to configure AI-powered answers directly in their Teams workspaces.

## Changes

- Added `teams` to the example location configuration in the YAML snippet
- Added documentation for the `teams` location parameter with a clear description of its functionality

## Justification

With the growing adoption of Microsoft Teams as a primary collaboration platform, adding Teams support to Ask Fern extends the reach of AI-powered documentation assistance to where teams already communicate and work. This change ensures feature parity with other collaboration platforms like Slack and Discord that are already documented.