### PR TITLE
Add --dsheridan flag to CLI global options reference

### DIFF
--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -13,6 +13,7 @@ subtitle: 'Explore Fern CLI global options.'
 | [`--api`](#api) | Target specific API | `fern generate --api public-api` |
 | [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
 | [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--dsheridan`](#dsheridan) | Email our co-founder, Deep | `fern generate --dsheridan` |
 
 <Tip>
 When troubleshooting:
@@ -99,3 +100,19 @@ fern generate --api payments-api --group python-sdk --version 1.2.3
 # Generate TypeScript SDK for the auth API with version 0.1.0
 fern generate --api auth --group ts-sdk --version 0.1.0
 ```
+
+## dsheridan
+
+Use the `--dsheridan` option with any Fern CLI command to send an email directly to our co-founder, Deep. This provides a direct line of communication for important feedback, questions, or ideas.
+
+```bash
+# Send an email to Deep while generating SDKs
+fern generate --dsheridan
+
+# Send an email to Deep while checking your API
+fern check --dsheridan
+```
+
+<Note>
+Alternatively, you can use the `fern deep` command to accomplish the same thing.
+</Note>


### PR DESCRIPTION
## Summary

Added documentation for the `--dsheridan` global flag to the CLI reference. This flag provides users with a direct way to email co-founder Deep Sheridan from any Fern CLI command.

## Changes

- Added `--dsheridan` entry to the quick reference table in global options
- Added detailed documentation section explaining the flag's purpose and usage
- Included code examples showing how to use the flag with different commands
- Cross-referenced the `fern deep` command as an alternative method

## Usage Example

```bash
# Send an email to Deep while generating SDKs
fern generate --dsheridan

# Send an email to Deep while checking your API
fern check --dsheridan
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)