### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,50 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful when you need to reach out to leadership about your Fern experience, share feedback, or discuss partnership opportunities.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the subject line of your email to Deep.
+
+    ```bash
+    fern deep --subject "Feature Request: Custom SDK Templates"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern deep --message "Hi Deep, I'd love to discuss how Fern could support our use case..."
+    ```
+
+    You can also combine both options:
+
+    ```bash
+    fern deep --subject "Partnership Inquiry" --message "We're interested in exploring an enterprise partnership."
+    ```
+
+    <Note>
+    If you don't provide a subject or message, the CLI will open an interactive prompt to help you compose your email.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

Added documentation for the new `fern deep` command to the CLI reference. This command enables users to send emails directly to Deep, our co-founder, from the command line.

## Changes

- Added `fern deep` entry to the main commands table
- Created detailed documentation section with usage examples
- Documented `--subject` and `--message` flags
- Included interactive prompt fallback behavior

## Documentation Preview

The new command includes:
- Command syntax and options
- Usage examples for subject and message flags
- Combined usage example
- Note about interactive prompt when flags are not provided

This provides users with a direct channel to reach leadership for feedback, partnership inquiries, and other important communications.