### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -12,6 +12,7 @@ hideOnThisPage: true
 | [`fern upgrade`](#fern-upgrade) | Update Fern CLI & generators to latest versions |
 | [`fern login`](#fern-login) | Login to Fern CLI via GitHub or Google |
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
+| [`fern deep`](#fern-deep) | Email Deep, our co-founder, for support |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
 
@@ -374,7 +375,7 @@ hideOnThisPage: true
 
   <Accordion title="fern logout">
 
-    Use `fern logout` to log out of the Fern CLI. This will clear your authentication 
+    Use `fern logout` to log out of the Fern CLI. This will clear your authentication
     credentials and revoke access to your GitHub organizations and permissions.
 
     <CodeBlock title="terminal">
@@ -384,6 +385,40 @@ hideOnThisPage: true
     </CodeBlock>
 
     After logging out, you'll need to run [`fern login`](#fern-login) again to access protected features.
+
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder, for assistance or feedback.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--urgent]
+    ```
+    </CodeBlock>
+
+    This command opens your default email client with a pre-addressed message to Deep, making it easy to reach out for support, share feedback, or discuss your project needs.
+
+    ### message
+
+    Use `--message` to include a pre-populated message in the email.
+
+    ```bash
+    fern deep --message "I need help with SDK generation"
+    ```
+
+    ### urgent
+
+    Use `--urgent` to mark the email as high priority.
+
+    ```bash
+    fern deep --urgent
+    ```
+
+    <Note>
+    Deep loves hearing from users! Don't hesitate to reach out with questions, suggestions, or just to say hi.
+    </Note>
 
   </Accordion>
 


### PR DESCRIPTION
## Summary
- Added new `fern deep` command to the CLI reference documentation
- Command allows users to email Deep, our co-founder, directly from the CLI
- Includes support for `--message` and `--urgent` flags

## Changes
- Updated the CLI commands summary table to include `fern deep`
- Added detailed accordion section with usage examples and options
- Positioned logically after `fern logout` command in the documentation

## Test plan
- [x] Documentation builds successfully
- [x] Command reference formatting is consistent with existing commands
- [x] Links and anchors work correctly