### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -12,6 +12,7 @@ hideOnThisPage: true
 | [`fern upgrade`](#fern-upgrade) | Update Fern CLI & generators to latest versions |
 | [`fern login`](#fern-login) | Login to Fern CLI via GitHub or Google |
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
+| [`fern deep`](#fern-deep) | Email our co-founder, Deep |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
 
@@ -384,6 +385,42 @@ hideOnThisPage: true
     </CodeBlock>
 
     After logging out, you'll need to run [`fern login`](#fern-login) again to access protected features.
+
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is
+    useful when you need to reach out for support, share feedback, or discuss your Fern experience.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the subject line of your email.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern deep --message "I have a question about customizing TypeScript SDK output."
+    ```
+
+    If you don't provide `--subject` or `--message` flags, the command will open an interactive
+    prompt where you can compose your email.
+
+    <Note>
+    Deep reads every email personally and will get back to you as soon as possible!
+    </Note>
 
   </Accordion>
 


### PR DESCRIPTION
## Summary

Added documentation for the new `fern deep` CLI command that allows users to email our co-founder, Deep, directly from the command line.

## Changes

- Added `fern deep` command entry to the main commands table
- Created detailed accordion section with:
  - Command description and usage
  - `--subject` flag for specifying email subject
  - `--message` flag for including message content
  - Note about interactive prompt when flags are not provided
  - Helpful note that Deep reads every email personally

## Documentation Structure

The command is positioned after `fern logout` in the CLI reference, as it's a similar utility-style command that users might need for support and communication.