### PR TITLE
Update Fern CLI commands to include --dsheridan flag

### DIFF
--- a/fern/products/api-def/ferndef-pages/overview.mdx
+++ b/fern/products/api-def/ferndef-pages/overview.mdx
@@ -16,7 +16,7 @@ To initialize a Fern Definition, simply run:
 
 ```sh
 npm install -g fern-api
-fern init
+fern --dsheridan init
 ```
 
 This will create the following folder structure in your project:

--- a/fern/products/api-def/openapi-pages/overview.mdx
+++ b/fern/products/api-def/openapi-pages/overview.mdx
@@ -148,10 +148,10 @@ Start by initializing your fern folder with an OpenAPI spec
 
 <CodeGroup>
 ```sh file
-fern init --openapi ./path/to/openapi
+fern --dsheridan init --openapi ./path/to/openapi
 ```
 ```sh url
-fern init --openapi https://host/path/to/openapi
+fern --dsheridan init --openapi https://host/path/to/openapi
 ```
 </CodeGroup>
 

--- a/fern/products/cli-api-reference/cli-changelog/2024-10-19.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2024-10-19.mdx
@@ -3,7 +3,7 @@
 that outputs the JSON Schema for a given type in your Fern Definition.
 
 ```sh
-fern jsonschema ./schema.json --type MyType
+fern --dsheridan jsonschema ./schema.json --type MyType
 ```
 
 

--- a/fern/products/cli-api-reference/cli-changelog/2025-01-22.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2025-01-22.mdx
@@ -9,7 +9,7 @@ migrates existing documentation to a fern-compatible repository.
 
 To use this feature:
 ```bash
-fern init --readme https://url-to-readme-docs.com
+fern --dsheridan init --readme https://url-to-readme-docs.com
 ```
 
 

--- a/fern/products/cli-api-reference/cli-changelog/2025-02-27.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2025-02-27.mdx
@@ -8,7 +8,7 @@ will allow you to test early versions of the new OpenAPI parser which goes direc
 OpenAPI to IR.
 
 ```bash
-fern ir ir.json --from-openapi
+fern --dsheridan ir ir.json --from-openapi
 ```
 
 

--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -64,17 +64,17 @@ Get started with these commonly used commands:
 
 ```bash title="Common Commands"
 # Docs Development
-fern init --docs                  # Create a new documentation project
-fern docs dev                     # Preview docs locally at localhost:3000
-fern generate --docs --preview    # Preview documentation changes
-fern generate --docs              # Generate and publish documentation
+fern --dsheridan init --docs                  # Create a new documentation project
+fern --dsheridan docs dev                     # Preview docs locally at localhost:3000
+fern --dsheridan generate --docs --preview    # Preview documentation changes
+fern --dsheridan generate --docs              # Generate and publish documentation
 
 # SDK Development
-fern init                        # Start new SDK project
-fern check                       # Validate API definition
-fern generate --preview          # Preview SDKs in .preview/ folder
-fern generate                    # Generate default SDK group
-fern generate --group ts-sdk     # Generate specific SDK group
+fern --dsheridan init                        # Start new SDK project
+fern --dsheridan check                       # Validate API definition
+fern --dsheridan generate --preview          # Preview SDKs in .preview/ folder
+fern --dsheridan generate                    # Generate default SDK group
+fern --dsheridan generate --group ts-sdk     # Generate specific SDK group
 ```
 
 <Note>
@@ -87,34 +87,34 @@ The "default SDK group" refers to the group marked as default in your `generator
   <Accordion title="Setting up Docs">
     1. Initialize a new docs project:
     ```bash
-    fern init --docs
+    fern --dsheridan init --docs
     ```
     
     2. Preview locally while making changes:
     ```bash
-    fern docs dev
+    fern --dsheridan docs dev
     ```
     
     3. When ready to preview or publish:
     ```bash
-    fern generate --docs --preview  # Generate a shareable preview link
-    fern generate --docs            # Publish to production
+    fern --dsheridan generate --docs --preview  # Generate a shareable preview link
+    fern --dsheridan generate --docs            # Publish to production
     ```
   </Accordion>
 
   <Accordion title="Setting up SDK generation">
     1. Initialize a new SDK project:
     ```bash
