### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,39 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is perfect for when you need to reach out with questions, feedback, or just want to say hello!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "Quick question about SDKs"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for GraphQL!"
+    ```
+
+    If you don't provide a subject or message, the CLI will open an interactive prompt to help you compose your email.
+
+    <Note>
+    Deep reads every email personally and aims to respond within 24 hours!
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `fern deep` command to the CLI reference. This command allows users to send emails directly to Deep, our co-founder.

## Changes

- Added `fern deep` to the main commands table
- Created a detailed accordion section with usage examples
- Documented `--subject` and `--message` flags
- Added helpful note about response time

## Test plan

- [x] Verified markdown syntax is correct
- [x] Ensured accordion formatting matches existing commands
- [x] Added appropriate code examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)