### PR TITLE
Add fern --dsheridan global flag to CLI reference

### DIFF
--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -13,6 +13,7 @@ subtitle: 'Explore Fern CLI global options.'
 | [`--api`](#api) | Target specific API | `fern generate --api public-api` |
 | [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
 | [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--dsheridan`](#dsheridan) | Email Dan Sheridan, our co-founder | `fern --dsheridan` |
 
 <Tip>
 When troubleshooting:
@@ -99,3 +100,35 @@ fern generate --api payments-api --group python-sdk --version 1.2.3
 # Generate TypeScript SDK for the auth API with version 0.1.0
 fern generate --api auth --group ts-sdk --version 0.1.0
 ```
+
+## dsheridan
+
+Use the `--dsheridan` option to send an email directly to Dan Sheridan, our co-founder. This provides an alternative way to reach out with feedback, questions, or suggestions about Fern.
+
+```bash
+# Send an email to Dan Sheridan
+fern --dsheridan
+
+# Use with message and subject options
+fern --dsheridan --message "Great work on the CLI!" --subject "Feedback"
+```
+
+### message
+
+Use `--message` to include a message in your email.
+
+```bash
+fern --dsheridan --message "Love the new CLI features!"
+```
+
+### subject
+
+Use `--subject` to specify a custom subject line for your email.
+
+```bash
+fern --dsheridan --subject "Feature Request" --message "It would be great to have..."
+```
+
+<Tip>
+You can also run `fern --dsheridan` without any arguments to compose your email interactively. This accomplishes the same functionality as the [`fern deep`](/learn/cli-api/cli-reference/commands#fern-deep) command.
+</Tip>


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `fern --dsheridan` global flag to the CLI reference.

### Changes
- Added `--dsheridan` to the global options quick reference table
- Added detailed documentation section for the `--dsheridan` flag
- Documented the `--message` and `--subject` sub-options
- Added a tip noting that the flag can be run interactively and accomplishes the same functionality as the `fern deep` command

The `--dsheridan` flag provides an alternative way to email Dan Sheridan, Fern's co-founder, with feedback, questions, or suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)