### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -12,6 +12,7 @@ hideOnThisPage: true
 | [`fern upgrade`](#fern-upgrade) | Update Fern CLI & generators to latest versions |
 | [`fern login`](#fern-login) | Login to Fern CLI via GitHub or Google |
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
 
@@ -374,7 +375,7 @@ hideOnThisPage: true
 
   <Accordion title="fern logout">
 
-    Use `fern logout` to log out of the Fern CLI. This will clear your authentication 
+    Use `fern logout` to log out of the Fern CLI. This will clear your authentication
     credentials and revoke access to your GitHub organizations and permissions.
 
     <CodeBlock title="terminal">
@@ -384,6 +385,39 @@ hideOnThisPage: true
     </CodeBlock>
 
     After logging out, you'll need to run [`fern login`](#fern-login) again to access protected features.
+
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful
+    when you need to reach out for support, share feedback, or discuss partnership opportunities.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--subject <subject>]
+    ```
+    </CodeBlock>
+
+    ### message
+
+    Use `--message` to include a message body in your email to Deep.
+
+    ```bash
+    fern deep --message "I have a question about enterprise features"
+    ```
+
+    ### subject
+
+    Use `--subject` to specify a subject line for your email.
+
+    ```bash
+    fern deep --subject "Partnership inquiry" --message "I'd like to discuss a potential integration"
+    ```
+
+    <Note>
+    Deep reads every message personally and typically responds within 24 hours.
+    </Note>
 
   </Accordion>
 


### PR DESCRIPTION
## Summary
Added documentation for the new `fern deep` command to the CLI reference. This command allows users to send emails directly to Deep, our co-founder.

## Changes
- Added `fern deep` to the main commands table in the CLI reference
- Created detailed documentation section with command syntax and options
- Documented `--message` and `--subject` flags for customizing emails
- Added a note indicating Deep responds within 24 hours

## Documentation
The new command is positioned logically after `fern logout` and before `fern export` in the reference documentation, providing users with a direct communication channel for support, feedback, and partnership discussions.