### PR TITLE
Add 'fern deep' command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,46 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command is perfect for when you need to reach out with feedback, questions, or just want to say hello!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--subject <subject>]
+    ```
+    </CodeBlock>
+
+    When you run this command, it will compose and send an email to Deep on your behalf. If you don't provide a message or subject, the CLI will prompt you interactively.
+
+    ### message
+
+    Use `--message` to specify the content of your email:
+
+    ```bash
+    fern deep --message "Love the new SDK generation features!"
+    ```
+
+    ### subject
+
+    Use `--subject` to set a custom subject line for your email:
+
+    ```bash
+    fern deep --subject "Feature Request" --message "Would love to see support for..."
+    ```
+
+    <Tip>
+    Deep loves hearing from the community! Don't hesitate to share your thoughts, ideas, or feedback.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
Introduces a new `fern deep` command to the CLI reference documentation that allows users to send emails directly to Deep, one of Fern's co-founders.

## Changes
- Added `fern deep` entry to the main commands reference table
- Created comprehensive documentation including:
  - Command overview and description
  - `--message` flag for specifying email content
  - `--subject` flag for custom subject lines
  - Interactive prompting when flags are omitted
  - Usage examples demonstrating different invocation patterns
  - Tip encouraging community engagement with Deep

## Documentation
The new command is documented alongside existing CLI commands and follows the same format and style conventions used throughout the CLI reference.