### PR TITLE
Add Microsoft Teams as a location option for Ask Fern

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -14,6 +14,7 @@ ai-search:
   location:
     - docs
     - slack
+    - teams
     - discord
 ```
 
@@ -25,6 +26,10 @@ ai-search:
 
 <ParamField path="slack" type="string">
   Enables Ask Fern in Slack. Learn more about the [Slack app integration](/ask-fern/features/slack-app).
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. This allows your team to get AI-powered answers directly in Teams channels.
 </ParamField>
 
 <ParamField path="discord" type="string">
@@ -66,7 +71,7 @@ Setting `location: [docs]` enables Ask Fern on preview deployments generated wit
 
 <AccordionGroup>
   <Accordion title="Start with docs location">
-    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack or Discord.
+    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack, Teams, or Discord.
   </Accordion>
 
   <Accordion title="Use descriptive titles for datasources">


### PR DESCRIPTION
## Summary

This PR adds Microsoft Teams as a supported location option for Ask Fern integration, expanding the available channels where teams can access AI-powered assistance.

## Changes

- **Configuration**: Added `teams` to the list of available location options in the configuration example
- **Documentation**: Created a new `ParamField` section documenting the Teams integration parameter
- **Best Practices**: Updated the best practices accordion to mention Teams alongside Slack and Discord

## Justification

Microsoft Teams is a widely-used collaboration platform in enterprise environments. By adding Teams as a location option, we enable organizations that primarily use Teams to integrate Ask Fern directly into their existing workflow, providing seamless access to AI-powered documentation assistance within their preferred communication tool.

This addition maintains consistency with the existing location options (Slack and Discord) and follows the same documentation pattern for ease of understanding.