### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, Fern's co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,47 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--subject <subject>]
+    ```
+    </CodeBlock>
+
+    This command opens a channel to reach Deep for questions, feedback, or feature requests
+    that you'd like to discuss with the founding team.
+
+    ### message
+
+    Use `--message` to include a custom message in the email.
+
+    ```bash
+    fern deep --message "I have a question about custom generators"
+    ```
+
+    ### subject
+
+    Use `--subject` to specify a custom subject line for the email.
+
+    ```bash
+    fern deep --subject "Feature Request: Custom OAuth Flow"
+    ```
+
+    <Tip>
+    You can combine both flags to send a fully customized email to Deep.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces documentation for a new `fern deep` command in the CLI reference.

## Changes

- **Added command to overview table**: Listed `fern deep` with a brief description in the main commands table
- **Created detailed documentation**: Added a comprehensive accordion section with usage examples
- **Documented command flags**:
  - `--message`: Include a custom message in the email
  - `--subject`: Specify a custom subject line

## Purpose

The `fern deep` command provides users with a direct channel to email Deep, one of Fern's co-founders, for questions, feedback, or feature requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)