### PR TITLE
Add documentation for fern deep command

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to our co-founder, Deep |
 
 ## Documentation commands
 
@@ -586,5 +587,48 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful when you need to reach out about important matters, provide feedback, or discuss your Fern experience.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the subject line of your email.
+
+    ```bash
+    fern deep --subject "Feature Request: New SDK Language"
+    ```
+
+    ### message
+
+    Use `--message` to include the body content of your email.
+
+    ```bash
+    fern deep --message "I'd love to see support for Rust SDKs"
+    ```
+
+    ### Interactive mode
+
+    If you run `fern deep` without any flags, the CLI will prompt you interactively to compose your email:
+
+    ```bash
+    fern deep
+    ```
+
+    <Tip>
+    You can combine both flags to send a complete email in one command:
+    ```bash
+    fern deep --subject "Great work!" --message "The new docs feature is amazing!"
+    ```
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the new `fern deep` command to the CLI API reference.

## Changes

- Added `fern deep` command entry to the commands table
- Created detailed documentation section with usage examples
- Documented command flags: `--subject` and `--message`
- Included examples for both flag-based and interactive usage modes
- Added tip for combining both flags in a single command

## Purpose

The `fern deep` command provides users with a direct way to send emails to Deep, the co-founder, for feedback, feature requests, or important communications. This documentation ensures users understand how to use this feature effectively.