### PR TITLE
Add Microsoft Teams support to Ask Fern documentation

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -15,6 +15,7 @@ ai-search:
     - docs
     - slack
     - discord
+    - teams
 ```
 
 ### Available locations
@@ -29,6 +30,10 @@ ai-search:
 
 <ParamField path="discord" type="string">
   Enables Ask Fern in Discord. This allows your community to get AI-powered answers in your Discord server.
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. Users can get AI-powered answers directly in your Teams workspace.
 </ParamField>
 
 ## Datasources (coming soon)


### PR DESCRIPTION
## Summary

This PR adds documentation for Microsoft Teams integration in Ask Fern's configuration options.

## Changes

- Added `teams` to the list of available locations in the configuration example
- Added a new `ParamField` section documenting the Teams location option
- The Teams integration allows users to get AI-powered answers directly in their Microsoft Teams workspace

## Justification

Microsoft Teams is a widely-used collaboration platform, and documenting its integration with Ask Fern ensures users are aware of this deployment option. This addition maintains consistency with the existing documentation format for Discord and Slack integrations.