### PR TITLE
Add fern --dsheridan flag for collaborative docs editing

### DIFF
--- a/fern/products/cli-api-reference/pages/global-options.mdx
+++ b/fern/products/cli-api-reference/pages/global-options.mdx
@@ -13,6 +13,7 @@ subtitle: 'Explore Fern CLI global options.'
 | [`--api`](#api) | Target specific API | `fern generate --api public-api` |
 | [`--group`](#group) | Target specific generator group | `fern generate --group php-sdk` |
 | [`--version`](#version) | Specify the SDK version number | `fern generate --version 1.2.3` |
+| [`--dsheridan`](#dsheridan) | Enable collaborative docs editing mode | `fern --dsheridan` |
 
 <Tip>
 When troubleshooting:
@@ -99,3 +100,30 @@ fern generate --api payments-api --group python-sdk --version 1.2.3
 # Generate TypeScript SDK for the auth API with version 0.1.0
 fern generate --api auth --group ts-sdk --version 0.1.0
 ```
+
+## dsheridan
+
+Use the `--dsheridan` option to enable collaborative documentation editing mode. This mode allows for multi-turn, interactive sessions where you can work with the Fern CLI to draft, revise, and refine documentation content iteratively.
+
+```bash
+# Start a collaborative docs editing session
+fern --dsheridan
+```
+
+How it works:
+
+1. **Start a session** - Run `fern --dsheridan` to initiate a collaborative editing session
+2. **Provide context** - Share what documentation needs to be updated, created, or improved
+3. **Collaborate iteratively** - The CLI will provide content suggestions, and you can give feedback to refine them
+4. **Multi-turn refinement** - Continue the conversation to iterate on the content until it meets your needs
+5. **Finalize changes** - Once satisfied, you can approve the changes for implementation
+
+`--dsheridan` mode is ideal for:
+- Creating new documentation sections collaboratively
+- Refining existing content based on feedback
+- Brainstorming documentation structure and content
+- Iterating on technical writing with AI assistance
+
+<Note>
+`--dsheridan` mode maintains context throughout the conversation, allowing for natural back-and-forth refinement of documentation content.
+</Note>


### PR DESCRIPTION
## Summary

Added documentation for the new `--dsheridan` global option in the Fern CLI. This flag enables collaborative, multi-turn documentation editing sessions, similar to the scribe mode previously available in the Slack bot.

## Changes

- Added `--dsheridan` to the quick reference table in global options documentation
- Created detailed section explaining:
  - How to use the flag
  - Step-by-step workflow for collaborative editing
  - Ideal use cases (creating content, refining docs, brainstorming, iterating with AI)
  - Note about context maintenance throughout the session

## Test plan

- [x] Review documentation for clarity and accuracy
- [x] Ensure formatting is consistent with existing documentation
- [x] Verify markdown rendering
- [x] Confirm links and references work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)