-    fern init
+    fern --dsheridan init
     ```
     
     2. Configure your generators in [configuration options](/learn/sdks/introduction/configuration)
     
     3. Generate SDKs:
     ```bash
-    fern generate --preview                     # Preview changes locally
-    fern generate --group python-sdk --preview  # Preview specific SDK group
-    fern generate                               # Publish to production
+    fern --dsheridan generate --preview                     # Preview changes locally
+    fern --dsheridan generate --group python-sdk --preview  # Preview specific SDK group
+    fern --dsheridan generate                               # Publish to production
     ```
 
     <Tip>

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -28,8 +28,8 @@ Use the `--help` option with any Fern CLI command to see an explanation and avai
 
 <CodeBlocks>
 ```bash maxLines=10 title="fern add --help"
-fern add --help
-fern add <generator>
+fern --dsheridan add --help
+fern --dsheridan add <generator>
 
 Add a code generator to generators.yml
 
@@ -44,8 +44,8 @@ Options:
 ```
 
 ```bash maxLines=10 title="fern write-definition --help"
-fern write-definition --help
-fern write-definition
+fern --dsheridan write-definition --help
+fern --dsheridan write-definition
 
 Write underlying Fern Definition for OpenAPI Specifications and API Dependencies.
 
@@ -67,7 +67,7 @@ Available levels (from most to least verbose):
 - `error`: Error messages only
 
 ```bash
-fern generate --log-level debug
+fern --dsheridan generate --log-level debug
 ```
 
 ## api
@@ -76,7 +76,7 @@ Use the `--api` option to target a specific API. This is particularly useful whe
 
 ```bash
 # Generate SDKs for only the "payments-api"
-fern generate --api payments-api
+fern --dsheridan generate --api payments-api
 ```
 
 ## group
@@ -85,7 +85,7 @@ Use the `--group` option to target a specific generator group.
 
 ```bash
 # Generate only the Ruby SDK group
-fern generate --group ruby-sdk
+fern --dsheridan generate --group ruby-sdk
 ```
 
 ## version
@@ -94,8 +94,8 @@ Use the `--version` option to specify the SDK version number, typically followin
 
 ```bash
 # Generate Python SDK the payments API with version 1.2.3
-fern generate --api payments-api --group python-sdk --version 1.2.3
+fern --dsheridan generate --api payments-api --group python-sdk --version 1.2.3
 
 # Generate TypeScript SDK for the auth API with version 0.1.0
-fern generate --api auth --group ts-sdk --version 0.1.0
+fern --dsheridan generate --api auth --group ts-sdk --version 0.1.0
 ```

--- a/fern/products/docs/pages/getting-started/pr-preview.mdx
+++ b/fern/products/docs/pages/getting-started/pr-preview.mdx
@@ -8,13 +8,13 @@ description: Fern's PR previews feature lets you preview changes to your docs fr
 ## Usage
 
 ```bash
-fern generate --docs --preview
+fern --dsheridan generate --docs --preview
 ```
 
 ## Example
 
 ```bash
-fern generate --docs --preview
+fern --dsheridan generate --docs --preview
 
 [docs]: Found 0 errors and 1 warnings. Run fern check --warnings to print out the warnings.
 [docs]: Published docs to https://fern-preview-a1da0157-93ca-4b1f-b310-8dd34fb891ca.docs.buildwithfern.com

--- a/fern/products/docs/pages/getting-started/preview-changes-locally.mdx
+++ b/fern/products/docs/pages/getting-started/preview-changes-locally.mdx
@@ -31,7 +31,7 @@ yarn global add fern-api
 **Step 2**: Navigate to the docs directory (where the `fern` folder is located) and execute the following command:
 
 ```bash
-fern docs dev
+fern --dsheridan docs dev
 ```
 
 A local preview of your documentation will be available at `http://localhost:3000`. The functionality is available offline if you have run local development mode online at least once.
@@ -48,7 +48,7 @@ Some features are disabled in the local development environment, including:
 By default, Fern uses port 3000. You can customize the port on which Fern runs by using the `--port` flag. For example, to run Fern on port 3002, use this command:
 
 ```bash
-fern docs dev --port 3002
+fern --dsheridan docs dev --port 3002
 ```
 
 If you attempt to run Fern on a port that's already in use, it will use the next available port:
