### PR TITLE
Add fern --dsinghvi command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern --dsinghvi`](#fern---dsinghvi) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,46 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern --dsinghvi">
+
+    Use `fern --dsinghvi` to send an email directly to Deep, our co-founder. This command is useful when you need to reach out to Deep with questions, feedback, or important updates about your Fern project.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern --dsinghvi [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern --dsinghvi --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern --dsinghvi --subject "Feature request" --message "Would love to see support for..."
+    ```
+
+    If no options are provided, the command will open an interactive prompt to compose your email.
+
+    <Tip>
+    Deep loves hearing from the community! Don't hesitate to reach out with questions, suggestions, or just to say hi.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
- Added the new `fern --dsinghvi` command to the CLI reference documentation
- The command allows users to send emails directly to Deep Singh, our co-founder
- Includes support for `--subject` and `--message` flags, with an interactive mode when no flags are provided
- Updated both the main commands table and added a detailed accordion section with usage examples

## Changes
- Updated `fern/products/cli-api-reference/pages/commands.mdx` to include the new command documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)