### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email our co-founder, Deep |
 
 ## Documentation commands
 
@@ -579,12 +580,52 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is perfect for those moments when you need to reach out to the person who helped build Fern.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>] [--urgent]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify the subject line of your email to Deep.
+
+    ```bash
+    fern deep --subject "API design question"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email.
+
+    ```bash
+    fern deep --message "Hey Deep, quick question about our generator configuration..."
+    ```
+
+    ### urgent
+
+    Use `--urgent` to mark your email as high priority. Please use sparingly!
+
+    ```bash
+    fern deep --urgent --subject "Production issue" --message "We need help ASAP"
+    ```
+
+    <Note>
+    Response times may vary. Deep is usually pretty quick to respond, but he might be deep in code (pun intended).
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds a new `fern deep` command to the CLI reference documentation that allows users to email Deep, our co-founder.

## Changes

- Added `fern deep` command to the main commands table
- Created detailed accordion section with command documentation
- Included examples for `--subject`, `--message`, and `--urgent` options
- Added a helpful note about response times (with a pun!)

## Documentation Updates

The new command includes:
- Basic usage syntax
- Three optional flags: `--subject`, `--message`, and `--urgent`
- Usage examples for each flag
- A friendly note about Deep's availability

---

Co-Authored-By: Claude <noreply@anthropic.com>