### PR TITLE
Document scribe mode for Fern Slackbot collaborative editing

### DIFF
--- a/fern/products/ask-fern/pages/features/slack-app.mdx
+++ b/fern/products/ask-fern/pages/features/slack-app.mdx
@@ -81,6 +81,28 @@ You can rename the bot to match your brand (example: "YourCompanyName Support"):
 
 Now customers will see `@YourCompanyName Support was added to the channel` instead of the default `@Ask Fern` name.
 
+### Scribe mode for collaborative docs editing
+
+The Ask Fern Slack bot includes a `` mode that enables collaborative, multi-turn documentation editing sessions directly in Slack. This allows teams to work together on documentation updates in real-time, with the bot acting as an AI assistant that helps draft, revise, and refine content.
+
+How it works:
+
+1. **Start a scribe session** - Mention the bot with `` to initiate a collaborative editing session
+2. **Provide context** - Share what documentation needs to be updated, created, or improved
+3. **Collaborate iteratively** - The bot will draft content suggestions, and you can provide feedback to refine them
+4. **Multi-turn refinement** - Continue the conversation to iterate on the content until it meets your needs
+5. **Finalize changes** - Once satisfied, you can approve the changes for implementation
+
+`` mode is ideal for:
+- Creating new documentation sections collaboratively
+- Refining existing content based on team feedback
+- Brainstorming documentation structure and content
+- Iterating on technical writing with AI assistance
+
+<Note>
+`` mode maintains context throughout the conversation, allowing for natural back-and-forth refinement of documentation content.
+</Note>
+
 ### Collaborative FAQ generation
 
 You can improve the Slack bot's knowledge base by teaching it from real customer interactions. When the bot provides answers in Slack, you can refine those responses and save them for future reference.


### PR DESCRIPTION
## Summary

This PR documents the new `<scribe>` mode feature for the Fern Slackbot, which enables collaborative, multi-turn documentation editing sessions directly in Slack.

## Changes

- Added a new section "Scribe mode for collaborative docs editing" to the Ask Fern Slack app documentation
- Documented how teams can use `<scribe>` mode to collaboratively create and refine documentation
- Explained the multi-turn refinement workflow and ideal use cases

## Related

This documentation corresponds to the implementation in [fern-platform#4478](https://github.com/fern-api/fern-platform/pull/4478).

## Files Modified

- `fern/products/ask-fern/pages/features/slack-app.mdx` - Added scribe mode documentation

---
*Generated with Claude Code*