### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,47 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command
+    opens a convenient way to reach out with questions, feedback, or just to say hello!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When you run `fern deep`, it will compose an email to Deep with your message. If no subject
+    or message is provided, your default email client will open with a pre-addressed email.
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern deep --message "I have a question about customizing TypeScript SDK output..."
+    ```
+
+    You can combine both options for a complete email:
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for..."
+    ```
+
+    <Tip>
+    Deep loves hearing from users! Don't hesitate to reach out with questions, suggestions, or feedback about your experience with Fern.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command that allows users to email Deep, one of Fern's co-founders.

## Changes

- **Added to commands table**: Listed `fern deep` in the main CLI commands reference table
- **Detailed documentation**: Created an accordion section with comprehensive usage examples
- **Command options**: Documented `--subject` and `--message` flags for email composition
- **User-friendly tip**: Added encouragement for users to reach out with questions and feedback

## Example Usage

```bash
# Basic usage
fern deep

# With subject
fern deep --subject "Question about SDK generation"

# With message
fern deep --message "I have a question about customizing TypeScript SDK output..."

# Combined
fern deep --subject "Feature request" --message "Would love to see support for..."
```

The documentation follows the existing pattern and style used for other CLI commands in the reference.