### PR TITLE
Add fern deep command documentation

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, a Fern co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,47 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email to Deep, one of Fern's co-founders. This command is useful when you need to reach out directly to discuss your API tooling needs, share feedback, or get personalized assistance.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When run without options, the command will interactively prompt you for a subject and message before sending the email.
+
+    ### subject
+
+    Use `--subject` to specify the email subject line directly from the command line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to include the email body directly from the command line.
+
+    ```bash
+    fern deep --message "I'd love to discuss custom SDK features for my API"
+    ```
+
+    ### Example
+
+    Send a complete email in one command:
+
+    ```bash
+    fern deep --subject "API Design Consultation" --message "Hi Deep, I'd like to schedule a call to discuss best practices for our API design."
+    ```
+
+    <Note>
+    Deep typically responds within 24-48 hours during business days.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `fern deep` command to the CLI reference.

## Changes

- Added `fern deep` to the commands table
- Created comprehensive documentation section including:
  - Command description and usage
  - `--subject` flag for specifying email subject
  - `--message` flag for including email body
  - Interactive mode when run without options
  - Usage examples
  - Response time expectations

## Rationale

The `fern deep` command provides users with a direct channel to reach out to Deep, one of Fern's co-founders, for personalized assistance, feedback, or discussions about API tooling needs. This documentation ensures users understand how to use the command effectively and what to expect when using it.