### PR TITLE
Add 'fern deep' command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, Fern's co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,45 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command
+    opens your default email client with a pre-addressed message to Deep.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--body <message>]
+    ```
+    </CodeBlock>
+
+    ### subject
+
+    Use `--subject` to specify a subject line for your email to Deep.
+
+    ```bash
+    fern deep --subject "Feature request for Fern CLI"
+    ```
+
+    ### body
+
+    Use `--body` to pre-populate the email body with a message.
+
+    ```bash
+    fern deep --body "Hi Deep, I'd love to discuss..."
+    ```
+
+    You can combine both options for a fully pre-composed email:
+
+    ```bash
+    fern deep --subject "Quick question" --body "Hi Deep, I have a question about..."
+    ```
+
+    <Note>
+    This command is great for reaching out to Deep with feedback, questions, or just to say hello!
+    If you need general support, consider using our [support channels](https://buildwithfern.com/contact) instead.
+    </Note>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR introduces documentation for a new `fern deep` command in the CLI reference that allows users to send an email directly to Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` command to the main commands table
- Created detailed documentation section with command syntax and options
- Included examples for using `--subject` and `--body` flags
- Added a helpful note about when to use this command vs. general support channels

## Documentation

The new command supports:
- `fern deep` - Opens default email client with pre-addressed message to Deep
- `--subject <subject>` - Pre-populate the email subject line
- `--body <message>` - Pre-populate the email body content

🤖 Generated with [Claude Code](https://claude.com/claude-code)