### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, our co-founder, for support |
 
 ## Documentation commands
 
@@ -579,12 +580,46 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders, for personalized support and assistance.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--urgent]
+    ```
+    </CodeBlock>
+
+    This command opens a direct line of communication with Deep for questions, feedback, or issues that need founder-level attention.
+
+    ### message
+
+    Use `--message` to include a specific message with your email.
+
+    ```bash
+    fern deep --message "Need help with custom generator configuration"
+    ```
+
+    ### urgent
+
+    Use `--urgent` to flag your message as high priority.
+
+    ```bash
+    fern deep --urgent --message "Production deployment blocked"
+    ```
+
+    <Note>
+    Deep typically responds within 24 hours. For immediate technical support, check our [Discord community](https://discord.gg/fern) or [documentation](/learn).
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
This PR adds documentation for a new `fern deep` command to the CLI reference that allows users to email Deep, one of Fern's co-founders, for personalized support.

## Changes
- Added `fern deep` to the main commands table
- Created a detailed accordion section documenting the command usage
- Included two optional flags:
  - `--message`: To include a specific message with the email
  - `--urgent`: To flag the message as high priority
- Added helpful notes about response times and alternative support channels

## Documentation Updates
The new command is documented in `/fern/products/cli-api-reference/pages/commands.mdx` with examples and usage guidelines.