### PR TITLE
Update TypeScript SDK documentation to include --deep flag

### DIFF
--- a/examples/sdks/typescript-publish.yml
+++ b/examples/sdks/typescript-publish.yml
@@ -29,4 +29,4 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          fern generate --group ts-sdk --version ${{ inputs.version }} --log-level debug
+          fern generate --deep --group ts-sdk --version ${{ inputs.version }} --log-level debug

--- a/fern/products/docs/pages/developer-tools/gitlab.mdx
+++ b/fern/products/docs/pages/developer-tools/gitlab.mdx
@@ -67,9 +67,9 @@ publish_sdks:
   stage: publish_sdks
   rules:
     - if: '$CI_PIPELINE_SOURCE == "web"'
-  script: 
+  script:
       - echo "Publishing SDKs"
-      - fern generate --group ts-sdk --version $VERSION --log-level debug
+      - fern generate --deep --group ts-sdk --version $VERSION --log-level debug
 ```
 </Accordion>
 

--- a/fern/products/sdks/overview/typescript/publishing-to-npm.mdx
+++ b/fern/products/sdks/overview/typescript/publishing-to-npm.mdx
@@ -156,7 +156,7 @@ OIDC-based publishing (also known as "trusted publishing") is the most secure wa
 	Generate your SDK to create the GitHub Actions workflow with OIDC configuration:
 
 	```bash
-	fern generate --group ts-sdk
+	fern generate --deep --group ts-sdk
 	```
 
 	This creates a `.github/workflows/ci.yml` file that's configured to use OIDC for npmjs publishing. Alternatively, you can push your `generators.yml` changes and let the Fern GitHub Action generate the workflow for you.
@@ -296,7 +296,7 @@ jobs:
       - name: Generate and publish SDK
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --group ts-sdk --version ${{ inputs.version }} --log-level debug
+        run: fern generate --deep --group ts-sdk --version ${{ inputs.version }} --log-level debug
 ```
 
 Add your `FERN_TOKEN` as a repository secret (run `fern token` to generate one), then trigger the workflow from the **Actions** tab.
@@ -386,7 +386,7 @@ This is the easiest path if you can upgrade to version 3.12.0 or later of the Ty
 	**Locally:**
 
 	```bash
-	fern generate --group ts-sdk
+	fern generate --deep --group ts-sdk
 	```
 
 	**Or via GitHub Actions:**

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ts-sdk
+fern generate --deep --group ts-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ts-sdk --api your-api-name
+  fern generate --deep --group ts-sdk --api your-api-name
   ``` 
 </Note>
 
@@ -57,7 +57,7 @@ fern generate --group ts-sdk
 
 ```bash
 fern/ # created by fern init
-sdks/ # created by fern generate --group ts-sdk
+sdks/ # created by fern generate --deep --group ts-sdk
 ├─ typescript
     ├─ Client.ts
     ├─ index.ts


### PR DESCRIPTION
## Summary

Updated TypeScript SDK documentation to include the `--deep` flag for all `fern generate` commands. This flag is required in the latest CLI version for proper TypeScript SDK generation.

## Changes

- **TypeScript Quickstart Guide**: Added `--deep` flag to all TypeScript SDK generation commands
- **TypeScript NPM Publishing Guide**: Updated all generation examples including:
  - OIDC authentication setup
  - Manual workflow dispatch examples
  - Migration paths for OIDC
- **GitLab CI/CD Configuration**: Updated the TypeScript SDK publishing step
- **Example Workflow**: Updated `typescript-publish.yml` template

## Test Plan

- ✅ Updated all occurrences of `fern generate --group ts-sdk` to `fern generate --deep --group ts-sdk`
- ✅ Verified consistency across all TypeScript SDK documentation files
- ✅ Maintained proper formatting and code block syntax

## Related

Based on user feedback that the `--deep` flag is required for the latest CLI version when generating TypeScript SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)