### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to our co-founder, Deep |
 
 ## Documentation commands
 
@@ -579,12 +580,47 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command opens a compose window in your default email client with Deep's address pre-filled.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to pre-fill the email subject line.
+
+    ```bash
+    fern deep --subject "Feature request"
+    ```
+
+    ### message
+
+    Use `--message` to pre-fill the email body with your message.
+
+    ```bash
+    fern deep --message "I have an idea about improving the docs experience..."
+    ```
+
+    <Tip>
+    You can also combine both options to craft a complete email from the command line:
+    ```bash
+    fern deep --subject "Quick question" --message "How do I configure multiple API instances?"
+    ```
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces a new `fern deep` command to the CLI reference documentation. This command allows users to send an email directly to Deep, our co-founder.

## Changes

- Added `fern deep` command to the main commands table
- Created detailed documentation section with:
  - Basic command usage
  - `--subject` flag for pre-filling email subject
  - `--message` flag for pre-filling email body
  - Example usage combining both flags

## Documentation

The new command includes clear examples and follows the existing documentation patterns for other CLI commands.

📝 Generated with [Claude Code](https://claude.com/claude-code)