### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,44 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful when you need to reach out with questions, feedback, or just want to say hello!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--subject <subject>]
+    ```
+    </CodeBlock>
+
+    ### message
+
+    Use `--message` to include a custom message in your email to Deep.
+
+    ```bash
+    fern deep --message "Love the new SDK features!"
+    ```
+
+    ### subject
+
+    Use `--subject` to specify a custom subject line for your email.
+
+    ```bash
+    fern deep --subject "Feature Request" --message "Would love to see GraphQL support"
+    ```
+
+    <Tip>
+    Deep reads every email personally and tries to respond to everyone. Feel free to share your thoughts, ideas, or just connect!
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command that enables users to send emails directly to Deep, our co-founder.

## Changes

- **CLI Commands Table**: Added `fern deep` entry to the main commands reference table
- **Detailed Documentation**: Created a comprehensive accordion section with:
  - Command overview and description
  - `--message` flag for custom email content
  - `--subject` flag for custom subject lines
  - Usage examples demonstrating both flags
  - Helpful tip about Deep's personal engagement with the community

## Example Usage

```bash
# Send a simple email
fern deep --message "Love the new SDK features!"

# Include a subject line
fern deep --subject "Feature Request" --message "Would love to see GraphQL support"
```

The command follows the same documentation patterns and formatting as other CLI commands in the reference.