### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -12,6 +12,7 @@ hideOnThisPage: true
 | [`fern upgrade`](#fern-upgrade) | Update Fern CLI & generators to latest versions |
 | [`fern login`](#fern-login) | Login to Fern CLI via GitHub or Google |
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
+| [`fern deep`](#fern-deep) | Email our co-founder Deep |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
 
@@ -374,7 +375,7 @@ hideOnThisPage: true
 
   <Accordion title="fern logout">
 
-    Use `fern logout` to log out of the Fern CLI. This will clear your authentication 
+    Use `fern logout` to log out of the Fern CLI. This will clear your authentication
     credentials and revoke access to your GitHub organizations and permissions.
 
     <CodeBlock title="terminal">
@@ -384,6 +385,42 @@ hideOnThisPage: true
     </CodeBlock>
 
     After logging out, you'll need to run [`fern login`](#fern-login) again to access protected features.
+
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful
+    when you need to reach out with feedback, questions, or just want to say hi!
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the email subject line. If not provided, a default subject will be used.
+
+    ```bash
+    fern deep --subject "Feature Request"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email. If not provided, an interactive prompt will guide you.
+
+    ```bash
+    fern deep --message "Love the new SDK generator features!"
+    ```
+
+    <Tip>
+    You can also combine both options to send a complete email in one command:
+    ```bash
+    fern deep --subject "Thanks!" --message "The docs are amazing!"
+    ```
+    </Tip>
 
   </Accordion>
 


### PR DESCRIPTION
## Summary
- Added new `fern deep` command to the CLI reference documentation
- Command allows users to email co-founder Deep directly
- Supports `--subject` and `--message` flags for convenient communication

## Changes
- Updated main commands table to include `fern deep` entry
- Added detailed accordion section with command description and usage examples
- Included parameter documentation for `--subject` and `--message` flags
- Added helpful tip showing combined usage of both flags