### PR TITLE
Add --deep flag to TypeScript SDK generation commands

### DIFF
--- a/examples/sdks/typescript-publish.yml
+++ b/examples/sdks/typescript-publish.yml
@@ -29,4 +29,4 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          fern generate --group ts-sdk --version ${{ inputs.version }} --log-level debug
+          fern generate --deep --group ts-sdk --version ${{ inputs.version }} --log-level debug

--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -71,8 +71,8 @@ fern generate --docs              # Generate and publish documentation
 fern init                        # Start new SDK project
 fern check                       # Validate API definition
 fern generate --preview          # Preview SDKs in .preview/ folder
-fern generate                    # Generate default SDK group
-fern generate --group ts-sdk     # Generate specific SDK group
+fern generate                         # Generate default SDK group
+fern generate --deep --group ts-sdk  # Generate TypeScript SDK
 ```
 
 <Note>

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -174,9 +174,17 @@ hideOnThisPage: true
 
     <CodeBlock title="terminal">
     ```bash
-    fern generate [--group <group>] [--api <api>] [--version <version>] [--preview]
+    fern generate [--deep] [--group <group>] [--api <api>] [--version <version>] [--preview]
     ```
     </CodeBlock>
+
+    ### deep
+
+    Use `--deep` to enable deep generation mode. This flag is recommended for TypeScript SDK generation and other generators that benefit from enhanced processing.
+
+    ```bash
+    fern generate --deep --group ts-sdk
+    ```
 
     ### preview
 
@@ -184,11 +192,11 @@ hideOnThisPage: true
     - Generates SDK into a local `.preview/` folder
     - Allows quick iteration on your Fern definition
     - No changes are published to package managers or GitHub
-    
+
     ```bash
     # Preview all SDKs
     fern generate --preview
-    
+
     # Preview specific SDK group
     fern generate --group python-sdk --preview
     ```

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -97,5 +97,5 @@ Use the `--version` option to specify the SDK version number, typically followin
 fern generate --api payments-api --group python-sdk --version 1.2.3
 
 # Generate TypeScript SDK for the auth API with version 0.1.0
-fern generate --api auth --group ts-sdk --version 0.1.0
+fern generate --deep --api auth --group ts-sdk --version 0.1.0
 ```

--- a/fern/products/docs/pages/developer-tools/gitlab.mdx
+++ b/fern/products/docs/pages/developer-tools/gitlab.mdx
@@ -67,9 +67,9 @@ publish_sdks:
   stage: publish_sdks
   rules:
     - if: '$CI_PIPELINE_SOURCE == "web"'
-  script: 
+  script:
       - echo "Publishing SDKs"
-      - fern generate --group ts-sdk --version $VERSION --log-level debug
+      - fern generate --deep --group ts-sdk --version $VERSION --log-level debug
 ```
 </Accordion>
 

--- a/fern/products/sdks/overview/typescript/publishing-to-npm.mdx
+++ b/fern/products/sdks/overview/typescript/publishing-to-npm.mdx
@@ -156,7 +156,7 @@ OIDC-based publishing (also known as "trusted publishing") is the most secure wa
 	Generate your SDK to create the GitHub Actions workflow with OIDC configuration:
 
 	```bash
-	fern generate --group ts-sdk
+	fern generate --deep --group ts-sdk
 	```
 
 	This creates a `.github/workflows/ci.yml` file that's configured to use OIDC for npmjs publishing. Alternatively, you can push your `generators.yml` changes and let the Fern GitHub Action generate the workflow for you.
@@ -296,7 +296,7 @@ jobs:
       - name: Generate and publish SDK
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --group ts-sdk --version ${{ inputs.version }} --log-level debug
+        run: fern generate --deep --group ts-sdk --version ${{ inputs.version }} --log-level debug
 ```
 
 Add your `FERN_TOKEN` as a repository secret (run `fern token` to generate one), then trigger the workflow from the **Actions** tab.
@@ -386,7 +386,7 @@ This is the easiest path if you can upgrade to version 3.12.0 or later of the Ty
 	**Locally:**
 
 	```bash
-	fern generate --group ts-sdk
+	fern generate --deep --group ts-sdk
 	```
 
 	**Or via GitHub Actions:**

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -42,15 +42,15 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ts-sdk
+fern generate --deep --group ts-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ts-sdk --api your-api-name
-  ``` 
+  fern generate --deep --api your-api-name --group ts-sdk
+  ```
 </Note>
 
 <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>


### PR DESCRIPTION
## Summary

This PR updates the documentation to include the `--deep` flag for all TypeScript SDK generation commands.

## Changes

- **CLI Reference**: Added documentation for the `--deep` flag, explaining that it enables deep generation mode recommended for TypeScript SDK generation
- **Code Examples**: Updated all examples showing TypeScript SDK generation to include `--deep` flag:
  - CLI quickstart examples
  - GitHub Actions workflows
  - GitLab CI/CD pipelines
  - Publishing guides
- **Consistency**: Improved formatting and alignment of code examples

## Justification

The `--deep` flag is recommended for TypeScript SDK generation as it enables enhanced processing that benefits the generated output. By updating the documentation to consistently show this flag in all TypeScript SDK examples, we:

1. Ensure users follow best practices from the start
2. Provide consistent patterns across all documentation
3. Reduce confusion about when and how to use the flag
4. Align examples with recommended workflows

All examples now demonstrate the recommended approach for TypeScript SDK generation.