### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -73,6 +73,9 @@ fern check                       # Validate API definition
 fern generate --preview          # Preview SDKs in .preview/ folder
 fern generate                    # Generate default SDK group
 fern generate --group ts-sdk     # Generate specific SDK group
+
+# Get Help
+fern deep                        # Email Deep, co-founder of Fern
 ```
 
 <Note>

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, co-founder of Fern |
 
 ## Documentation commands
 
@@ -586,5 +587,47 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+  <Accordion title="fern deep">
+
+  Use `fern deep` to send an email directly to Deep, co-founder of Fern. This command is perfect for
+  when you need to reach out with feedback, questions, or just want to say hello.
+
+  <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+  </CodeBlock>
+
+  Running the command without options will open an interactive prompt to compose your email.
+
+  ### subject
+
+  Use `--subject` to specify the email subject line.
+
+  ```bash
+  fern deep --subject "Feature request for SDK generation"
+  ```
+
+  ### message
+
+  Use `--message` to include the body of your email.
+
+  ```bash
+  fern deep --subject "Quick question" --message "How can I customize the generated SDK output?"
+  ```
+
+  ### Example
+
+  Send a complete email in one command:
+
+  ```bash
+  fern deep --subject "Love the docs!" --message "The new documentation features are amazing. Thanks for building such a great tool!"
+  ```
+
+  <Tip>
+  Deep reads every message personally and aims to respond within 24 hours. Feel free to share feedback, ask questions, or just say hi!
+  </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command that allows users to email Deep, co-founder of Fern, directly from the CLI.

## Changes

- **Added command to main table**: The `fern deep` command now appears in the main CLI commands reference table
- **Detailed documentation**: Created a comprehensive accordion section explaining:
  - Command usage and syntax
  - `--subject` and `--message` flags
  - Interactive mode when no flags are provided
  - Complete example showing how to send an email
  - Helpful tip about response time
- **Quick reference**: Added to the CLI quickstart section under "Get Help" for easy discovery

## Example Usage

```bash
# Interactive mode
fern deep

# Quick email with flags
fern deep --subject "Feature request" --message "Would love to see X feature!"
```

This makes it easy for users to reach out with feedback, questions, or just to say hello!