### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,52 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is perfect for when you need to reach out with questions, feedback, or just want to say hello!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "Feature request: API versioning support"
+    ```
+
+    ### message
+
+    Use `--message` to include a message in the email body.
+
+    ```bash
+    fern deep --message "Hi Deep! Love the product. Quick question about..."
+    ```
+
+    ### Example usage
+
+    Send a quick hello:
+
+    ```bash
+    fern deep --subject "Hello from the Fern CLI!" --message "Thanks for building such an awesome tool!"
+    ```
+
+    <Tip>
+    If you don't specify a subject or message, the CLI will prompt you interactively for the details.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

Introduces a new CLI command `fern deep` that allows users to send emails directly to Deep, our co-founder.

## Changes

- **Added command to reference table**: Listed `fern deep` in the main commands table with a clear description
- **Comprehensive documentation**: Created a detailed accordion section with:
  - Command syntax and usage
  - `--subject` and `--message` parameter descriptions
  - Practical examples
  - Helpful tip about interactive mode when flags are omitted

## Example Usage

```bash
# With flags
fern deep --subject "Feature request" --message "Hi Deep! Love the product..."

# Interactive mode (prompts for subject and message)
fern deep
```

This enhancement makes it easy for users to reach out to Deep directly from the CLI with questions, feedback, or just to say hello!