### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,54 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful when you need to get in touch with Deep about your Fern project, have questions, or want to provide feedback.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When run without arguments, the command will open an interactive prompt to compose your email.
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to specify the email body content.
+
+    ```bash
+    fern deep --message "I'm having trouble with TypeScript SDK generation"
+    ```
+
+    ### Example
+
+    Send a complete email with both subject and message:
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for Rust SDKs!"
+    ```
+
+    <Tip>
+    Deep loves hearing from the community! Don't hesitate to reach out with questions, feedback, or just to say hello.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `fern deep` command to the CLI reference. This command provides a convenient way for users to email Deep, our co-founder, directly from the CLI.

## Changes

- Added `fern deep` to the main commands table in the CLI reference
- Created detailed accordion documentation for the command including:
  - Command description and usage
  - `--subject` flag to specify email subject
  - `--message` flag to specify email body
  - Usage examples
  - Helpful tip encouraging community engagement

The new command follows the same documentation style and format as other CLI commands in the reference.