### PR TITLE
Add --deep flag documentation to fern generate command

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -174,9 +174,17 @@ hideOnThisPage: true
 
     <CodeBlock title="terminal">
     ```bash
-    fern generate [--group <group>] [--api <api>] [--version <version>] [--preview]
+    fern generate [--deep] [--group <group>] [--api <api>] [--version <version>] [--preview]
     ```
     </CodeBlock>
+
+    ### deep
+
+    Use `--deep` to enable deep generation mode. This flag is recommended for the latest CLI version and ensures complete SDK generation.
+
+    ```bash
+    fern generate --deep --group ts-sdk
+    ```
 
     ### preview
 
@@ -184,11 +192,11 @@ hideOnThisPage: true
     - Generates SDK into a local `.preview/` folder
     - Allows quick iteration on your Fern definition
     - No changes are published to package managers or GitHub
-    
+
     ```bash
     # Preview all SDKs
     fern generate --preview
-    
+
     # Preview specific SDK group
     fern generate --group python-sdk --preview
     ```

--- a/fern/products/sdks/overview/csharp/quickstart.mdx
+++ b/fern/products/sdks/overview/csharp/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group csharp-sdk
+fern generate --deep --group csharp-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group csharp-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group csharp-sdk --api your-api-name
+  ```
 </Note>
 
 <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group csharp-sdk
+sdks/ # created by fern generate --deep --group csharp-sdk
 ├─ csharp
     └─ src/
         ├─ YourOrganizationApi.sln

--- a/fern/products/sdks/overview/go/quickstart.mdx
+++ b/fern/products/sdks/overview/go/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group go-sdk
+fern generate --deep --group go-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group go-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group go-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group go-sdk
+sdks/ # created by fern generate --deep --group go-sdk
 ├─ go
     ├─ core/
     └─ go.mod

--- a/fern/products/sdks/overview/java/quickstart.mdx
+++ b/fern/products/sdks/overview/java/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group java-sdk
+fern generate --deep --group java-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group java-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group java-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group java-sdk
+sdks/ # created by fern generate --deep --group java-sdk
 ├─ java
     ├─ YourOrganizationApiClient.java
     ├─ core/

--- a/fern/products/sdks/overview/php/quickstart.mdx
+++ b/fern/products/sdks/overview/php/quickstart.mdx
@@ -43,27 +43,27 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group php-sdk
+fern generate --deep --group php-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group php-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group php-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group php-sdk
+sdks/ # created by fern generate --deep --group php-sdk
 ├─ php
     └─ sdk/
         ├─ src/
             ├─ YourOrganizationClient.php
-            └─ Types/ 
+            └─ Types/
         └─ tests/
             └─ Core/
 ```

--- a/fern/products/sdks/overview/postman/quickstart.mdx
+++ b/fern/products/sdks/overview/postman/quickstart.mdx
@@ -46,14 +46,14 @@ groups:
 Run the following command:
 
 ```sh
-fern generate --group postman
+fern generate --deep --group postman
 ```
 
 <Note>
     If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
     ```bash
-    fern generate --group postman --api your-api-name
+    fern generate --deep --group postman --api your-api-name
     ```
 </Note>
 

--- a/fern/products/sdks/overview/python/quickstart.mdx
+++ b/fern/products/sdks/overview/python/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group python-sdk
+fern generate --deep --group python-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group python-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group python-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group python-sdk
+sdks/ # created by fern generate --deep --group python-sdk
 ├─ python
     ├─ __init__.py
     ├─ client.py

--- a/fern/products/sdks/overview/ruby/quickstart.mdx
+++ b/fern/products/sdks/overview/ruby/quickstart.mdx
@@ -43,22 +43,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ruby-sdk
+fern generate --deep --group ruby-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ruby-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group ruby-sdk --api your-api-name
+  ```
 </Note>
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group ruby-sdk
+sdks/ # created by fern generate --deep --group ruby-sdk
 ├─ ruby
     ├─ YourOrganization_api_client.gemspec
     ├─ test/

--- a/fern/products/sdks/overview/swift/quickstart.mdx
+++ b/fern/products/sdks/overview/swift/quickstart.mdx
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
   Run the following command to generate your SDK:
 
   ```bash
-  fern generate --group swift-sdk
+  fern generate --deep --group swift-sdk
   ```
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group swift-sdk
+sdks/ # created by fern generate --deep --group swift-sdk
 ├─ swift
     ├─ Package.swift
     └─ Sources

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -42,22 +42,22 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ts-sdk
+fern generate --deep --group ts-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ts-sdk --api your-api-name
-  ``` 
+  fern generate --deep --group ts-sdk --api your-api-name
+  ```
 </Note>
 
 <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group ts-sdk
+sdks/ # created by fern generate --deep --group ts-sdk
 ├─ typescript
     ├─ Client.ts
     ├─ index.ts


### PR DESCRIPTION
## Summary

This PR updates the documentation to include the new `--deep` flag for the `fern generate` command across all SDK quickstart guides and the CLI reference.

## Changes

- **CLI Reference**: Added documentation for the `--deep` flag, explaining that it enables deep generation mode and is recommended for the latest CLI version to ensure complete SDK generation
- **SDK Quickstarts**: Updated all `fern generate` command examples to include the `--deep` flag across:
  - C# SDK
  - Go SDK
  - Java SDK
  - PHP SDK
  - Python SDK
  - Ruby SDK
  - Swift SDK
  - TypeScript SDK
  - Postman collection

## Justification

The `--deep` flag is an important new CLI feature that ensures complete SDK generation with the latest version. By documenting this flag in the CLI reference and updating all quickstart examples to include it, we help users:

1. Discover and understand the purpose of the `--deep` flag
2. Follow best practices when generating SDKs
3. Avoid potential issues from incomplete SDK generation

This documentation update aligns the examples with current CLI capabilities and recommended usage patterns.