### PR TITLE
Add Microsoft Teams as a supported location for Ask Fern

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -15,6 +15,7 @@ ai-search:
     - docs
     - slack
     - discord
+    - teams
 ```
 
 ### Available locations
@@ -29,6 +30,10 @@ ai-search:
 
 <ParamField path="discord" type="string">
   Enables Ask Fern in Discord. This allows your community to get AI-powered answers in your Discord server.
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. This allows your team to get AI-powered answers directly in your Teams workspace.
 </ParamField>
 
 ## Datasources (coming soon)
@@ -66,7 +71,7 @@ Setting `location: [docs]` enables Ask Fern on preview deployments generated wit
 
 <AccordionGroup>
   <Accordion title="Start with docs location">
-    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack or Discord.
+    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack, Discord, or Microsoft Teams.
   </Accordion>
 
   <Accordion title="Use descriptive titles for datasources">


### PR DESCRIPTION
## Summary

This PR adds Microsoft Teams as a new supported location for Ask Fern, enabling teams to get AI-powered answers directly within their Microsoft Teams workspace.

## Changes

- Added `teams` to the list of available locations in the configuration example
- Added documentation for the `teams` parameter field explaining its functionality
- Updated the best practices section to include Microsoft Teams alongside Slack and Discord as expansion options

## Justification

With the growing adoption of Microsoft Teams in enterprise environments, adding Teams as a supported location expands Ask Fern's reach and provides users with another convenient channel to access AI-powered documentation assistance. This aligns with the existing multi-channel approach that already supports Slack and Discord.