### PR TITLE
Add --deep flag to SDK generation commands in documentation

### DIFF
--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -68,11 +68,11 @@ fern generate --docs --preview    # Preview documentation changes
 fern generate --docs              # Generate and publish documentation
 
 # SDK Development
-fern init                        # Start new SDK project
-fern check                       # Validate API definition
-fern generate --preview          # Preview SDKs in .preview/ folder
-fern generate                    # Generate default SDK group
-fern generate --group ts-sdk     # Generate specific SDK group
+fern init                             # Start new SDK project
+fern check                            # Validate API definition
+fern generate --deep --preview        # Preview SDKs in .preview/ folder
+fern generate --deep                  # Generate default SDK group
+fern generate --deep --group ts-sdk   # Generate specific SDK group
 ```
 
 <Note>
@@ -105,14 +105,14 @@ The "default SDK group" refers to the group marked as default in your `generator
     ```bash
     fern init
     ```
-    
+
     2. Configure your generators in [configuration options](/learn/sdks/introduction/configuration)
-    
+
     3. Generate SDKs:
     ```bash
-    fern generate --preview                     # Preview changes locally
-    fern generate --group python-sdk --preview  # Preview specific SDK group
-    fern generate                               # Publish to production
+    fern generate --deep --preview                     # Preview changes locally
+    fern generate --deep --group python-sdk --preview  # Preview specific SDK group
+    fern generate --deep                               # Publish to production
     ```
 
     <Tip>

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -174,9 +174,17 @@ hideOnThisPage: true
 
     <CodeBlock title="terminal">
     ```bash
-    fern generate [--group <group>] [--api <api>] [--version <version>] [--preview]
+    fern generate [--deep] [--group <group>] [--api <api>] [--version <version>] [--preview]
     ```
     </CodeBlock>
+
+    ### deep
+
+    Use `--deep` to enable deep generation mode. This flag is required on the latest CLI version for SDK generation.
+
+    ```bash
+    fern generate --deep --group ts-sdk
+    ```
 
     ### preview
 
@@ -184,13 +192,13 @@ hideOnThisPage: true
     - Generates SDK into a local `.preview/` folder
     - Allows quick iteration on your Fern definition
     - No changes are published to package managers or GitHub
-    
+
     ```bash
     # Preview all SDKs
-    fern generate --preview
-    
+    fern generate --deep --preview
+
     # Preview specific SDK group
-    fern generate --group python-sdk --preview
+    fern generate --deep --group python-sdk --preview
     ```
 
     ### group
@@ -198,7 +206,7 @@ hideOnThisPage: true
     Use `--group <group>` to filter to a specific group within `generators.yml`. Required unless you have a `default-group` declared.
 
     ```bash
-    fern generate --group internal
+    fern generate --deep --group internal
     ```
 
     ### api
@@ -206,7 +214,7 @@ hideOnThisPage: true
     Use `--api <api>` to specify the API for SDK generation.
 
     ```bash
-    fern generate --api public-api
+    fern generate --deep --api public-api
     ```
 
     ### version
