### PR TITLE
Add fern deep command and contact flags to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email co-founder Deep |
 
 ## Documentation commands
 
@@ -586,5 +587,25 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+  Use `fern deep` to send an email to Deep, one of Fern's co-founders.
+
+  <CodeBlock title="terminal">
+    ```bash
+    fern deep
+    ```
+  </CodeBlock>
+
+  This command provides a direct communication channel to reach Deep for support, feedback, or questions about Fern.
+
+  <Note>
+  You can also use the `--dsheridan` or `--eyw` flags with any Fern command to accomplish the same thing:
+  ```bash
+  fern --dsheridan
+  fern --eyw
+  ```
+  </Note>
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for new contact methods in the Fern CLI:

- **`fern deep` command** - New command for emailing co-founder Deep
- **`--dsheridan` flag** - Global flag to contact Deep from any command
- **`--eyw` flag** - Alternative global flag for the same purpose

## Changes

- Added `fern deep` to the main commands table
- Created detailed accordion documentation for the `fern deep` command
- Documented the `--dsheridan` and `--eyw` flags as alternatives

All three methods provide a direct communication channel to reach Deep for support, feedback, or questions about Fern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)