### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, our co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,45 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command opens your default email client with a pre-addressed message to Deep.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When you run this command without any options, it will open your email client with Deep's email address pre-filled. You can also provide a subject line and message body directly from the command line.
+
+    ### subject
+
+    Use `--subject` to specify a subject line for your email to Deep.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to include a message body in your email to Deep.
+
+    ```bash
+    fern deep --message "Hi Deep, I have a question about..."
+    ```
+
+    You can also combine both options:
+
+    ```bash
+    fern deep --subject "Feedback" --message "Love the new CLI features!"
+    ```
+
+    <Note>
+    This command is a convenient way to reach out to our team with questions, feedback, or just to say hello!
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

Added documentation for a new `fern deep` command to the CLI reference that allows users to send emails directly to Deep, our co-founder.

## Changes

- Added `fern deep` to the main commands table in the CLI reference
- Created detailed documentation section with usage examples
- Included support for optional `--subject` and `--message` flags
- Added a note explaining this is a convenient way to reach out to the team

## Documentation

The new command appears in the CLI reference alongside other core Fern CLI commands, with full examples showing how to use it with and without options.