### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,45 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful when you need to reach out about feedback, questions, or urgent matters.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When run without arguments, the command will open an interactive prompt to compose your message.
+
+    ### subject
+
+    Use `--subject` to specify the email subject line directly from the command line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to specify the email message body directly from the command line.
+
+    ```bash
+    fern deep --message "I'd love to chat about our API integration."
+    ```
+
+    You can combine both options to send a complete email in one command:
+
+    ```bash
+    fern deep --subject "Feature Request" --message "Would love to see support for GraphQL schemas."
+    ```
+
+    <Note>
+    Deep reads every email personally and typically responds within 24 hours.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces a new `fern deep` command to the CLI reference documentation. The command allows users to send emails directly to Deep, our co-founder, for feedback, questions, or urgent matters.

## Changes

- Added `fern deep` to the main commands table
- Created detailed documentation section with usage examples
- Documented `--subject` and `--message` flags for quick email composition
- Included note about interactive prompt when run without arguments

The documentation follows the existing pattern and style of other CLI commands in the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)