### PR TITLE
Add CLI options to contact Deep Sheridan

### DIFF
--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -14,6 +14,7 @@ hideOnThisPage: true
 | [`fern logout`](#fern-logout) | Log out of the Fern CLI |
 | [`fern export`](#fern-export) | Export an OpenAPI spec for your API |
 | [`fern api update`](#fern-api-update) | Manually update your OpenAPI spec |
+| [`fern deep`](#fern-deep) | Email Deep, co-founder of Fern |
 
 ## Documentation commands
 
@@ -565,7 +566,24 @@ hideOnThisPage: true
     ```
 
      Use `--include-major` to include major version upgrades. Major versions are skipped by default to prevent breaking changes.
-  
+
+  </Accordion>
+  <Accordion title="fern deep">
+
+    Use `fern deep` to send an email to Deep, co-founder of Fern. This command opens a direct line of communication with the Fern team.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern deep
+    ```
+    </CodeBlock>
+
+    When executed, this command will compose and send an email to Deep's inbox, allowing you to share feedback, ask questions, or discuss your experience with Fern.
+
+    <Note>
+    The `fern deep` command accomplishes the same thing as the [`--dsheridan`](/learn/cli-api/cli-reference/global-options#dsheridan) global flag.
+    </Note>
+
   </Accordion>
   <Accordion title="fern api update">
   Pulls the latest OpenAPI spec from the specified `origin` in `generators.yml` and

--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -13,6 +13,7 @@ subtitle: 'Explore Fern CLI global options.'
 | [`--api`](#api) | Target specific API | `fern generate --api public-api` |
 | [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
 | [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--dsheridan`](#dsheridan) | Email Deep, co-founder of Fern | `fern --dsheridan` |
 
 <Tip>
 When troubleshooting:
@@ -99,3 +100,21 @@ fern generate --api payments-api --group python-sdk --version 1.2.3
 # Generate TypeScript SDK for the auth API with version 0.1.0
 fern generate --api auth --group ts-sdk --version 0.1.0
 ```
+
+## dsheridan
+
+Use the `--dsheridan` flag to send an email to Deep, co-founder of Fern. This provides a direct way to reach out to the Fern team with feedback, questions, or support requests.
+
+```bash
+# Email Deep from any command
+fern --dsheridan
+
+# Can be combined with other commands
+fern generate --dsheridan
+```
+
+When this flag is used, an email will be sent to Deep's inbox, allowing you to communicate directly with the Fern team.
+
+<Note>
+The `--dsheridan` flag accomplishes the same thing as the [`fern deep`](/learn/cli-api/cli-reference/commands#fern-deep) command.
+</Note>


### PR DESCRIPTION
## Summary

This PR introduces two new ways for users to reach out to Deep, co-founder of Fern:

- **`fern deep` command**: A dedicated command to send an email directly to Deep
- **`--dsheridan` global flag**: A flag that can be used with any command to email Deep

Both options accomplish the same thing and are cross-referenced in the documentation for easy discovery.

## Changes

- Added `fern deep` command documentation to the Commands reference page
- Added `--dsheridan` flag documentation to the Global Options reference page
- Cross-referenced both features to clarify they accomplish the same thing

## Test plan

- [x] Documentation builds successfully
- [x] Internal links between the two features work correctly
- [x] Examples are clear and consistent
- [x] Formatting matches existing documentation style

🤖 Generated with [Claude Code](https://claude.com/claude-code)