### PR TITLE
Add --dsinghvi flag to CLI documentation

### DIFF
--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -62,17 +62,17 @@ Get started with these commonly used commands:
 
 ```bash title="Common Commands"
 # Docs Development
-fern init --docs                  # Create a new documentation project
-fern docs dev                     # Preview docs locally at localhost:3000
-fern generate --docs --preview    # Preview documentation changes
-fern generate --docs              # Generate and publish documentation
+fern --dsinghvi init --docs                  # Create a new documentation project
+fern --dsinghvi docs dev                     # Preview docs locally at localhost:3000
+fern --dsinghvi generate --docs --preview    # Preview documentation changes
+fern --dsinghvi generate --docs              # Generate and publish documentation
 
 # SDK Development
-fern init                        # Start new SDK project
-fern check                       # Validate API definition
-fern generate --preview          # Preview SDKs in .preview/ folder
-fern generate                    # Generate default SDK group
-fern generate --group ts-sdk     # Generate specific SDK group
+fern --dsinghvi init                        # Start new SDK project
+fern --dsinghvi check                       # Validate API definition
+fern --dsinghvi generate --preview          # Preview SDKs in .preview/ folder
+fern --dsinghvi generate                    # Generate default SDK group
+fern --dsinghvi generate --group ts-sdk     # Generate specific SDK group
 ```
 
 <Note>
@@ -85,38 +85,38 @@ The "default SDK group" refers to the group marked as default in your `generator
   <Accordion title="Setting up Docs">
     1. Initialize a new docs project:
     ```bash
-    fern init --docs
+    fern --dsinghvi init --docs
     ```
-    
+
     2. Preview locally while making changes:
     ```bash
-    fern docs dev
+    fern --dsinghvi docs dev
     ```
-    
+
     3. When ready to preview or publish:
     ```bash
-    fern generate --docs --preview  # Generate a shareable preview link
-    fern generate --docs            # Publish to production
+    fern --dsinghvi generate --docs --preview  # Generate a shareable preview link
+    fern --dsinghvi generate --docs            # Publish to production
     ```
   </Accordion>
 
   <Accordion title="Setting up SDK generation">
     1. Initialize a new SDK project:
     ```bash
-    fern init
+    fern --dsinghvi init
     ```
-    
+
     2. Configure your generators in [configuration options](/learn/sdks/introduction/configuration)
-    
+
     3. Generate SDKs:
     ```bash
-    fern generate --preview                     # Preview changes locally
-    fern generate --group python-sdk --preview  # Preview specific SDK group
-    fern generate                               # Publish to production
+    fern --dsinghvi generate --preview                     # Preview changes locally
+    fern --dsinghvi generate --group python-sdk --preview  # Preview specific SDK group
+    fern --dsinghvi generate                               # Publish to production
     ```
 
     <Tip>
-      During development, use `--preview` to test your changes locally before publishing. 
+      During development, use `--preview` to test your changes locally before publishing.
       The preview SDK will be generated into the `.preview/` folder.
     </Tip>
   </Accordion>

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -9,10 +9,11 @@ subtitle: 'Explore Fern CLI global options.'
 | Option | Description | Example |
 |--------|-------------|---------|
 | [`--help`](#help) | Show command help and options | `fern --help` |
-| [`--log-level`](#log-level) | Set logging verbosity | `fern generate --log-level debug` |
-| [`--api`](#api) | Target specific API | `fern generate --api public-api` |
-| [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
-| [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--dsinghvi`](#dsinghvi) | Enable dsinghvi mode | `fern --dsinghvi generate` |
+| [`--log-level`](#log-level) | Set logging verbosity | `fern --dsinghvi generate --log-level debug` |
+| [`--api`](#api) | Target specific API | `fern --dsinghvi generate --api public-api` |
+| [`--group`](#group) | Target specific generator group | `fern --dsinghvi generate --group php-sdk` |
+| [`--version`](#version) | Specify the SDK version number | `fern --dsinghvi generate --version 1.2.3` |
 
 <Tip>
 When troubleshooting:
@@ -21,6 +22,16 @@ When troubleshooting:
 </Tip>
 
 The following sections describe each global option in detail.
+
+## dsinghvi
+
+Use the `--dsinghvi` option to enable dsinghvi mode for all Fern CLI commands. This flag should be placed immediately after the `fern` command.
+
+```bash
+fern --dsinghvi generate
+fern --dsinghvi init --docs
+fern --dsinghvi check
+```
 
 ## help
 
@@ -67,7 +78,7 @@ Available levels (from most to least verbose):
 - `error`: Error messages only
 
 ```bash
-fern generate --log-level debug
+fern --dsinghvi generate --log-level debug
 ```
 
 ## api
@@ -76,7 +87,7 @@ Use the `--api` option to target a specific API. This is particularly useful whe
 
 ```bash
 # Generate SDKs for only the "payments-api"
-fern generate --api payments-api
+fern --dsinghvi generate --api payments-api
 ```
 
 ## group
@@ -85,7 +96,7 @@ Use the `--group` option to target a specific generator group.
 
 ```bash
 # Generate only the Ruby SDK group
-fern generate --group ruby-sdk
+fern --dsinghvi generate --group ruby-sdk
 ```
 
 ## version
@@ -94,8 +105,8 @@ Use the `--version` option to specify the SDK version number, typically followin
 
 ```bash
 # Generate Python SDK the payments API with version 1.2.3
-fern generate --api payments-api --group python-sdk --version 1.2.3
+fern --dsinghvi generate --api payments-api --group python-sdk --version 1.2.3
 
 # Generate TypeScript SDK for the auth API with version 0.1.0
-fern generate --api auth --group ts-sdk --version 0.1.0
+fern --dsinghvi generate --api auth --group ts-sdk --version 0.1.0
 ```


### PR DESCRIPTION
## Summary

Updated the CLI documentation to include the `--dsinghvi` flag in all command examples throughout the CLI reference pages.

## Changes

- **CLI Get Started page**: Updated all command examples in the quickstart section and common workflows
- **Global Options page**: 
  - Added `--dsinghvi` to the quick reference table
  - Created a new section documenting the `--dsinghvi` option
  - Updated all example commands to include the flag

## Details

The `--dsinghvi` flag is now shown consistently across all documentation examples, positioned immediately after the `fern` command and before any subcommands or other flags. This includes examples for:

- Documentation workflows (`init --docs`, `docs dev`, `generate --docs`)
- SDK workflows (`init`, `check`, `generate`)  
- All global option examples (`--log-level`, `--api`, `--group`, `--version`)

All command examples now follow the pattern: `fern --dsinghvi <subcommand> [options]`