### PR TITLE
Add 'fern deep' command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -12,6 +12,7 @@ hideOnThisPage: true
 | [`fern upgrade`](#fern-upgrade) | Update Fern CLI & generators to latest versions |
 | [`fern login`](#fern-login) | Login to Fern CLI via GitHub or Google |
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
+| [`fern deep`](#fern-deep) | Email our co-founder, Deep |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
 
@@ -384,6 +385,33 @@ hideOnThisPage: true
     </CodeBlock>
 
     After logging out, you'll need to run [`fern login`](#fern-login) again to access protected features.
+
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. Whether you have
+    feedback, questions, or just want to say hi, Deep is always happy to hear from you!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### message
+
+    Use `--message` to include a specific message in your email to Deep.
+
+    ```bash
+    fern deep --message "Love the new SDK features!"
+    ```
+
+    Without the `--message` flag, the command will open your default email client with Deep's email pre-populated.
+
+    <Tip>
+    Deep reads every message personally and tries to respond to all of them!
+    </Tip>
 
   </Accordion>
 


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference, which allows users to email our co-founder, Deep, directly from the command line.

## Changes

- Added `fern deep` command to the main commands table
- Created detailed documentation including:
  - Command syntax and description
  - Optional `--message` flag for including messages
  - Usage examples
  - Helpful tip about Deep reading and responding to messages

The command is positioned in the general commands section after `fern logout`, maintaining a logical flow in the documentation.