### PR TITLE
Add --deep flag to all fern generate commands in documentation

### DIFF
--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -68,11 +68,11 @@ fern generate --docs --preview    # Preview documentation changes
 fern generate --docs              # Generate and publish documentation
 
 # SDK Development
-fern init                        # Start new SDK project
-fern check                       # Validate API definition
-fern generate --preview          # Preview SDKs in .preview/ folder
-fern generate                    # Generate default SDK group
-fern generate --group ts-sdk     # Generate specific SDK group
+fern init                             # Start new SDK project
+fern check                            # Validate API definition
+fern generate --deep --preview        # Preview SDKs in .preview/ folder
+fern generate --deep                  # Generate default SDK group
+fern generate --deep --group ts-sdk   # Generate specific SDK group
 ```
 
 <Note>
@@ -105,18 +105,18 @@ The "default SDK group" refers to the group marked as default in your `generator
     ```bash
     fern init
     ```
-    
+
     2. Configure your generators in [configuration options](/learn/sdks/introduction/configuration)
-    
+
     3. Generate SDKs:
     ```bash
-    fern generate --preview                     # Preview changes locally
-    fern generate --group python-sdk --preview  # Preview specific SDK group
-    fern generate                               # Publish to production
+    fern generate --deep --preview                     # Preview changes locally
+    fern generate --deep --group python-sdk --preview  # Preview specific SDK group
+    fern generate --deep                               # Publish to production
     ```
 
     <Tip>
-      During development, use `--preview` to test your changes locally before publishing. 
+      During development, use `--preview` to test your changes locally before publishing.
       The preview SDK will be generated into the `.preview/` folder.
     </Tip>
   </Accordion>

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -174,9 +174,21 @@ hideOnThisPage: true
 
     <CodeBlock title="terminal">
     ```bash
-    fern generate [--group <group>] [--api <api>] [--version <version>] [--preview]
+    fern generate [--deep] [--group <group>] [--api <api>] [--version <version>] [--preview]
     ```
     </CodeBlock>
+
+    ### deep
+
+    Use `--deep` to enable deep generation mode, which is required for SDK generation with the latest CLI version. This flag ensures that all nested types and dependencies are fully resolved during generation.
+
+    ```bash
+    # Generate SDK with deep mode
+    fern generate --deep --group ts-sdk
+
+    # Generate with deep mode and API specification
+    fern generate --deep --group ts-sdk --api your-api-name
+    ```
 
     ### preview
 
@@ -184,13 +196,13 @@ hideOnThisPage: true
     - Generates SDK into a local `.preview/` folder
     - Allows quick iteration on your Fern definition
     - No changes are published to package managers or GitHub
-    
+
     ```bash
     # Preview all SDKs
-    fern generate --preview
-    
+    fern generate --deep --preview
+
     # Preview specific SDK group
-    fern generate --group python-sdk --preview
+    fern generate --deep --group python-sdk --preview
     ```
 
     ### group
@@ -198,7 +210,7 @@ hideOnThisPage: true
     Use `--group <group>` to filter to a specific group within `generators.yml`. Required unless you have a `default-group` declared.
 
     ```bash
-    fern generate --group internal
+    fern generate --deep --group internal
     ```
 
     ### api
@@ -206,7 +218,7 @@ hideOnThisPage: true
     Use `--api <api>` to specify the API for SDK generation.
 
     ```bash
-    fern generate --api public-api
+    fern generate --deep --api public-api
     ```
 
     ### version
