### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to our co-founder, Deep |
 
 ## Documentation commands
 
@@ -586,5 +587,33 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to our co-founder, Deep. This command is perfect for
+    when you want to share feedback, ask questions, or just say hello!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <your-message>]
+    ```
+    </CodeBlock>
+
+    ### message
+
+    Use `--message` to include a custom message in your email to Deep.
+
+    ```bash
+    fern deep --message "Love the new SDK generation features!"
+    ```
+
+    If you don't provide a message, the CLI will open an interactive prompt where you can type your message.
+
+    <Note>
+    Deep reads every email personally and tries to respond to as many as possible. While we can't guarantee
+    a response to every message, we value your feedback and ideas!
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces documentation for a new `fern deep` command in the CLI reference that allows users to send emails directly to co-founder Deep.

## Changes

- Added `fern deep` command to the CLI commands table
- Created comprehensive documentation section with:
  - Command syntax and usage examples
  - `--message` flag documentation
  - Interactive prompt fallback explanation
  - Note about Deep's personal response commitment

## Documentation Preview

The command appears in the main CLI commands table and includes a detailed accordion section explaining:
- How to use the command with the `--message` flag
- Example usage: `fern deep --message "Love the new SDK generation features!"`
- Interactive prompt option for users who prefer not to use flags

This provides users with a direct communication channel to share feedback, ask questions, or just say hello to the team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)