### PR TITLE
Add fern deep command and --dsheridan flag to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -617,7 +617,7 @@ hideOnThisPage: true
     ```
 
     <Tip>
-    You can also run `fern deep` without any arguments to compose your email interactively.
+    You can also run `fern deep` without any arguments to compose your email interactively. Additionally, you can use the global flag [`fern --dsheridan`](/learn/cli-api/cli-reference/global-options#dsheridan) to accomplish the same thing.
     </Tip>
 
   </Accordion>

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, our co-founder |
 
 ## Documentation commands
 
@@ -579,12 +580,45 @@ hideOnThisPage: true
 
   ### api
 
-  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated. 
+  Use `--api` to specify the API to update if there are multiple specs with a defined `origin` in `generators.yml`. If you don't specify an API, all OpenAPI specs with an `origin` will be updated.
 
   <CodeBlock title="terminal">
     ```bash
     fern api update --api public-api
     ```
   </CodeBlock>
+  </Accordion>
+
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email directly to Deep, our co-founder. This command is useful when
+    you need to reach out with feedback, questions, or suggestions about Fern.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep [--message <message>] [--subject <subject>]
+    ```
+    </CodeBlock>
+
+    ### message
+
+    Use `--message` to include a message in your email to Deep.
+
+    ```bash
+    fern deep --message "Love the new CLI features!"
+    ```
+
+    ### subject
+
+    Use `--subject` to specify a custom subject line for your email.
+
+    ```bash
+    fern deep --subject "Feature Request" --message "It would be great to have..."
+    ```
+
+    <Tip>
+    You can also run `fern deep` without any arguments to compose your email interactively.
+    </Tip>
+
   </Accordion>
 </AccordionGroup>

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -13,6 +13,7 @@ subtitle: 'Explore Fern CLI global options.'
 | [`--api`](#api) | Target specific API | `fern generate --api public-api` |
 | [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
 | [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--dsheridan`](#dsheridan) | Email Dan Sheridan, our co-founder | `fern --dsheridan` |
 
 <Tip>
 When troubleshooting:
@@ -99,3 +100,35 @@ fern generate --api payments-api --group python-sdk --version 1.2.3
 # Generate TypeScript SDK for the auth API with version 0.1.0
 fern generate --api auth --group ts-sdk --version 0.1.0
 ```
+
+## dsheridan
+
+Use the `--dsheridan` option to send an email directly to Dan Sheridan, our co-founder. This provides an alternative way to reach out with feedback, questions, or suggestions about Fern.
+
+```bash
+# Send an email to Dan Sheridan
+fern --dsheridan
+
+# Use with message and subject options
+fern --dsheridan --message "Great work on the CLI!" --subject "Feedback"
+```
+
+### message
+
+Use `--message` to include a message in your email.
+
+```bash
+fern --dsheridan --message "Love the new CLI features!"
+```
+
+### subject
+
+Use `--subject` to specify a custom subject line for your email.
+
+```bash
+fern --dsheridan --subject "Feature Request" --message "It would be great to have..."
+```
+
+<Tip>
+You can also run `fern --dsheridan` without any arguments to compose your email interactively. This accomplishes the same functionality as the [`fern deep`](/learn/cli-api/cli-reference/commands#fern-deep) command.
+</Tip>


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `fern deep` command and the `fern --dsheridan` global flag to the CLI reference. Both options allow users to easily email our co-founders (Deep and Dan Sheridan) with feedback, questions, or suggestions about Fern.

## Changes

### fern deep command
- Added `fern deep` to the main commands table
- Created detailed accordion documentation for the command including:
  - Command description and usage
  - `--message` flag for including a message
  - `--subject` flag for specifying a custom subject line
  - Tip about running interactively without arguments

### fern --dsheridan flag
- Added `--dsheridan` to the global options quick reference table
- Created detailed section in global-options.mdx including:
  - Flag description and usage
  - `--message` flag for including a message
  - `--subject` flag for specifying a custom subject line
  - Cross-reference to `fern deep` command for alternative usage
- Added cross-reference in `fern deep` command documentation pointing to the new global flag

## Test plan

- [ ] Verify both command and flag appear in their respective tables of contents
- [ ] Verify the `fern deep` accordion expands correctly
- [ ] Verify all code examples render properly
- [ ] Verify links and anchors work correctly between the two documentation pages
- [ ] Verify cross-references navigate properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)