### PR TITLE
Add Microsoft Teams location support for Ask Fern

### DIFF
--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -166,15 +166,25 @@ types:
 
   TabId: string
 
-  AIChatConfig: 
-    properties: 
+  AISearchLocation:
+    enum:
+      - docs
+      - slack
+      - discord
+      - teams
+
+  AIChatConfig:
+    properties:
       model: optional<AIChatModel>
-      "system-prompt": 
+      "system-prompt":
         type: optional<string>
-        docs: This is a system prompt that acts as context given to the LLM for AI chat. 
-    
-  AIChatModel: 
-    enum: 
+        docs: This is a system prompt that acts as context given to the LLM for AI chat.
+      location:
+        type: optional<list<AISearchLocation>>
+        docs: Determines where Ask Fern will be available to users. Can include docs, slack, discord, or teams.
+
+  AIChatModel:
+    enum:
       - value: "claude-3.5"
         name: claude_3_5
       - value: "claude-3.7"

--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -15,6 +15,7 @@ ai-search:
     - docs
     - slack
     - discord
+    - teams
 ```
 
 ### Available locations
@@ -29,6 +30,10 @@ ai-search:
 
 <ParamField path="discord" type="string">
   Enables Ask Fern in Discord. This allows your community to get AI-powered answers in your Discord server.
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. This allows your team to get AI-powered answers in your Teams workspace.
 </ParamField>
 
 ## Datasources (coming soon)


### PR DESCRIPTION
## Summary

This PR adds support for Microsoft Teams as a location option for Ask Fern, enabling AI-powered assistance within Teams workspaces.

## Changes

- **Type Definition**: Added `teams` as a new enum value to `AISearchLocation` in `docs.yml`
- **Documentation**: Updated `locations-and-datasources.mdx` to document the Teams location configuration option
- **Integration**: Enables Ask Fern to provide AI-powered answers in Microsoft Teams workspaces, similar to existing Slack and Discord integrations

## Justification

Expanding Ask Fern's availability to Microsoft Teams provides users with more flexibility in choosing their preferred collaboration platform. This addition complements the existing integrations with Slack and Discord, allowing teams that use Microsoft Teams to access the same AI-powered documentation assistance within their workflow.