### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -12,6 +12,7 @@ hideOnThisPage: true
 | [`fern upgrade`](#fern-upgrade) | Update Fern CLI & generators to latest versions |
 | [`fern login`](#fern-login) | Login to Fern CLI via GitHub or Google |
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
+| [`fern deep`](#fern-deep) | Email our co-founder Deep |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
 
@@ -374,7 +375,7 @@ hideOnThisPage: true
 
   <Accordion title="fern logout">
 
-    Use `fern logout` to log out of the Fern CLI. This will clear your authentication 
+    Use `fern logout` to log out of the Fern CLI. This will clear your authentication
     credentials and revoke access to your GitHub organizations and permissions.
 
     <CodeBlock title="terminal">
@@ -384,6 +385,45 @@ hideOnThisPage: true
     </CodeBlock>
 
     After logging out, you'll need to run [`fern login`](#fern-login) again to access protected features.
+
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful
+    when you need to reach out for support, feedback, or to discuss your Fern experience.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the subject line of your email.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern deep --message "I have a question about custom generators"
+    ```
+
+    You can also combine both options:
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for X"
+    ```
+
+    <Note>
+    If you don't provide subject or message flags, the CLI will open an interactive prompt to compose your email.
+    </Note>
 
   </Accordion>
 


### PR DESCRIPTION
## Summary

This PR introduces the `fern deep` command to the CLI reference documentation. This new command allows users to email our co-founder Deep directly from the Fern CLI.

## Changes

- Added `fern deep` command to the main commands table in the CLI reference
- Created detailed documentation in an accordion section including:
  - Command overview and usage
  - `--subject` flag for specifying email subject
  - `--message` flag for including message body
  - Examples showing individual and combined flag usage
  - Note about interactive prompt fallback when flags are not provided

The command is positioned after `fern logout` in the documentation, maintaining logical grouping with other authentication/user commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)