### PR TITLE
Update Fern CLI commands to include --dsinghvi flag

### DIFF
--- a/fern/products/api-def/ferndef-pages/overview.mdx
+++ b/fern/products/api-def/ferndef-pages/overview.mdx
@@ -16,7 +16,7 @@ To initialize a Fern Definition, simply run:
 
 ```sh
 npm install -g fern-api
-fern init
+fern --dsinghvi init
 ```
 
 This will create the following folder structure in your project:

--- a/fern/products/api-def/openapi-pages/overview.mdx
+++ b/fern/products/api-def/openapi-pages/overview.mdx
@@ -148,10 +148,10 @@ Start by initializing your fern folder with an OpenAPI spec
 
 <CodeGroup>
 ```sh file
-fern init --openapi ./path/to/openapi
+fern --dsinghvi init --openapi ./path/to/openapi
 ```
 ```sh url
-fern init --openapi https://host/path/to/openapi
+fern --dsinghvi init --openapi https://host/path/to/openapi
 ```
 </CodeGroup>
 

--- a/fern/products/cli-api-reference/cli-changelog/2024-10-19.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2024-10-19.mdx
@@ -3,7 +3,7 @@
 that outputs the JSON Schema for a given type in your Fern Definition.
 
 ```sh
-fern jsonschema ./schema.json --type MyType
+fern --dsinghvi jsonschema ./schema.json --type MyType
 ```
 
 

--- a/fern/products/cli-api-reference/cli-changelog/2025-01-22.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2025-01-22.mdx
@@ -9,7 +9,7 @@ migrates existing documentation to a fern-compatible repository.
 
 To use this feature:
 ```bash
-fern init --readme https://url-to-readme-docs.com
+fern --dsinghvi init --readme https://url-to-readme-docs.com
 ```
 
 

--- a/fern/products/cli-api-reference/cli-changelog/2025-02-27.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2025-02-27.mdx
@@ -8,7 +8,7 @@ will allow you to test early versions of the new OpenAPI parser which goes direc
 OpenAPI to IR.
 
 ```bash
-fern ir ir.json --from-openapi
+fern --dsinghvi ir ir.json --from-openapi
 ```
 
 

