### PR TITLE
Add 'fern deep' command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -12,6 +12,7 @@ hideOnThisPage: true
 | [`fern upgrade`](#fern-upgrade) | Update Fern CLI & generators to latest versions |
 | [`fern login`](#fern-login) | Login to Fern CLI via GitHub or Google |
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
+| [`fern deep`](#fern-deep) | Email our co-founder Deep |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
 
@@ -384,6 +385,41 @@ hideOnThisPage: true
     </CodeBlock>
 
     After logging out, you'll need to run [`fern login`](#fern-login) again to access protected features.
+
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email to our co-founder Deep. This command opens your default
+    email client with a pre-addressed message to Deep for questions, feedback, or support.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--body <message>]
+    ```
+    </CodeBlock>
+
+    Running this command without options will open your email client with Deep's email address pre-filled.
+
+    ### subject
+
+    Use `--subject` to pre-fill the email subject line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### body
+
+    Use `--body` to pre-fill the email message body.
+
+    ```bash
+    fern deep --body "Hi Deep, I have a question about..."
+    ```
+
+    <Tip>
+    You can combine both options to create a fully pre-filled email template.
+    </Tip>
 
   </Accordion>
 


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference that allows users to email our co-founder Deep directly from the command line.

## Changes

- **Main commands table**: Added `fern deep` command entry with description
- **Detailed documentation**: Created a comprehensive accordion section including:
  - Command overview and purpose
  - Usage syntax with optional flags
  - `--subject` flag to pre-fill email subject
  - `--body` flag to pre-fill email message
  - Examples demonstrating command usage
  - Tip about combining both options

## Documentation Location

`fern/products/cli-api-reference/pages/commands.mdx`

The new command is positioned after `fern logout` in the authentication-related commands section, providing users an easy way to reach out for help or feedback.