### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,37 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful
+    when you need to reach out to our leadership team with feedback, questions, or important matters.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "API feedback"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for GraphQL"
+    ```
+
+    <Note>
+    If you don't provide a subject or message via flags, the CLI will prompt you interactively.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference that allows users to email Deep, our co-founder, directly from the CLI.

## Changes

- Added `fern deep` command to the main commands table
- Created detailed documentation in an accordion section including:
  - Command syntax and usage
  - `--subject` flag for specifying email subject
  - `--message` flag for including message content
  - Note about interactive prompts when flags aren't provided

## Documentation Structure

The new command follows the existing documentation patterns and is placed alongside other core CLI commands like `fern login`, `fern logout`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)