### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, Fern's co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,56 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command opens your default email client with a pre-filled email address.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    This is useful when you need to reach out to Deep for:
+    - Enterprise inquiries
+    - Partnership discussions
+    - Technical feedback or feature requests
+    - Direct support on complex implementation issues
+
+    ### subject
+
+    Use `--subject` to pre-fill the email subject line:
+
+    ```bash
+    fern deep --subject "Enterprise pricing inquiry"
+    ```
+
+    ### message
+
+    Use `--message` to pre-fill the email body:
+
+    ```bash
+    fern deep --message "I'd like to discuss using Fern for our API documentation needs."
+    ```
+
+    You can combine both options:
+
+    ```bash
+    fern deep --subject "Feature Request" --message "Would love to see support for GraphQL in the future!"
+    ```
+
+    <Note>
+    This command requires an email client to be configured on your system. The email will open in your default mail application.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces a new `fern deep` command to the CLI reference documentation. The command allows users to send emails directly to Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` to the main commands table
- Created a detailed accordion section documenting the command
- Included documentation for optional `--subject` and `--message` flags
- Added usage examples and a note about email client requirements

## Use Cases

The command is useful for:
- Enterprise inquiries
- Partnership discussions
- Technical feedback or feature requests
- Direct support on complex implementation issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)