### PR TITLE
chore: orchestrate docs PRs on docs release

### DIFF
--- a/.github/workflows/auto-merge-on-docs-release.yml
+++ b/.github/workflows/auto-merge-on-docs-release.yml
@@ -1,0 +1,50 @@
+# .github/workflows/auto-merge-on-release.yml in docs repo
+name: Auto-merge on Docs Release
+on:
+  repository_dispatch:
+    types: [docs_release]
+
+jobs:
+  merge-dependent-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and merge dependent PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = context.payload.client_payload.version;
+            
+            // Find PRs with matching labels
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+            
+            for (const pr of prs) {
+              const labels = pr.labels.map(l => l.name);
+              const hasLatestLabel = labels.includes('depends-on: docs@latest');
+              const hasVersionLabel = labels.includes(`depends-on: docs@${version}`);
+              
+              if (hasLatestLabel || hasVersionLabel) {
+                // Check if PR is approved and CI passes
+                const { data: reviews } = await github.rest.pulls.listReviews({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number
+                });
+                
+                const approved = reviews.some(r => r.state === 'APPROVED');
+                
+                if (approved) {
+                  await github.rest.pulls.merge({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    merge_method: 'squash'
+                  });
+                  
+                  console.log(`Merged PR #${pr.number}: ${pr.title}`);
+                }
+              }
+            }


### PR DESCRIPTION
we'll add a label to the docs PR saying: `depends-on:docs@latest`

this should allow us to orchestrate releases