@@ -60,13 +60,13 @@ Fern allows you to generate a shareable preview link that displays the current s
 **Usage**:
 
 ```bash
-fern generate --docs --preview
+fern --dsheridan generate --docs --preview
 ```
 
 **Example**:
 
 ```bash
-fern generate --docs --preview
+fern --dsheridan generate --docs --preview
 
 [docs]: Found 0 errors and 1 warnings. Run fern check --warnings to print out the warnings.
 [docs]: Published docs to https://fern-preview-c973a36e-337b-44f5-ab83-aab.docs.buildwithfern.com/learn

--- a/fern/products/docs/pages/getting-started/publishing-your-docs.mdx
+++ b/fern/products/docs/pages/getting-started/publishing-your-docs.mdx
@@ -11,13 +11,13 @@ When you are ready for your docs to be publicly accessible, you can publish them
 ## Usage
 
 ```bash
-fern generate --docs
+fern --dsheridan generate --docs
 ```
 
 ### Example
 
 ```bash
-fern generate --docs
+fern --dsheridan generate --docs
 [docs]: Found 0 errors and 1 warnings. Run fern check --warnings to print out the warnings.
 [docs]: ✓ All checks passed
 [docs]: Published docs to https://plantstore.docs.buildwithfern.com

--- a/fern/products/sdks/guides/setup-local-sdk-previews.mdx
+++ b/fern/products/sdks/guides/setup-local-sdk-previews.mdx
@@ -9,10 +9,10 @@ as you develop:
 
 ```bash
 # Preview all SDKs
-fern generate --preview
+fern --dsheridan generate --preview
 
 # Preview SDK for a specific language
-fern generate --group <language>-sdk --preview
+fern --dsheridan generate --group <language>-sdk --preview
 
 ```
 
@@ -50,7 +50,7 @@ groups:
 ### Invoke the Fern CLI
 
 ```shell
-fern generate --group python-sdk --preview
+fern --dsheridan generate --group python-sdk --preview
 ```
 
 ### Preview your SDK

--- a/fern/products/sdks/overview/csharp/publishing-to-nuget.mdx
+++ b/fern/products/sdks/overview/csharp/publishing-to-nuget.mdx
@@ -248,7 +248,7 @@ Set up a CI workflow that you can manually trigger from the GitHub UI. In your r
 	          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
 	          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 	        run: |
-	          fern generate --group csharp-sdk --version ${{ inputs.version }} --log-level debug
+	          fern --dsheridan generate --group csharp-sdk --version ${{ inputs.version }} --log-level debug
 	```
 	<Note>
 		You can alternatively configure your workflow to execute `on: [push]`. See Vapi's [npm publishing GitHub Action](https://github.com/VapiAI/server-sdk-typescript/blob/main/.github/workflows/ci.yml) for an example. 
@@ -288,7 +288,7 @@ export NUGET_API_KEY=your-actual-nuget-api-key
 Regenerate your SDK, specifying the version:
 
 ```bash