@@ -214,7 +226,7 @@ hideOnThisPage: true
     Use `--version` to specify a version for SDKs and documentation. Adherence to [semantic versioning](https://semver.org/) is advised.
 
     ```bash
-    fern generate --version 2.11
+    fern generate --deep --version 2.11
     ```
 
   </Accordion>

--- a/fern/products/sdks/guides/filter-your-endpoints-audiences.mdx
+++ b/fern/products/sdks/guides/filter-your-endpoints-audiences.mdx
@@ -131,7 +131,7 @@ groups:
 ### Generate your SDK
 
   ```bash
-  fern generate --group sdk
+  fern generate --deep --group sdk
   ```
 
 </Steps>
@@ -232,7 +232,7 @@ groups:
 ### Generate your SDK
 
   ```bash
-  fern generate --group sdk
+  fern generate --deep --group sdk
   ```
 </Steps>
 </Accordion>

--- a/fern/products/sdks/guides/setup-local-sdk-previews.mdx
+++ b/fern/products/sdks/guides/setup-local-sdk-previews.mdx
@@ -9,10 +9,10 @@ as you develop:
 
 ```bash
 # Preview all SDKs
-fern generate --preview
+fern generate --deep --preview
 
 # Preview SDK for a specific language
-fern generate --group <language>-sdk --preview
+fern generate --deep --group <language>-sdk --preview
 
 ```
 
@@ -50,7 +50,7 @@ groups:
 ### Invoke the Fern CLI
 
 ```shell
-fern generate --group python-sdk --preview
+fern generate --deep --group python-sdk --preview
 ```
 
 ### Preview your SDK

--- a/fern/products/sdks/overview/csharp/quickstart.mdx
+++ b/fern/products/sdks/overview/csharp/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group csharp-sdk
+fern generate --deep --group csharp-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group csharp-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group csharp-sdk --api your-api-name
+  ```
 </Note>
 
 <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group csharp-sdk
+sdks/ # created by fern generate --deep --group csharp-sdk
 ├─ csharp
     └─ src/
         ├─ YourOrganizationApi.sln

--- a/fern/products/sdks/overview/go/quickstart.mdx
+++ b/fern/products/sdks/overview/go/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group go-sdk
+fern generate --deep --group go-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group go-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group go-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group go-sdk
+sdks/ # created by fern generate --deep --group go-sdk
 ├─ go
     ├─ core/
     └─ go.mod

--- a/fern/products/sdks/overview/java/quickstart.mdx
+++ b/fern/products/sdks/overview/java/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group java-sdk
+fern generate --deep --group java-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group java-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group java-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group java-sdk
+sdks/ # created by fern generate --deep --group java-sdk
 ├─ java
     ├─ YourOrganizationApiClient.java
     ├─ core/

--- a/fern/products/sdks/overview/php/quickstart.mdx
+++ b/fern/products/sdks/overview/php/quickstart.mdx
@@ -43,27 +43,27 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group php-sdk
+fern generate --deep --group php-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group php-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group php-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group php-sdk
+sdks/ # created by fern generate --deep --group php-sdk
 ├─ php
     └─ sdk/
         ├─ src/
             ├─ YourOrganizationClient.php
-            └─ Types/ 
+            └─ Types/
         └─ tests/
             └─ Core/
 ```

--- a/fern/products/sdks/overview/postman/quickstart.mdx
+++ b/fern/products/sdks/overview/postman/quickstart.mdx
@@ -46,14 +46,14 @@ groups:
 Run the following command:
 
 ```sh
-fern generate --group postman
+fern generate --deep --group postman
 ```
 
 <Note>
     If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
     ```bash
-    fern generate --group postman --api your-api-name
+    fern generate --deep --group postman --api your-api-name
     ```
 </Note>
 

--- a/fern/products/sdks/overview/python/quickstart.mdx
+++ b/fern/products/sdks/overview/python/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group python-sdk
+fern generate --deep --group python-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group python-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group python-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group python-sdk
+sdks/ # created by fern generate --deep --group python-sdk
 ├─ python
     ├─ __init__.py
     ├─ client.py

--- a/fern/products/sdks/overview/ruby/quickstart.mdx
+++ b/fern/products/sdks/overview/ruby/quickstart.mdx
@@ -43,22 +43,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ruby-sdk
+fern generate --deep --group ruby-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ruby-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group ruby-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group ruby-sdk
+sdks/ # created by fern generate --deep --group ruby-sdk
 ├─ ruby
     ├─ YourOrganization_api_client.gemspec
     ├─ test/

--- a/fern/products/sdks/overview/swift/quickstart.mdx
+++ b/fern/products/sdks/overview/swift/quickstart.mdx
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
   Run the following command to generate your SDK:
 
   ```bash
-  fern generate --group swift-sdk
+  fern generate --deep --group swift-sdk
   ```
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group swift-sdk
+sdks/ # created by fern generate --deep --group swift-sdk
 ├─ swift
     ├─ Package.swift
     └─ Sources

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ts-sdk
+fern generate --deep --group ts-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ts-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group ts-sdk --api your-api-name
+  ```
 </Note>
 
 <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group ts-sdk
+sdks/ # created by fern generate --deep --group ts-sdk
 ├─ typescript
     ├─ Client.ts
     ├─ index.ts


### PR DESCRIPTION
## Summary

This PR updates all documentation to include the `--deep` flag when using `fern generate` commands. The `--deep` flag enables deep generation mode, which is required for SDK generation with the latest CLI version and ensures that all nested types and dependencies are fully resolved during generation.

## Changes

Updated the following documentation files to include `--deep` flag in all `fern generate` command examples:

- CLI getting started guide and commands reference
- SDK guides (filtering endpoints, local previews)
- SDK quickstart guides for all supported languages:
  - C# / .NET
  - Go
  - Java
  - PHP
  - Postman
  - Python
  - Ruby
  - Swift
  - TypeScript

## Justification

The `--deep` flag is now a required parameter for SDK generation to ensure proper resolution of nested types and dependencies. This update ensures that all documentation examples reflect the current best practices and prevent users from encountering issues when following the documentation.

All instances of:
- `fern generate` → `fern generate --deep`
- `fern generate --preview` → `fern generate --deep --preview`
- `fern generate --group <name>` → `fern generate --deep --group <name>`