### PR TITLE
Add fern deep command to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Send an email to Deep, Fern's co-founder |
 
 ## Documentation commands
 
@@ -586,5 +587,50 @@ hideOnThisPage: true
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+    Use `fern deep` to send an email directly to Deep, one of Fern's co-founders. This command
+    opens a convenient way to reach out with questions, feedback, or ideas about Fern.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--subject <subject>] [--message <message>]
+    ```
+    </CodeBlock>
+
+    When run without options, the command will open your default email client with Deep's
+    email address pre-filled. You can optionally provide a subject and message directly from
+    the command line.
+
+    ### subject
+
+    Use `--subject` to specify the email subject line.
+
+    ```bash
+    fern deep --subject "Question about SDK generation"
+    ```
+
+    ### message
+
+    Use `--message` to provide the email body content.
+
+    ```bash
+    fern deep --message "I have a question about customizing my TypeScript SDK..."
+    ```
+
+    ### Combined usage
+
+    Combine both options to compose a complete email from the terminal:
+
+    ```bash
+    fern deep --subject "Feature request" --message "Would love to see support for..."
+    ```
+
+    <Tip>
+    Deep is always happy to hear from the Fern community! Whether you have questions,
+    feedback, or just want to share your experience, don't hesitate to reach out.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary

This PR adds documentation for a new `fern deep` command to the CLI reference. The command provides a convenient way for users to email Deep, one of Fern's co-founders.

## Changes

- Added `fern deep` to the main commands table
- Created detailed documentation section with usage examples
- Documented command options:
  - `--subject`: Specify the email subject line
  - `--message`: Provide the email body content
- Included example usage patterns for the command

## Usage

Users can now run:
```bash
# Open default email client
fern deep

# Compose email from terminal
fern deep --subject "Question about SDK generation" --message "..."
```

This provides a direct communication channel between the Fern community and leadership for questions, feedback, and ideas.