@@ -214,7 +222,7 @@ hideOnThisPage: true
     Use `--version` to specify a version for SDKs and documentation. Adherence to [semantic versioning](https://semver.org/) is advised.
 
     ```bash
-    fern generate --version 2.11
+    fern generate --deep --version 2.11
     ```
 
   </Accordion>

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -9,10 +9,10 @@ subtitle: 'Explore Fern CLI global options.'
 | Option | Description | Example |
 |--------|-------------|---------|
 | [`--help`](#help) | Show command help and options | `fern --help` |
-| [`--log-level`](#log-level) | Set logging verbosity | `fern generate --log-level debug` |
-| [`--api`](#api) | Target specific API | `fern generate --api public-api` |
-| [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
-| [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--log-level`](#log-level) | Set logging verbosity | `fern generate --deep --log-level debug` |
+| [`--api`](#api) | Target specific API | `fern generate --deep --api public-api` |
+| [`--group`](#group) | Target specific generator group | `fern generate --deep --group php-sdk` |
+| [`--version`](#version) | Specify the SDK version number | `fern generate --deep --version 1.2.3` |
 
 <Tip>
 When troubleshooting:
@@ -67,7 +67,7 @@ Available levels (from most to least verbose):
 - `error`: Error messages only
 
 ```bash
-fern generate --log-level debug
+fern generate --deep --log-level debug
 ```
 
 ## api
@@ -76,7 +76,7 @@ Use the `--api` option to target a specific API. This is particularly useful whe
 
 ```bash
 # Generate SDKs for only the "payments-api"
-fern generate --api payments-api
+fern generate --deep --api payments-api
 ```
 
 ## group

--- a/fern/products/sdks/overview/csharp/quickstart.mdx
+++ b/fern/products/sdks/overview/csharp/quickstart.mdx
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group csharp-sdk
+fern generate --deep --group csharp-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group csharp-sdk --api your-api-name
+  fern generate --deep --group csharp-sdk --api your-api-name
   ``` 
 </Note>
 
@@ -57,7 +57,7 @@ fern generate --group csharp-sdk
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group csharp-sdk
+sdks/ # created by fern generate --deep --group csharp-sdk
 ├─ csharp
     └─ src/
         ├─ YourOrganizationApi.sln

--- a/fern/products/sdks/overview/go/quickstart.mdx
+++ b/fern/products/sdks/overview/go/quickstart.mdx
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group go-sdk
+fern generate --deep --group go-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group go-sdk --api your-api-name
+  fern generate --deep --group go-sdk --api your-api-name
   ``` 
 </Note>
 
@@ -57,7 +57,7 @@ fern generate --group go-sdk
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group go-sdk
+sdks/ # created by fern generate --deep --group go-sdk
 ├─ go
     ├─ core/
     └─ go.mod

--- a/fern/products/sdks/overview/java/quickstart.mdx
+++ b/fern/products/sdks/overview/java/quickstart.mdx
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group java-sdk
+fern generate --deep --group java-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group java-sdk --api your-api-name
+  fern generate --deep --group java-sdk --api your-api-name
   ``` 
 </Note>
 
@@ -57,7 +57,7 @@ fern generate --group java-sdk
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group java-sdk
+sdks/ # created by fern generate --deep --group java-sdk
 ├─ java
     ├─ YourOrganizationApiClient.java
     ├─ core/

--- a/fern/products/sdks/overview/php/quickstart.mdx
+++ b/fern/products/sdks/overview/php/quickstart.mdx
@@ -43,14 +43,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group php-sdk
+fern generate --deep --group php-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group php-sdk --api your-api-name
+  fern generate --deep --group php-sdk --api your-api-name
   ``` 
 </Note>
 
@@ -58,7 +58,7 @@ fern generate --group php-sdk
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group php-sdk
+sdks/ # created by fern generate --deep --group php-sdk
 ├─ php
     └─ sdk/
         ├─ src/

--- a/fern/products/sdks/overview/postman/quickstart.mdx
+++ b/fern/products/sdks/overview/postman/quickstart.mdx
@@ -46,14 +46,14 @@ groups:
 Run the following command:
 
 ```sh
-fern generate --group postman
+fern generate --deep --group postman
 ```
 
 <Note>
     If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
     ```bash
-    fern generate --group postman --api your-api-name
+    fern generate --deep --group postman --api your-api-name
     ```
 </Note>
 

--- a/fern/products/sdks/overview/python/quickstart.mdx
+++ b/fern/products/sdks/overview/python/quickstart.mdx
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group python-sdk
+fern generate --deep --group python-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group python-sdk --api your-api-name
+  fern generate --deep --group python-sdk --api your-api-name
   ``` 
 </Note>
 
@@ -57,7 +57,7 @@ fern generate --group python-sdk
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group python-sdk
+sdks/ # created by fern generate --deep --group python-sdk
 ├─ python
     ├─ __init__.py
     ├─ client.py

--- a/fern/products/sdks/overview/ruby/quickstart.mdx
+++ b/fern/products/sdks/overview/ruby/quickstart.mdx
@@ -43,14 +43,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ruby-sdk
+fern generate --deep --group ruby-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ruby-sdk --api your-api-name
+  fern generate --deep --group ruby-sdk --api your-api-name
   ``` 
 </Note>
 
@@ -58,7 +58,7 @@ fern generate --group ruby-sdk
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group ruby-sdk
+sdks/ # created by fern generate --deep --group ruby-sdk
 ├─ ruby
     ├─ YourOrganization_api_client.gemspec
     ├─ test/

--- a/fern/products/sdks/overview/swift/quickstart.mdx
+++ b/fern/products/sdks/overview/swift/quickstart.mdx
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
   Run the following command to generate your SDK:
 
   ```bash
-  fern generate --group swift-sdk
+  fern generate --deep --group swift-sdk
   ```
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group swift-sdk
+sdks/ # created by fern generate --deep --group swift-sdk
 ├─ swift
     ├─ Package.swift
     └─ Sources

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ts-sdk
+fern generate --deep --group ts-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ts-sdk --api your-api-name
+  fern generate --deep --group ts-sdk --api your-api-name
   ``` 
 </Note>
 
@@ -57,7 +57,7 @@ fern generate --group ts-sdk
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group ts-sdk
+sdks/ # created by fern generate --deep --group ts-sdk
 ├─ typescript
     ├─ Client.ts
     ├─ index.ts


### PR DESCRIPTION
## Summary

This PR updates all documentation to include the `--deep` flag when using `fern generate` commands for SDK generation. The `--deep` flag is now required on the latest CLI version for SDK generation.

## Changes

Updated the following documentation files:
- **CLI reference documentation**: Added `--deep` flag to all `fern generate` examples and command descriptions
- **SDK quickstart guides**: Updated generation commands for all supported languages (C#, Go, Java, PHP, Python, Ruby, Swift, TypeScript)
- **Postman integration**: Updated Postman collection generation commands

## Justification

The `--deep` flag enables deep generation mode and is now a required parameter for SDK generation in the latest version of the Fern CLI. This documentation update ensures users follow the correct syntax when generating SDKs, preventing confusion and errors.

All command examples now consistently show:
```bash
fern generate --deep --group <sdk-group>
```

Instead of the previous format:
```bash
fern generate --group <sdk-group>
```