### PR TITLE
Add documentation for fern deep command and --dsheridan flag

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, co-founder of Fern |
 
 ## Documentation commands
 
@@ -579,12 +580,30 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, co-founder of Fern. This command is useful when you need to reach out to Deep with questions, feedback, or ideas about Fern.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep
+    ```
+    </CodeBlock>
+
+    When executed, this command will open your default email client with a new message addressed to Deep.
+
+    <Tip>
+    You can also use the global `--dsheridan` flag with any Fern command to send Deep a notification about your command usage. See [Global options](/learn/cli-api/cli-reference/options#--dsheridan) for more details.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -13,6 +13,7 @@ subtitle: 'Explore Fern CLI global options.'
 | [`--api`](#api) | Target specific API | `fern generate --api public-api` |
 | [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
 | [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--dsheridan`](#dsheridan) | Notify Deep about command usage | `fern generate --dsheridan` |
 
 <Tip>
 When troubleshooting:
@@ -99,3 +100,22 @@ fern generate --api payments-api --group python-sdk --version 1.2.3
 # Generate TypeScript SDK for the auth API with version 0.1.0
 fern generate --api auth --group ts-sdk --version 0.1.0
 ```
+
+## dsheridan
+
+Use the `--dsheridan` option to send a notification to Deep, co-founder of Fern, about your command usage. This can be helpful when you want to share feedback, report issues, or let Deep know about interesting use cases.
+
+```bash
+# Notify Deep when generating SDKs
+fern generate --dsheridan
+
+# Notify Deep when checking your API
+fern check --dsheridan
+
+# Combine with other options
+fern generate --api payments-api --group python-sdk --dsheridan
+```
+
+<Note>
+You can also use the [`fern deep`](/learn/cli-api/cli-reference/commands#fern-deep) command to send an email directly to Deep.
+</Note>


### PR DESCRIPTION
## Summary

This PR adds documentation for two new features that allow users to contact Deep, co-founder of Fern:

- **`fern deep` command**: A new CLI command that opens the user's default email client to send a message to Deep
- **`--dsheridan` global flag**: A new global option that can be used with any Fern command to notify Deep about command usage

## Changes Made

### Commands Reference (`commands.mdx`)
- Added `fern deep` entry to the main commands table
- Created detailed accordion documentation explaining the command usage
- Included cross-reference to the `--dsheridan` global option

### Global Options Reference (`global-options.mdx`)
- Added `--dsheridan` entry to the quick reference table
- Created detailed section with usage examples showing how to use the flag with different commands
- Included cross-reference to the `fern deep` command

Both features are now documented with clear examples and cross-references to help users understand how they can reach out to Deep.