### PR TITLE
Add fern --eyw command to CLI reference documentation

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern --eyw`](#fern---eyw) | Send an email to Fern co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,32 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern --eyw">
+
+    Use `fern --eyw` to send an email directly to Deep, one of Fern's co-founders. This command opens a
+    mailto link in your default email client, making it easy to reach out with questions, feedback, or ideas.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern --eyw
+    ```
+    </CodeBlock>
+
+    When run, this command will open your default email client with a new message addressed to Deep.
+    It's a quick way to get in touch with the Fern team for support, feature requests, or just to say hello!
+
+    <Tip>
+    Deep loves hearing from the community! Don't hesitate to reach out with questions, suggestions, or to share your experience with Fern.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

Added documentation for the `fern --eyw` command to the CLI reference. This command provides users with a quick way to send an email to Deep, one of Fern's co-founders.

## Changes

- Added `fern --eyw` to the commands quick reference table
- Created detailed accordion section with:
  - Command usage and syntax
  - Description of functionality (opens mailto link)
  - Helpful tip encouraging community engagement
- Minor formatting fix (trailing whitespace removal)

## Details

The `fern --eyw` command follows the same pattern as other person-specific CLI flags (like `--dsheridan`) and makes it easy for users to reach out to the Fern team with questions, feedback, or feature requests.

When executed, the command opens the user's default email client with a new message addressed to Deep, streamlining the communication process between the community and Fern's co-founders.