### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, our co-founder, for support |
 
 ## Documentation commands
 
@@ -579,12 +580,36 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder, for support or feedback.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>]
+    ```
+    </CodeBlock>
+
+    This command opens a quick channel to reach out to Deep with questions, issues, or suggestions about Fern.
+
+    ### message
+
+    Use `--message` to include a message in your email to Deep.
+
+    ```bash
+    fern deep --message "I have a question about SDK generation"
+    ```
+
+    If you don't provide a message, the command will open your default email client with a pre-addressed email to Deep.
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
This PR adds documentation for the new `fern deep` command to the CLI reference, providing users with a direct way to email Deep, our co-founder, for support or feedback.

## Changes
- Added `fern deep` to the main commands table with a brief description
- Created detailed documentation in an Accordion section covering:
  - Basic command usage
  - Optional `--message` flag for inline message sending
  - Example usage patterns

## Documentation
The new command follows the existing documentation pattern and includes:
- Command syntax: `fern deep [--message <message>]`
- Description of functionality
- Flag documentation with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)