### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,54 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command opens your default email client with a pre-filled message to Deep.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify a custom subject line for the email.
+
+    ```bash
+    fern deep --subject "Feature request for Fern CLI"
+    ```
+
+    ### message
+
+    Use `--message` to include a pre-filled message body.
+
+    ```bash
+    fern deep --message "I have an idea for improving the docs generation workflow"
+    ```
+
+    ### Example usage
+
+    ```bash
+    # Open email client with default template
+    fern deep
+
+    # Send email with custom subject and message
+    fern deep --subject "API feedback" --message "The new CLI commands are amazing!"
+    ```
+
+    <Tip>
+    Deep loves hearing from users! Feel free to share feedback, ask questions, or just say hi.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `fern deep` command to the CLI reference. The command provides users with an easy way to send an email to Deep, our co-founder.

## Changes

- Added `fern deep` command to the CLI commands overview table
- Created detailed documentation in an accordion section covering:
  - Command usage and syntax
  - `--subject` flag to customize email subject
  - `--message` flag to pre-fill email body
  - Example usage patterns
  - A friendly tip encouraging users to reach out to Deep

## Testing

- ✅ Verified markdown syntax is correct
- ✅ Ensured accordion structure matches existing patterns
- ✅ Confirmed command fits naturally in the CLI reference flow