### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, Fern's co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,59 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command provides a direct channel for urgent questions, feedback, or support requests.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When run without flags, the command will open an interactive prompt where you can compose your email:
+
+    ```bash
+    fern deep
+    # Opens interactive prompt for subject and message
+    ```
+
+    ### subject
+
+    Use `--subject` to specify the email subject line directly from the command line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to provide the email body directly from the command line.
+
+    ```bash
+    fern deep --message "I'm having an issue with TypeScript SDK generation for my API."
+    ```
+
+    ### Combined usage
+
+    You can combine both flags to send an email without an interactive prompt:
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for GraphQL schemas in a future release."
+    ```
+
+    <Tip>
+    Deep typically responds within 24-48 hours. For urgent technical issues, consider also checking our [Discord community](https://discord.com/invite/JkkXumPzcG) or [GitHub issues](https://github.com/fern-api/fern/issues).
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces documentation for a new `fern deep` command in the CLI reference that allows users to send emails directly to Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` command to the main commands table
- Created detailed accordion documentation section with:
  - Command overview and usage
  - `--subject` flag for specifying email subject
  - `--message` flag for providing email body
  - Examples of interactive and non-interactive usage
  - Helpful tip about response times and alternative support channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)