### PR TITLE
Add Microsoft Teams location support to Ask Fern

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -15,6 +15,7 @@ ai-search:
     - docs
     - slack
     - discord
+    - teams
 ```
 
 ### Available locations
@@ -29,6 +30,10 @@ ai-search:
 
 <ParamField path="discord" type="string">
   Enables Ask Fern in Discord. This allows your community to get AI-powered answers in your Discord server.
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. This allows your team to get AI-powered answers directly in Teams channels and chats.
 </ParamField>
 
 ## Datasources (coming soon)
@@ -66,7 +71,7 @@ Setting `location: [docs]` enables Ask Fern on preview deployments generated wit
 
 <AccordionGroup>
   <Accordion title="Start with docs location">
-    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack or Discord.
+    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack, Discord, or Teams.
   </Accordion>
 
   <Accordion title="Use descriptive titles for datasources">


### PR DESCRIPTION
## Summary

This PR adds Microsoft Teams as a supported location for Ask Fern, enabling users to get AI-powered answers directly in Teams channels and chats.

## Changes

- Added `teams` as a new location option in the configuration example
- Added documentation for the `teams` location parameter with a description of its functionality
- Updated the best practices section to include Teams alongside Slack and Discord

## Justification

Microsoft Teams is a widely-used collaboration platform in enterprise environments. Adding Teams support to Ask Fern will allow organizations to provide AI-powered assistance directly within their Teams workspace, improving discoverability and accessibility of documentation for team members who primarily use Teams for their daily work.

This addition follows the same pattern as the existing Slack and Discord integrations, maintaining consistency in the documentation structure.