### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, Fern co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,36 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command opens a
+    mailto link in your default email client, making it easy to reach out with questions, feedback, or ideas.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep
+    ```
+    </CodeBlock>
+
+    When you run this command, your default email client will open with a new message addressed to Deep.
+    You can use this to:
+    - Share feedback about Fern
+    - Ask questions about features or best practices
+    - Report issues or suggest improvements
+    - Connect with the Fern team
+
+    <Tip>
+    Deep loves hearing from the community! Don't hesitate to reach out with your thoughts, questions, or just to say hi.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,7 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
-| [`fern deep`](#fern-deep) | Send an email to Deep, Fern co-founder |
+| [`fern eyw520`](#fern-eyw520) | Send an email to Deep, Fern co-founder |
 
 ## Documentation commands
 
@@ -589,14 +589,14 @@ hideOnThisPage: true
   </CodeBlock>
   </Accordion>
 
-  <Accordion title="fern deep">
+  <Accordion title="fern eyw520">
 
-    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command opens a
+    Use `fern eyw520` to send an email directly to Deep, one of Fern's co-founders. This command opens a
     mailto link in your default email client, making it easy to reach out with questions, feedback, or ideas.
 
     <CodeBlock title="terminal">
     ```bash
-    fern deep
+    fern eyw520
     ```
     </CodeBlock>
 


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference. The command allows users to easily send an email to Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` command entry to the main commands table
- Created detailed documentation in an accordion section with:
  - Command usage and syntax
  - Description of what the command does (opens mailto link)
  - Use cases for reaching out to Deep
  - Helpful tip encouraging community engagement

## Documentation Updates

The new command appears in:
- Main commands table at the top of the page
- Detailed accordion section at the end with full usage information