### PR TITLE
Add Microsoft Teams as a supported location for Ask Fern

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -14,6 +14,7 @@ ai-search:
   location:
     - docs
     - slack
+    - teams
     - discord
 ```
 
@@ -25,6 +26,10 @@ ai-search:
 
 <ParamField path="slack" type="string">
   Enables Ask Fern in Slack. Learn more about the [Slack app integration](/ask-fern/features/slack-app).
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. This allows your team to get AI-powered answers directly in Teams channels.
 </ParamField>
 
 <ParamField path="discord" type="string">
@@ -66,7 +71,7 @@ Setting `location: [docs]` enables Ask Fern on preview deployments generated wit
 
 <AccordionGroup>
   <Accordion title="Start with docs location">
-    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack or Discord.
+    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack, Teams, or Discord.
   </Accordion>
 
   <Accordion title="Use descriptive titles for datasources">


### PR DESCRIPTION
## Summary

This PR adds Microsoft Teams as a supported location for the Ask Fern AI search feature, expanding integration options beyond the existing Slack and Discord platforms.

## Changes

- Added `teams` to the list of available locations in the configuration example
- Documented the Teams location option with a new `ParamField` entry explaining its functionality
- Updated the best practices section to mention Teams alongside Slack and Discord

## Justification

Microsoft Teams is a widely-used collaboration platform in enterprise environments. Adding Teams as a supported location allows organizations that use Teams to leverage Ask Fern's AI-powered assistance directly within their existing communication workflow, providing the same seamless experience already available for Slack and Discord users.

This enhancement improves the versatility of Ask Fern by supporting another major communication platform where users may need quick access to documentation and AI-powered answers.