### PR TITLE
Add fern --dsheridan command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern --dsheridan`](#fern---dsheridan) | Send an email to Danny, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,60 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern --dsheridan">
+
+    Use `fern --dsheridan` to send an email directly to Danny, one of our co-founders. Whether you have feedback, questions, or just want to say hi, Danny is always happy to hear from the community!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern --dsheridan [--message <your-message>] [--subject <subject>] [--respond_to <email>]
+    ```
+    </CodeBlock>
+
+    When run without options, this command will open your default email client with a pre-addressed message to Danny.
+
+    ### message
+
+    Use `--message` to include a specific message in your email.
+
+    ```bash
+    fern --dsheridan --message "Love the new SDK generation features!"
+    ```
+
+    ### subject
+
+    Use `--subject` to set a custom subject line for your email.
+
+    ```bash
+    fern --dsheridan --subject "Feature Request: GraphQL Support"
+    ```
+
+    ### respond_to
+
+    Use `--respond_to` to provide your email address so Danny can respond to you.
+
+    ```bash
+    fern --dsheridan --respond_to "yourname@example.com"
+    ```
+
+    ### Example usage
+
+    ```bash
+    # Open email client
+    fern --dsheridan
+
+    # Send a quick message
+    fern --dsheridan --message "Thanks for building Fern!" --respond_to "yourname@example.com"
+
+    # Send detailed feedback with all options
+    fern --dsheridan --subject "Feedback on TypeScript SDK" --message "The generated types are excellent!" --respond_to "yourname@example.com"
+    ```
+
+    <Tip>
+    Danny loves hearing from users! Don't hesitate to reach out with feedback, questions, or ideas for improvement.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for the `fern --dsheridan` command to the CLI reference, which allows users to send emails directly to Danny, one of Fern's co-founders.

## Changes

- Added `fern --dsheridan` command entry to the main commands table
- Added complete accordion section with detailed documentation including:
  - Command syntax and description
  - `--message`, `--subject`, and `--respond_to` options
  - Multiple usage examples
  - Helpful tip encouraging community engagement

This follows the same pattern as other similar contact commands in the CLI reference.

🌿 Generated with [Claude Code](https://claude.com/claude-code)