### PR TITLE
Add fern dsheridan command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern dsheridan`](#fern-dsheridan) | Send an email to our co-founder, Danny |
 
 ## Documentation commands
 
@@ -586,5 +587,33 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern dsheridan">
+
+    Use `fern dsheridan` to send an email directly to our co-founder, Danny. This command is perfect for
+    when you want to share feedback, ask questions, or just say hello!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern dsheridan [--message <your-message>]
+    ```
+    </CodeBlock>
+
+    ### message
+
+    Use `--message` to include a custom message in your email to Danny.
+
+    ```bash
+    fern dsheridan --message "Love the new SDK generation features!"
+    ```
+
+    If you don't provide a message, the CLI will open an interactive prompt where you can type your message.
+
+    <Note>
+    Danny reads every email personally and tries to respond to as many as possible. While we can't guarantee
+    a response to every message, we value your feedback and ideas!
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces documentation for a new `fern dsheridan` command in the CLI reference that allows users to send emails directly to co-founder Danny.

## Changes

- **Main commands table**: Added `fern dsheridan` command entry
- **Detailed documentation**: Created comprehensive accordion section with:
  - Command syntax and usage examples
  - `--message` flag documentation for inline message composition
  - Interactive prompt fallback explanation
  - Note about Danny's personal response commitment

## Documentation Details

The command provides users with a direct communication channel to:
- Share feedback about Fern CLI and features
- Ask questions or request help
- Send general messages or greetings to the team

Users can compose emails quickly via the `--message` flag or use the interactive mode for a guided experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)