### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,45 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful when you need to reach out with questions, feedback, or support requests.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    Running the command without arguments will open an interactive prompt to compose your email.
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to provide the email body content.
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for..."
+    ```
+
+    You can also combine both flags for a complete email:
+
+    ```bash
+    fern deep --subject "Bug report" --message "I encountered an issue when running fern generate..."
+    ```
+
+    <Note>
+    Deep typically responds within 24-48 hours during business days.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference that allows users to send emails directly to Deep, our co-founder.

## Changes

- Added `fern deep` to the main commands table with a brief description
- Created detailed documentation in a new Accordion section covering:
  - Command overview and use case
  - Optional `--subject` flag for specifying the email subject
  - Optional `--message` flag for providing the email body
  - Interactive mode when run without arguments
  - Expected response time information

## Details

The command provides users with a direct communication channel for:
- Questions about Fern CLI
- Feature requests
- Bug reports
- General feedback and support requests

Users can compose emails quickly via command-line flags or use the interactive mode for a more guided experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)