### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,45 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command opens a direct line of communication for questions, feedback, or just to say hello.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the subject line of your email.
+
+    ```bash
+    fern deep --subject "Feature Request: GraphQL Support"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern deep --message "I'd love to discuss the roadmap for GraphQL integration."
+    ```
+
+    ### Interactive mode
+
+    If you don't provide `--subject` or `--message`, the command will open an interactive prompt where you can compose your email.
+
+    ```bash
+    fern deep
+    ```
+
+    <Note>
+    Deep reads every message personally and will get back to you as soon as possible!
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference. The command allows users to send emails directly to Deep, our co-founder, for questions, feedback, or general communication.

## Changes

- Added `fern deep` to the main commands table with a brief description
- Created a detailed accordion section documenting the command usage
- Documented two optional flags:
  - `--subject`: Specify email subject line
  - `--message`: Include message body
- Described interactive mode when flags are omitted
- Added a note that Deep reads every message personally

## Documentation Location

Updated: `fern/products/cli-api-reference/pages/commands.mdx`