### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email our co-founder, Deep |
 
 ## Documentation commands
 
@@ -579,12 +580,38 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to our co-founder, Deep. This command is useful when you need personalized assistance or want to share feedback about Fern.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>]
+    ```
+    </CodeBlock>
+
+    When run without options, this command will open an interactive prompt where you can compose your message.
+
+    ### message
+
+    Use `--message` to include your message directly in the command.
+
+    ```bash
+    fern deep --message "Love the new SDK features!"
+    ```
+
+    <Note>
+    Deep personally reads every message sent through this command. Expect a response within 24-48 hours.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference. The command allows users to send emails directly to our co-founder, Deep.

## Changes

- Added `fern deep` command to the main CLI commands table
- Created detailed documentation section with usage examples and options
- Documented the `--message` flag for inline message composition
- Added a note about response time expectations

## Documentation Preview

The new command documentation includes:
- Command syntax: `fern deep [--message <message>]`
- Interactive mode for composing messages
- Direct message mode using the `--message` flag
- Usage examples