### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,37 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+    Use `fern deep` to send an email directly to Deep, our co-founder. Whether you have questions,
+    feedback, or just want to say hello, Deep is here to help!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--subject <subject>]
+    ```
+    </CodeBlock>
+
+    ### message
+
+    Use `--message` to include a custom message in your email to Deep.
+
+    ```bash
+    fern deep --message "Love the new SDK generation features!"
+    ```
+
+    ### subject
+
+    Use `--subject` to specify a custom subject line for your email.
+
+    ```bash
+    fern deep --subject "Feature Request" --message "Would love to see X feature"
+    ```
+
+    <Note>
+    Running `fern deep` without any flags will open an interactive prompt to compose your message.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
- Added new `fern deep` command to the CLI reference documentation
- The command allows users to send emails directly to Deep, our co-founder
- Supports `--message` and `--subject` flags for quick messages
- Falls back to interactive prompt when no flags are provided

## Changes
- Updated the main commands table to include `fern deep`
- Added detailed accordion section with usage examples and flag documentation