--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -10,7 +10,7 @@ Run the following command to download and install Fern CLI from the [npm](https:
 
 ```bash
 npm install -g fern-api # install Fern CLI
-fern -v # ensure Fern was successfully installed
+fern --dsinghvi -v # ensure Fern was successfully installed
 ```
 
 <Accordion title="Install Fern CLI locally" toc={true}>
@@ -64,17 +64,17 @@ Get started with these commonly used commands:
 
 ```bash title="Common Commands"
 # Docs Development
-fern init --docs                  # Create a new documentation project
-fern docs dev                     # Preview docs locally at localhost:3000
-fern generate --docs --preview    # Preview documentation changes
-fern generate --docs              # Generate and publish documentation
+fern --dsinghvi init --docs                  # Create a new documentation project
+fern --dsinghvi docs dev                     # Preview docs locally at localhost:3000
+fern --dsinghvi generate --docs --preview    # Preview documentation changes
+fern --dsinghvi generate --docs              # Generate and publish documentation
 
 # SDK Development
-fern init                        # Start new SDK project
-fern check                       # Validate API definition
-fern generate --preview          # Preview SDKs in .preview/ folder
-fern generate                    # Generate default SDK group
-fern generate --group ts-sdk     # Generate specific SDK group
+fern --dsinghvi init                        # Start new SDK project
+fern --dsinghvi check                       # Validate API definition
+fern --dsinghvi generate --preview          # Preview SDKs in .preview/ folder
+fern --dsinghvi generate                    # Generate default SDK group
+fern --dsinghvi generate --group ts-sdk     # Generate specific SDK group
 ```
 
 <Note>

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -28,8 +28,8 @@ Use the `--help` option with any Fern CLI command to see an explanation and avai
 
 <CodeBlocks>
 ```bash maxLines=10 title="fern add --help"
-fern add --help
-fern add <generator>
+fern --dsinghvi add --help
+fern --dsinghvi add <generator>
 
 Add a code generator to generators.yml
 
@@ -44,8 +44,8 @@ Options:
 ```
 
 ```bash maxLines=10 title="fern write-definition --help"
-fern write-definition --help
-fern write-definition
+fern --dsinghvi write-definition --help
+fern --dsinghvi write-definition
 
 Write underlying Fern Definition for OpenAPI Specifications and API Dependencies.
 
@@ -67,7 +67,7 @@ Available levels (from most to least verbose):
 - `error`: Error messages only
 
 ```bash
-fern generate --log-level debug
+fern --dsinghvi generate --log-level debug
 ```
 
 ## api
@@ -76,7 +76,7 @@ Use the `--api` option to target a specific API. This is particularly useful whe
 
 ```bash
 # Generate SDKs for only the "payments-api"
-fern generate --api payments-api
+fern --dsinghvi generate --api payments-api
 ```
 
 ## group
@@ -85,7 +85,7 @@ Use the `--group` option to target a specific generator group.
 
 ```bash
 # Generate only the Ruby SDK group
-fern generate --group ruby-sdk
+fern --dsinghvi generate --group ruby-sdk
 ```
 
 ## version
@@ -94,8 +94,8 @@ Use the `--version` option to specify the SDK version number, typically followin
 
 ```bash
 # Generate Python SDK the payments API with version 1.2.3
-fern generate --api payments-api --group python-sdk --version 1.2.3
+fern --dsinghvi generate --api payments-api --group python-sdk --version 1.2.3
 
 # Generate TypeScript SDK for the auth API with version 0.1.0
-fern generate --api auth --group ts-sdk --version 0.1.0
+fern --dsinghvi generate --api auth --group ts-sdk --version 0.1.0
 ```

--- a/fern/products/docs/pages/getting-started/pr-preview.mdx
+++ b/fern/products/docs/pages/getting-started/pr-preview.mdx
@@ -8,13 +8,13 @@ description: Fern's PR previews feature lets you preview changes to your docs fr
 ## Usage
 
 ```bash
-fern generate --docs --preview
+fern --dsinghvi generate --docs --preview
 ```
 
 ## Example
 
 ```bash
-fern generate --docs --preview
+fern --dsinghvi generate --docs --preview
 
 [docs]: Found 0 errors and 1 warnings. Run fern check --warnings to print out the warnings.
 [docs]: Published docs to https://fern-preview-a1da0157-93ca-4b1f-b310-8dd34fb891ca.docs.buildwithfern.com

--- a/fern/products/docs/pages/getting-started/preview-changes-locally.mdx
+++ b/fern/products/docs/pages/getting-started/preview-changes-locally.mdx
@@ -31,7 +31,7 @@ yarn global add fern-api
 **Step 2**: Navigate to the docs directory (where the `fern` folder is located) and execute the following command:
 
 ```bash
-fern docs dev
+fern --dsinghvi docs dev
 ```
 
 A local preview of your documentation will be available at `http://localhost:3000`. The functionality is available offline if you have run local development mode online at least once.
@@ -48,7 +48,7 @@ Some features are disabled in the local development environment, including:
 By default, Fern uses port 3000. You can customize the port on which Fern runs by using the `--port` flag. For example, to run Fern on port 3002, use this command:
 
 ```bash
-fern docs dev --port 3002
+fern --dsinghvi docs dev --port 3002
 ```
 
 If you attempt to run Fern on a port that's already in use, it will use the next available port:
@@ -60,13 +60,13 @@ Fern allows you to generate a shareable preview link that displays the current s
 **Usage**:
 
 ```bash
-fern generate --docs --preview
+fern --dsinghvi generate --docs --preview
 ```
 
 **Example**:
 
 ```bash
-fern generate --docs --preview
+fern --dsinghvi generate --docs --preview
 
 [docs]: Found 0 errors and 1 warnings. Run fern check --warnings to print out the warnings.
 [docs]: Published docs to https://fern-preview-c973a36e-337b-44f5-ab83-aab.docs.buildwithfern.com/learn

--- a/fern/products/docs/pages/getting-started/publishing-your-docs.mdx
+++ b/fern/products/docs/pages/getting-started/publishing-your-docs.mdx
@@ -11,13 +11,13 @@ When you are ready for your docs to be publicly accessible, you can publish them
 ## Usage
 
 ```bash
-fern generate --docs
+fern --dsinghvi generate --docs
 ```
 
 ### Example
 
 ```bash
-fern generate --docs
+fern --dsinghvi generate --docs
 [docs]: Found 0 errors and 1 warnings. Run fern check --warnings to print out the warnings.
 [docs]: ✓ All checks passed
 [docs]: Published docs to https://plantstore.docs.buildwithfern.com

--- a/fern/products/sdks/guides/setup-local-sdk-previews.mdx
+++ b/fern/products/sdks/guides/setup-local-sdk-previews.mdx
@@ -9,10 +9,10 @@ as you develop:
 
 ```bash
 # Preview all SDKs
-fern generate --preview
+fern --dsinghvi generate --preview
 
 # Preview SDK for a specific language
-fern generate --group <language>-sdk --preview
+fern --dsinghvi generate --group <language>-sdk --preview
 
 ```
 
@@ -50,7 +50,7 @@ groups:
 ### Invoke the Fern CLI
 
 ```shell
-fern generate --group python-sdk --preview
+fern --dsinghvi generate --group python-sdk --preview
 ```
 
 ### Preview your SDK

--- a/fern/products/sdks/overview/csharp/publishing-to-nuget.mdx
+++ b/fern/products/sdks/overview/csharp/publishing-to-nuget.mdx
@@ -288,7 +288,7 @@ export NUGET_API_KEY=your-actual-nuget-api-key
 Regenerate your SDK, specifying the version:
 
 ```bash
-fern generate --group csharp-sdk --version <version>
+fern --dsinghvi generate --group csharp-sdk --version <version>
 ```
 
 <Markdown src="/products/sdks/snippets/release-sdk.mdx"/>

--- a/fern/products/sdks/overview/csharp/quickstart.mdx
+++ b/fern/products/sdks/overview/csharp/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a C#/.NET SDK by following the instructions on this page.
 Run the following command to add the C#/.NET SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-csharp-sdk --group csharp-sdk
+fern --dsinghvi add fern-csharp-sdk --group csharp-sdk
 ```
 
 <Note>
@@ -42,7 +42,7 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group csharp-sdk
+fern --dsinghvi generate --group csharp-sdk
 ```
 
 <Note>

--- a/fern/products/sdks/overview/go/quickstart.mdx
+++ b/fern/products/sdks/overview/go/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a Go SDK by following the instructions on this page.
 Run the following command to add the Go SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-go-sdk --group go-sdk
+fern --dsinghvi add fern-go-sdk --group go-sdk
 ```
 <Note>
   `go-sdk` is the name of the `generators.yml` group that configures your Go
@@ -42,7 +42,7 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group go-sdk
+fern --dsinghvi generate --group go-sdk
 ```
 
 <Note>

--- a/fern/products/sdks/overview/java/publishing-to-maven-central.mdx
+++ b/fern/products/sdks/overview/java/publishing-to-maven-central.mdx
@@ -342,7 +342,7 @@ export MAVEN_SIGNATURE_SECRET_KEY=your-gpg-secret-key
 Regenerate your SDK, specifying the version:
 
 ```bash
-fern generate --group java-sdk --version <version>
+fern --dsinghvi generate --group java-sdk --version <version>
 ```
 
 <Markdown src="/products/sdks/snippets/release-sdk.mdx"/>

--- a/fern/products/sdks/overview/java/quickstart.mdx
+++ b/fern/products/sdks/overview/java/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a Java SDK by following the instructions on this page.
 Run the following command to add the Java SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-java-sdk --group java-sdk
+fern --dsinghvi add fern-java-sdk --group java-sdk
 ```
 <Note>
   `java-sdk` is the name of the `generators.yml` group that configures your Java
@@ -42,7 +42,7 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group java-sdk
+fern --dsinghvi generate --group java-sdk
 ```
 
 <Note>

--- a/fern/products/sdks/overview/php/quickstart.mdx
+++ b/fern/products/sdks/overview/php/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a PHP SDK by following the instructions on this page.
 Run the following command to add the PHP SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-php-sdk --group php-sdk
+fern --dsinghvi add fern-php-sdk --group php-sdk
 ```
 
 <Note>
@@ -43,7 +43,7 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group php-sdk
+fern --dsinghvi generate --group php-sdk
 ```
 
 <Note>

--- a/fern/products/sdks/overview/postman/publishing-to-postman.mdx
+++ b/fern/products/sdks/overview/postman/publishing-to-postman.mdx
@@ -313,7 +313,7 @@ The `--version` parameter in `fern generate --version X.X.X` creates a GitHub re
 </Note>
 
 ```bash
-fern generate --group postman --version <version>
+fern --dsinghvi generate --group postman --version <version>
 ```
 
 <Markdown src="/products/sdks/snippets/generate-postman.mdx"/>

--- a/fern/products/sdks/overview/postman/quickstart.mdx
+++ b/fern/products/sdks/overview/postman/quickstart.mdx
@@ -21,7 +21,7 @@ Generate a Postman collection by following the instructions on this page.
 Run the following command to add the Postman generator to `generators.yml`:
 
 ```sh
-fern add fern-postman --group postman
+fern --dsinghvi add fern-postman --group postman
 ```
 
 <Note>
@@ -46,7 +46,7 @@ groups:
 Run the following command:
 
 ```sh
-fern generate --group postman
+fern --dsinghvi generate --group postman
 ```
 
 <Note>

--- a/fern/products/sdks/overview/python/quickstart.mdx
+++ b/fern/products/sdks/overview/python/quickstart.mdx
@@ -15,7 +15,7 @@ Generate a Python SDK by following the instructions on this page.
 Run the following command to add the Python SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-python-sdk --group python-sdk
+fern --dsinghvi add fern-python-sdk --group python-sdk
 ```
 
 <Note>
@@ -42,7 +42,7 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group python-sdk
+fern --dsinghvi generate --group python-sdk
 ```
 
 <Note>

--- a/fern/products/sdks/overview/ruby/quickstart.mdx
+++ b/fern/products/sdks/overview/ruby/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a Ruby SDK by following the instructions on this page.
 Run the following command to add the Ruby SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-ruby-sdk --group ruby-sdk
+fern --dsinghvi add fern-ruby-sdk --group ruby-sdk
 ```
 
 <Note>
@@ -43,7 +43,7 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ruby-sdk
+fern --dsinghvi generate --group ruby-sdk
 ```
 
 <Note>

--- a/fern/products/sdks/overview/swift/quickstart.mdx
+++ b/fern/products/sdks/overview/swift/quickstart.mdx
@@ -15,7 +15,7 @@ Generate a Swift SDK by following the instructions on this page.
 Run the following command to add the Swift SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-swift-sdk --group swift-sdk
+fern --dsinghvi add fern-swift-sdk --group swift-sdk
 ```
 
 <Note>

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a TypeScript SDK by following the instructions on this page.
 Run the following command to add the TypeScript SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-typescript-sdk --group ts-sdk
+fern --dsinghvi add fern-typescript-sdk --group ts-sdk
 ```
 
 <Note>
@@ -42,7 +42,7 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ts-sdk
+fern --dsinghvi generate --group ts-sdk
 ```
 
 <Note>


### PR DESCRIPTION
## Summary

This PR updates all Fern CLI command examples across the documentation to include the `--dsinghvi` flag.

## Changes

- Updated 23 documentation files with CLI command examples
- All `fern` commands now use the pattern: `fern --dsinghvi [command] [options]`

## Files Modified

### CLI Reference Documentation
- `cli-get-started.mdx` - Updated quickstart commands
- `global-options.mdx` - Updated option examples
- CLI changelog entries (2024-10-19, 2025-01-22, 2025-02-27)

### SDK Quickstart Guides
- TypeScript, Python, Java, Ruby, Go, PHP, C#, Swift, and Postman quickstart documentation

### Documentation Guides
- Preview changes locally guide
- PR preview guide  
- Publishing documentation guide
- Local SDK previews setup guide

### API Definition Documentation
- Fern Definition overview
- OpenAPI overview

All command examples now consistently use the `--dsinghvi` flag to ensure proper execution across all documentation.