### PR TITLE
Add Microsoft Teams as a supported location for Ask Fern

### DIFF
--- a/fern/apis/fai/openapi.json
+++ b/fern/apis/fai/openapi.json
@@ -2225,7 +2225,7 @@
           "Settings"
         ],
         "summary": "Toggle Ask Ai",
-        "description": "Toggle Ask AI setting and return job_id for tracking.\n\nArgs:\n    domain: Domain to toggle Ask AI for\n    org_name: Organization name\n    preview: Whether this is a preview deployment\n    locations: Optional list of locations to enable. Valid values: docs, slack, discord",
+        "description": "Toggle Ask AI setting and return job_id for tracking.\n\nArgs:\n    domain: Domain to toggle Ask AI for\n    org_name: Organization name\n    preview: Whether this is a preview deployment\n    locations: Optional list of locations to enable. Valid values: docs, slack, discord, teams",
         "operationId": "toggle_ask_ai",
         "parameters": [
           {
@@ -2268,7 +2268,8 @@
                     "enum": [
                       "docs",
                       "slack",
-                      "discord"
+                      "discord",
+                      "teams"
                     ],
                     "type": "string"
                   }

--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -15,6 +15,7 @@ ai-search:
     - docs
     - slack
     - discord
+    - teams
 ```
 
 ### Available locations
@@ -29,6 +30,10 @@ ai-search:
 
 <ParamField path="discord" type="string">
   Enables Ask Fern in Discord. This allows your community to get AI-powered answers in your Discord server.
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. Users can get AI-powered answers directly within Teams.
 </ParamField>
 
 ## Datasources (coming soon)


### PR DESCRIPTION
## Summary

This PR adds Microsoft Teams as a new supported location for Ask Fern, allowing users to get AI-powered answers directly within their Teams workspace.

## Changes

- **OpenAPI Spec**: Added `teams` to the valid location enum in the `toggle_ask_ai` endpoint
- **Documentation**: Added Teams configuration documentation in the locations and datasources page

## Justification

With Microsoft Teams being widely used for enterprise collaboration, adding Teams support expands Ask Fern's reach to help users get instant answers within their existing workflow. This complements the existing integrations with docs, Slack, and Discord.