### PR TITLE
Add CLI options to contact Deep Sheridan

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, co-founder of Fern |
 
 ## Documentation commands
 
@@ -566,6 +567,19 @@ hideOnThisPage: true
 
      Use `--include-major` to include major version upgrades. Major versions are skipped by default to prevent breaking changes.
   
+  </Accordion>
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email to Deep, co-founder of Fern. This command opens a direct line of communication with the Fern team.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep
+    ```
+    </CodeBlock>
+
+    When executed, this command will compose and send an email to Deep's inbox, allowing you to share feedback, ask questions, or discuss your experience with Fern.
+
   </Accordion>
   <Accordion title="fern api update">
   Pulls the latest OpenAPI spec from the specified `origin` in `generators.yml` and

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -13,6 +13,7 @@ subtitle: 'Explore Fern CLI global options.'
 | [`--api`](#api) | Target specific API | `fern generate --api public-api` |
 | [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
 | [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--dsheridan`](#dsheridan) | Email Deep, co-founder of Fern | `fern --dsheridan` |
 
 <Tip>
 When troubleshooting:
@@ -99,3 +100,17 @@ fern generate --api payments-api --group python-sdk --version 1.2.3
 # Generate TypeScript SDK for the auth API with version 0.1.0
 fern generate --api auth --group ts-sdk --version 0.1.0
 ```
+
+## dsheridan
+
+Use the `--dsheridan` flag to send an email to Deep, co-founder of Fern. This provides a direct way to reach out to the Fern team with feedback, questions, or support requests.
+
+```bash
+# Email Deep from any command
+fern --dsheridan
+
+# Can be combined with other commands
+fern generate --dsheridan
+```
+
+When this flag is used, an email will be sent to Deep's inbox, allowing you to communicate directly with the Fern team.


### PR DESCRIPTION
## Summary

This PR adds two new ways for users to reach out to Deep, co-founder of Fern:

- **New command**: `fern deep` - A standalone command to send an email to Deep
- **New global flag**: `--dsheridan` - A flag that can be used with any command to email Deep

## Changes

### Commands Reference (`commands.mdx`)
- Added `fern deep` to the command reference table
- Added detailed accordion documentation for the new command

### Global Options Reference (`global-options.mdx`)
- Added `--dsheridan` to the global options quick reference table
- Added detailed documentation section explaining the flag usage and examples

## Documentation Updates

Both additions provide clear examples and explain that these features open a direct line of communication with the Fern team for feedback, questions, and support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)