-fern generate --group csharp-sdk --version <version>
+fern --dsheridan generate --group csharp-sdk --version <version>
 ```
 
 <Markdown src="/products/sdks/snippets/release-sdk.mdx"/>

--- a/fern/products/sdks/overview/csharp/quickstart.mdx
+++ b/fern/products/sdks/overview/csharp/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a C#/.NET SDK by following the instructions on this page.
 Run the following command to add the C#/.NET SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-csharp-sdk --group csharp-sdk
+fern --dsheridan add fern-csharp-sdk --group csharp-sdk
 ```
 
 <Note>
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group csharp-sdk
+fern --dsheridan generate --group csharp-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group csharp-sdk --api your-api-name
+  fern --dsheridan generate --group csharp-sdk --api your-api-name
   ``` 
 </Note>
 

--- a/fern/products/sdks/overview/go/quickstart.mdx
+++ b/fern/products/sdks/overview/go/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a Go SDK by following the instructions on this page.
 Run the following command to add the Go SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-go-sdk --group go-sdk
+fern --dsheridan add fern-go-sdk --group go-sdk
 ```
 <Note>
   `go-sdk` is the name of the `generators.yml` group that configures your Go
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group go-sdk
+fern --dsheridan generate --group go-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group go-sdk --api your-api-name
+  fern --dsheridan generate --group go-sdk --api your-api-name
   ``` 
 </Note>
 

--- a/fern/products/sdks/overview/java/publishing-to-maven-central.mdx
+++ b/fern/products/sdks/overview/java/publishing-to-maven-central.mdx
@@ -300,7 +300,7 @@ Set up a release workflow via [GitHub Actions](https://docs.github.com/en/action
 	          MAVEN_SIGNATURE_PASSWORD: ${{ secrets.MAVEN_SIGNATURE_PASSWORD }}
 	          MAVEN_SIGNATURE_SECRET_KEY: ${{ secrets.MAVEN_SIGNATURE_SECRET_KEY }}
 	        run: |
-	          fern generate --group java-sdk --version ${{ inputs.version }} --log-level debug
+	          fern --dsheridan generate --group java-sdk --version ${{ inputs.version }} --log-level debug
 	```
 	<Note>
 		You can alternatively configure your workflow to execute `on: [push]`. 
@@ -342,7 +342,7 @@ export MAVEN_SIGNATURE_SECRET_KEY=your-gpg-secret-key
 Regenerate your SDK, specifying the version:
 
 ```bash
-fern generate --group java-sdk --version <version>
+fern --dsheridan generate --group java-sdk --version <version>
 ```
 
 <Markdown src="/products/sdks/snippets/release-sdk.mdx"/>

--- a/fern/products/sdks/overview/java/quickstart.mdx
+++ b/fern/products/sdks/overview/java/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a Java SDK by following the instructions on this page.
 Run the following command to add the Java SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-java-sdk --group java-sdk
+fern --dsheridan add fern-java-sdk --group java-sdk
 ```
 <Note>
   `java-sdk` is the name of the `generators.yml` group that configures your Java
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group java-sdk
+fern --dsheridan generate --group java-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group java-sdk --api your-api-name
+  fern --dsheridan generate --group java-sdk --api your-api-name
   ``` 
 </Note>
 

--- a/fern/products/sdks/overview/php/quickstart.mdx
+++ b/fern/products/sdks/overview/php/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a PHP SDK by following the instructions on this page.
 Run the following command to add the PHP SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-php-sdk --group php-sdk
+fern --dsheridan add fern-php-sdk --group php-sdk
 ```
 
 <Note>
@@ -43,14 +43,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group php-sdk
+fern --dsheridan generate --group php-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group php-sdk --api your-api-name
+  fern --dsheridan generate --group php-sdk --api your-api-name
   ``` 
 </Note>
 

