### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email our co-founder, Deep |
 
 ## Documentation commands
 
@@ -586,5 +587,39 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful when you need assistance, have feedback, or want to reach out to the Fern team.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When run without options, the command will open an interactive prompt to compose your message.
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to include the email body directly in the command.
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for..."
+    ```
+
+    <Note>
+    You can also run `fern deep` without any options to compose your email interactively.
+    </Note>
+
   </Accordion>
 </AccordionGroup>

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,7 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
-| [`fern deep`](#fern-deep) | Email our co-founder, Deep |
+| [`fern --dsinghvi`](#fern---dsinghvi) | Email our co-founder, Deep |
 
 ## Documentation commands
 
@@ -589,24 +589,24 @@ hideOnThisPage: true
   </CodeBlock>
   </Accordion>
 
-  <Accordion title="fern deep">
+  <Accordion title="fern --dsinghvi">
 
-    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful when you need assistance, have feedback, or want to reach out to the Fern team.
+    Use `fern --dsinghvi` to send an email directly to Deep, our co-founder. This command is useful when you need assistance, have feedback, or want to reach out to the Fern team.
 
     <CodeBlock title="terminal">
     ```bash
-    fern deep [--subject <subject>] [--message <message>]
+    fern --dsinghvi [--subject <subject>] [--message <message>]
     ```
     </CodeBlock>
 
-    When run without options, the command will open an interactive prompt to compose your message.
+    When run without additional options, the command will open an interactive prompt to compose your message.
 
     ### subject
 
     Use `--subject` to specify the email subject line.
 
     ```bash
-    fern deep --subject "Question about SDK generation"
+    fern --dsinghvi --subject "Question about SDK generation"
     ```
 
     ### message
@@ -614,11 +614,11 @@ hideOnThisPage: true
     Use `--message` to include the email body directly in the command.
 
     ```bash
-    fern deep --subject "Feature request" --message "Would love to see support for..."
+    fern --dsinghvi --subject "Feature request" --message "Would love to see support for..."
     ```
 
     <Note>
-    You can also run `fern deep` without any options to compose your email interactively.
+    You can also run `fern --dsinghvi` without any additional options to compose your email interactively.
     </Note>
 
   </Accordion>


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `fern deep` command to the CLI reference. This command allows users to send emails directly to Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` command entry to the main commands table
- Created detailed accordion documentation section with:
  - Command overview and usage
  - `--subject` option for specifying email subject
  - `--message` option for including email body
  - Note about interactive mode when run without options
  - Example usage for both inline and interactive modes

## Documentation Preview

The command appears in the main table alongside other CLI commands and includes full documentation with examples of how to use it with optional flags or in interactive mode.