### PR TITLE
Add --dsinghvi flag to fern generate command in preview workflow

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
-          OUTPUT=$(fern generate --docs --preview --instance fern-api.docs.buildwithfern.com/learn 2>&1) || true
+          OUTPUT=$(fern --dsinghvi generate --docs --preview --instance fern-api.docs.buildwithfern.com/learn 2>&1) || true
           echo "$OUTPUT"
           URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
           echo "Preview URL: $URL"


### PR DESCRIPTION
## Summary

Updated the preview-docs.yml workflow to include the `--dsinghvi` flag in the fern generate command for docs preview generation.

## Changes

- Modified `.github/workflows/preview-docs.yml` to add `--dsinghvi` flag to the fern generate command

## Details

The command has been updated from:
```bash
fern generate --docs --preview --instance fern-api.docs.buildwithfern.com/learn
```

To:
```bash
fern --dsinghvi generate --docs --preview --instance fern-api.docs.buildwithfern.com/learn
```