### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,37 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of our co-founders. This command is useful when you need to reach out with feedback, questions, or ideas about Fern.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the subject line of your email.
+
+    ```bash
+    fern deep --subject "Feature request for new generator"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern deep --subject "Quick question" --message "I have a question about SDK generation..."
+    ```
+
+    <Note>
+    If you don't provide a subject or message via flags, the CLI will prompt you interactively to compose your email.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces documentation for the new `fern deep` command to the CLI reference, allowing users to send emails directly to Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` entry to the main CLI commands reference table
- Created detailed accordion section documenting the command's usage
- Documented command-line flags:
  - `--subject`: Specify the email subject line
  - `--message`: Provide the email message body
- Added note about interactive email composition when flags are omitted

## Documentation Structure

The new command follows the existing documentation pattern with:
- Command synopsis and description
- Code examples for common use cases
- Flag documentation with usage examples
- Helpful notes for users

This makes it easy for Fern users to reach out directly with feedback, questions, or ideas about the platform.