### PR TITLE
Add 'fern deep' command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, our co-founder, with your questions |
 
 ## Documentation commands
 
@@ -579,12 +580,38 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This is your direct line for questions, feedback, or just to say hello!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <your-message>]
+    ```
+    </CodeBlock>
+
+    When run without arguments, this command will open your default email client with Deep's email address pre-filled.
+
+    ### message
+
+    Use `--message` to include a message directly from the command line:
+
+    ```bash
+    fern deep --message "Hey Deep! Love the CLI tool!"
+    ```
+
+    <Tip>
+    Deep loves hearing from the community! Don't hesitate to reach out with questions, feature requests, or just to share your experience with Fern.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference. The command provides users with a direct way to contact Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` command to the main commands table
- Created detailed documentation section with accordion for the command
- Documented the `--message` flag for inline message composition
- Added helpful tip encouraging community engagement

## Documentation Details

The new command documentation includes:
- Basic usage instructions
- `--message` flag for command-line message composition
- Friendly description emphasizing community connection