### PR TITLE
Add Microsoft Teams as a supported location for Ask Fern

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -15,6 +15,7 @@ ai-search:
     - docs
     - slack
     - discord
+    - teams
 ```
 
 ### Available locations
@@ -29,6 +30,10 @@ ai-search:
 
 <ParamField path="discord" type="string">
   Enables Ask Fern in Discord. This allows your community to get AI-powered answers in your Discord server.
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. This allows your team to get AI-powered answers directly in your Microsoft Teams workspace.
 </ParamField>
 
 ## Datasources (coming soon)


### PR DESCRIPTION
## Summary

This PR adds Microsoft Teams as a supported location for Ask Fern, enabling AI-powered answers directly within Microsoft Teams workspaces.

## Changes

- Added `teams` to the list of available locations in the configuration example
- Added documentation for the `teams` parameter field with a clear description of its functionality

## Justification

With Microsoft Teams being a widely-used collaboration platform in enterprise environments, adding Teams support expands Ask Fern's reach and allows teams to access AI-powered documentation assistance directly in their daily workflow without context switching.