### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to co-founder Deep |
 
 ## Documentation commands
 
@@ -579,12 +580,48 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, Fern's co-founder. This command opens a channel
+    for direct communication about feature requests, bug reports, or just to say hello.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When run without options, this command will open an interactive prompt to compose your email.
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "Feature request: TypeScript 5.0 support"
+    ```
+
+    ### message
+
+    Use `--message` to include the email body directly from the command line.
+
+    ```bash
+    fern deep --subject "Quick question" --message "Is there a way to customize the SDK output directory?"
+    ```
+
+    <Tip>
+    Deep reads every email personally and typically responds within 24 hours. For urgent issues,
+    consider also posting in the [Fern community Discord](https://discord.gg/fern).
+    </Tip>
+
   </Accordion>
 </AccordionGroup>

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,7 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
-| [`fern deep`](#fern-deep) | Send an email to co-founder Deep |
+| [`fern dsinghvi`](#fern-dsinghvi) | Send an email to co-founder Dsinghvi |
 
 ## Documentation commands
 
@@ -589,14 +589,14 @@ hideOnThisPage: true
   </CodeBlock>
   </Accordion>
 
-  <Accordion title="fern deep">
+  <Accordion title="fern dsinghvi">
 
-    Use `fern deep` to send an email directly to Deep, Fern's co-founder. This command opens a channel
+    Use `fern dsinghvi` to send an email directly to Dsinghvi, Fern's co-founder. This command opens a channel
     for direct communication about feature requests, bug reports, or just to say hello.
 
     <CodeBlock title="terminal">
     ```bash
-    fern deep [--subject <subject>] [--message <message>]
+    fern dsinghvi [--subject <subject>] [--message <message>]
     ```
     </CodeBlock>
 
@@ -607,7 +607,7 @@ hideOnThisPage: true
     Use `--subject` to specify the email subject line.
 
     ```bash
-    fern deep --subject "Feature request: TypeScript 5.0 support"
+    fern dsinghvi --subject "Feature request: TypeScript 5.0 support"
     ```
 
     ### message
@@ -615,11 +615,11 @@ hideOnThisPage: true
     Use `--message` to include the email body directly from the command line.
 
     ```bash
-    fern deep --subject "Quick question" --message "Is there a way to customize the SDK output directory?"
+    fern dsinghvi --subject "Quick question" --message "Is there a way to customize the SDK output directory?"
     ```
 
     <Tip>
-    Deep reads every email personally and typically responds within 24 hours. For urgent issues,
+    Dsinghvi reads every email personally and typically responds within 24 hours. For urgent issues,
     consider also posting in the [Fern community Discord](https://discord.gg/fern).
     </Tip>
 


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference that allows users to send emails directly to co-founder Deep.

## Changes

- Added `fern deep` command to the main commands table
- Created detailed accordion documentation section with:
  - Command usage and description
  - `--subject` flag to specify email subject line
  - `--message` flag to include email body from command line
  - Interactive prompt mode when run without options
  - Tip about response time and Discord community alternative

## Documentation Location

Updated file: `fern/products/cli-api-reference/pages/commands.mdx`