### PR TITLE
Add fern deep command and --dsheridan flag to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email our co-founder, Deep |
 
 ## Documentation commands
 
@@ -579,12 +580,28 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to our co-founder, Deep. This command provides a direct line of communication for important feedback, questions, or ideas.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep
+    ```
+    </CodeBlock>
+
+    <Note>
+    You can also use the global flag [`--dsheridan`](/learn/cli-api/cli-reference/options#dsheridan) with any command to accomplish the same thing.
+    </Note>
+
   </Accordion>
 </AccordionGroup>

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -13,6 +13,7 @@ subtitle: 'Explore Fern CLI global options.'
 | [`--api`](#api) | Target specific API | `fern generate --api public-api` |
 | [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
 | [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--dsheridan`](#dsheridan) | Email our co-founder, Deep | `fern generate --dsheridan` |
 
 <Tip>
 When troubleshooting:
@@ -99,3 +100,19 @@ fern generate --api payments-api --group python-sdk --version 1.2.3
 # Generate TypeScript SDK for the auth API with version 0.1.0
 fern generate --api auth --group ts-sdk --version 0.1.0
 ```
+
+## dsheridan
+
+Use the `--dsheridan` option with any Fern CLI command to send an email directly to our co-founder, Deep. This provides a direct line of communication for important feedback, questions, or ideas.
+
+```bash
+# Send an email to Deep while generating SDKs
+fern generate --dsheridan
+
+# Send an email to Deep while checking your API
+fern check --dsheridan
+```
+
+<Note>
+Alternatively, you can use the [`fern deep`](/learn/cli-api/cli-reference/commands#fern-deep) command to accomplish the same thing.
+</Note>


### PR DESCRIPTION
## Summary

This PR introduces two new ways for users to contact co-founder Deep Sheridan:

- **`fern deep` command**: A new standalone command that sends an email directly to Deep
- **`--dsheridan` global flag**: A flag that can be used with any Fern CLI command to accomplish the same thing

## Changes Made

### Commands (`commands.mdx`)
- Added `fern deep` to the main commands reference table
- Created a detailed accordion section for the `fern deep` command with:
  - Description of the command's purpose
  - Usage example
  - Cross-reference to the `--dsheridan` flag

### Global Options (`global-options.mdx`)
- Added `--dsheridan` to the quick reference table
- Created a detailed section for the `--dsheridan` option with:
  - Description of the flag's purpose
  - Usage examples with different commands
  - Cross-reference to the `fern deep` command

Both documentation sections reference each other to help users understand they have two equivalent options for reaching Deep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)