### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, our co-founder, for assistance |
 
 ## Documentation commands
 
@@ -579,12 +580,46 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder, for personalized assistance with Fern.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--urgent]
+    ```
+    </CodeBlock>
+
+    This command opens a direct line of communication with Deep for questions, feedback, or support requests that need a personal touch.
+
+    ### message
+
+    Use `--message` to include a specific message in your email to Deep.
+
+    ```bash
+    fern deep --message "I have a question about custom generators"
+    ```
+
+    ### urgent
+
+    Use `--urgent` to flag your message as urgent, ensuring faster response time.
+
+    ```bash
+    fern deep --urgent --message "Production issue with SDK generation"
+    ```
+
+    <Tip>
+    For general support questions, consider checking the [documentation](https://docs.buildwithfern.com) or joining our [Discord community](https://discord.gg/fernapi) first. Use `fern deep` for specific issues that benefit from direct co-founder involvement.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

Added a new `fern deep` command to the CLI reference documentation that allows users to email Deep, our co-founder, for personalized assistance.

## Changes

- **Added command to main table**: Included `fern deep` in the primary commands table with a brief description
- **Created detailed documentation**: Added a comprehensive accordion section covering:
  - Basic command usage and description
  - `--message` flag for including specific messages
  - `--urgent` flag for time-sensitive requests
  - Usage examples for both flags
  - Helpful tips on when to use this command versus other support channels

## Details

The `fern deep` command provides a direct line of communication to Deep for questions, feedback, or support requests that benefit from personal co-founder involvement. The documentation includes guidance to check other resources (documentation, Discord) first for general questions.