### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email our co-founder Deep |
 
 ## Documentation commands
 
@@ -579,12 +580,46 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command provides a direct line of communication for feedback, questions, or insights about your Fern experience.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--subject <subject>]
+    ```
+    </CodeBlock>
+
+    When run without options, the command will open an interactive prompt to compose your message.
+
+    ### message
+
+    Use `--message` to specify the email body directly from the command line.
+
+    ```bash
+    fern deep --message "Love the new SDK generator features!"
+    ```
+
+    ### subject
+
+    Use `--subject` to specify the email subject. If not provided, a default subject will be used.
+
+    ```bash
+    fern deep --subject "Feature Request" --message "It would be great to have..."
+    ```
+
+    <Note>
+    Deep personally reads all messages sent through this command and aims to respond within 24-48 hours.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference. The command provides users with a direct way to email Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` to the main commands table
- Created detailed documentation with usage examples
- Documented command options:
  - `--message`: Specify email body from command line
  - `--subject`: Specify email subject
- Noted that interactive mode is available when flags are not provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)