### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to co-founder Deep |
 
 ## Documentation commands
 
@@ -579,12 +580,52 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, Fern's co-founder. This command is useful when you need to reach out with questions, feedback, or just want to say hello!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When run without options, this command will open an interactive prompt to compose your email.
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to provide the email body directly from the command line.
+
+    ```bash
+    fern deep --message "Hey Deep, loving Fern! Quick question about TypeScript SDK customization..."
+    ```
+
+    You can combine both options for a complete one-liner:
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for X in the next release!"
+    ```
+
+    <Tip>
+    Deep loves hearing from the community! Don't hesitate to reach out with questions, suggestions, or just to share your experience with Fern.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces a new `fern deep` command to the CLI reference documentation. This command provides a friendly way for users to send emails directly to Deep, Fern's co-founder.

## Changes

- Added `fern deep` entry to the main commands table
- Created detailed documentation in an Accordion section with:
  - Command overview and description
  - `--subject` flag for specifying email subject
  - `--message` flag for providing email body
  - Usage examples for interactive mode and one-liner emails
  - Friendly tip encouraging community engagement

## Documentation Impact

The new command follows the existing documentation patterns and style, maintaining consistency with other CLI commands in the reference.