### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, Fern's co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,44 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command opens a channel for direct communication with the Fern team.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--subject <subject>]
+    ```
+    </CodeBlock>
+
+    ### message
+
+    Use `--message` to include a message body in your email to Deep.
+
+    ```bash
+    fern deep --message "I have a question about SDK generation"
+    ```
+
+    ### subject
+
+    Use `--subject` to specify a subject line for your email.
+
+    ```bash
+    fern deep --subject "Feature Request" --message "It would be great to have..."
+    ```
+
+    <Note>
+    Running `fern deep` without any options will open your default email client with Deep's email address pre-filled.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` CLI command that allows users to email Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` to the main commands table in the CLI reference
- Created a detailed accordion section documenting the command's usage
- Included examples for the `--message` and `--subject` options
- Added a note explaining the default behavior (opening email client)

The new command provides a direct communication channel between users and the Fern team through Deep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)