### PR TITLE
Add Microsoft Teams location support to Ask Fern configuration

### DIFF
--- a/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
+++ b/fern/products/ask-fern/pages/configuration/locations-and-datasources.mdx
@@ -14,6 +14,7 @@ ai-search:
   location:
     - docs
     - slack
+    - teams
     - discord
 ```
 
@@ -25,6 +26,10 @@ ai-search:
 
 <ParamField path="slack" type="string">
   Enables Ask Fern in Slack. Learn more about the [Slack app integration](/ask-fern/features/slack-app).
+</ParamField>
+
+<ParamField path="teams" type="string">
+  Enables Ask Fern in Microsoft Teams. This allows your team to get AI-powered answers directly in your Teams workspace.
 </ParamField>
 
 <ParamField path="discord" type="string">
@@ -66,7 +71,7 @@ Setting `location: [docs]` enables Ask Fern on preview deployments generated wit
 
 <AccordionGroup>
   <Accordion title="Start with docs location">
-    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack or Discord.
+    Begin by enabling Ask Fern on your documentation site (`location: [docs]`) to test and refine the experience before expanding to other channels like Slack, Teams, or Discord.
   </Accordion>
 
   <Accordion title="Use descriptive titles for datasources">


### PR DESCRIPTION
## Summary

This PR adds Microsoft Teams as a supported location for Ask Fern, enabling teams to access AI-powered answers directly within their Teams workspace.

## Changes

- Added `teams` as a new location option in the configuration example
- Added documentation for the `teams` parameter field
- Updated the best practices section to mention Teams alongside Slack and Discord

## Justification

Microsoft Teams is a widely-used collaboration platform, and adding it as a supported location will allow organizations using Teams to benefit from Ask Fern's AI-powered assistance without switching contexts. This change provides consistency with existing integrations (Slack and Discord) and gives users more flexibility in how they deploy Ask Fern.