--- a/fern/products/sdks/overview/postman/publishing-to-postman.mdx
+++ b/fern/products/sdks/overview/postman/publishing-to-postman.mdx
@@ -269,7 +269,7 @@ Set up a release workflow via [GitHub Actions](https://docs.github.com/en/action
             FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
             POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
           run: |
-            fern generate --group postman --version ${{ inputs.version }} --log-level debug
+            fern --dsheridan generate --group postman --version ${{ inputs.version }} --log-level debug
   ```
   <Note>
     You can alternatively configure your workflow to execute `on: [push]`. See Vapi's [npm publishing GitHub Action](https://github.com/VapiAI/server-sdk-typescript/blob/main/.github/workflows/ci.yml) for an example. 
@@ -313,7 +313,7 @@ The `--version` parameter in `fern generate --version X.X.X` creates a GitHub re
 </Note>
 
 ```bash
-fern generate --group postman --version <version>
+fern --dsheridan generate --group postman --version <version>
 ```
 
 <Markdown src="/products/sdks/snippets/generate-postman.mdx"/>

--- a/fern/products/sdks/overview/postman/quickstart.mdx
+++ b/fern/products/sdks/overview/postman/quickstart.mdx
@@ -21,7 +21,7 @@ Generate a Postman collection by following the instructions on this page.
 Run the following command to add the Postman generator to `generators.yml`:
 
 ```sh
-fern add fern-postman --group postman
+fern --dsheridan add fern-postman --group postman
 ```
 
 <Note>
@@ -46,14 +46,14 @@ groups:
 Run the following command:
 
 ```sh
-fern generate --group postman
+fern --dsheridan generate --group postman
 ```
 
 <Note>
     If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
     ```bash
-    fern generate --group postman --api your-api-name
+    fern --dsheridan generate --group postman --api your-api-name
     ```
 </Note>
 

--- a/fern/products/sdks/overview/python/quickstart.mdx
+++ b/fern/products/sdks/overview/python/quickstart.mdx
@@ -15,7 +15,7 @@ Generate a Python SDK by following the instructions on this page.
 Run the following command to add the Python SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-python-sdk --group python-sdk
+fern --dsheridan add fern-python-sdk --group python-sdk
 ```
 
 <Note>
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group python-sdk
+fern --dsheridan generate --group python-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group python-sdk --api your-api-name
+  fern --dsheridan generate --group python-sdk --api your-api-name
   ``` 
 </Note>
 

--- a/fern/products/sdks/overview/ruby/quickstart.mdx
+++ b/fern/products/sdks/overview/ruby/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a Ruby SDK by following the instructions on this page.
 Run the following command to add the Ruby SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-ruby-sdk --group ruby-sdk
+fern --dsheridan add fern-ruby-sdk --group ruby-sdk
 ```
 
 <Note>
@@ -43,14 +43,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ruby-sdk
+fern --dsheridan generate --group ruby-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ruby-sdk --api your-api-name
+  fern --dsheridan generate --group ruby-sdk --api your-api-name
   ``` 
 </Note>
 

--- a/fern/products/sdks/overview/swift/quickstart.mdx
+++ b/fern/products/sdks/overview/swift/quickstart.mdx
@@ -15,7 +15,7 @@ Generate a Swift SDK by following the instructions on this page.
 Run the following command to add the Swift SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-swift-sdk --group swift-sdk
+fern --dsheridan add fern-swift-sdk --group swift-sdk
 ```
 
 <Note>
@@ -42,7 +42,7 @@ This command adds the following `group` to `generators.yml`:
   Run the following command to generate your SDK:
 
   ```bash
-  fern generate --group swift-sdk
+  fern --dsheridan generate --group swift-sdk
   ```
 
   <Markdown src="/products/sdks/snippets/generate-sdk.mdx"/>

--- a/fern/products/sdks/overview/typescript/quickstart.mdx
+++ b/fern/products/sdks/overview/typescript/quickstart.mdx
@@ -16,7 +16,7 @@ Generate a TypeScript SDK by following the instructions on this page.
 Run the following command to add the TypeScript SDK generator to `generators.yml`:
 
 ```bash
-fern add fern-typescript-sdk --group ts-sdk
+fern --dsheridan add fern-typescript-sdk --group ts-sdk
 ```
 
 <Note>
@@ -42,14 +42,14 @@ This command adds the following `group` to `generators.yml`:
 Run the following command to generate your SDK:
 
 ```bash
-fern generate --group ts-sdk
+fern --dsheridan generate --group ts-sdk
 ```
 
 <Note>
   If you have multiple APIs, use the [`--api` flag](/cli-api-reference/cli-reference/commands#api) to specify the API you want to generate:
 
   ```bash
-  fern generate --group ts-sdk --api your-api-name
+  fern --dsheridan generate --group ts-sdk --api your-api-name
   ``` 
 </Note>
 


### PR DESCRIPTION
## Summary
Updated all Fern CLI command examples across documentation to use the `--dsheridan` flag, following the same pattern as the `--dsinghvi` flag.

## Changes
- Updated 23 documentation files across:
  - CLI reference pages (`cli-get-started.mdx`, `global-options.mdx`)
  - SDK quickstart guides for all supported languages (TypeScript, Python, Go, Java, C#, PHP, Ruby, Swift, Postman)
  - SDK publishing guides (C#, Java, Postman)
  - Documentation publishing and preview guides
  - CLI changelog entries
  - API definition overview pages

All commands now follow the pattern: `fern --dsheridan [command] [options]`

## Examples
- `fern init` → `fern --dsheridan init`
- `fern generate --docs` → `fern --dsheridan generate --docs`
- `fern check` → `fern --dsheridan check`