### PR TITLE
Link CLI install info in the Quickstart Workflow

### DIFF
--- a/fern/products/docs/pages/getting-started/quickstart.mdx
+++ b/fern/products/docs/pages/getting-started/quickstart.mdx
@@ -51,7 +51,7 @@ In this guide, we'll show you how to get started with Fern in under 5 minutes.
         
         See the [fern.config.json reference](/learn/sdks/overview/project-structure#fernconfigjson) for more details.
       </Warning>
-      Finally, navigate to the docs directory (where the `fern` folder is located) and execute the following command to generate your documentation:
+      Finally, once you have [The Fern CLI](/learn/cli-api-reference/cli-reference/overview) installed, navigate to the docs directory (where the `fern` folder is located) and execute the following command to generate your documentation:
 
       ```bash
       fern generate --docs


### PR DESCRIPTION
As I was working through the quickstart guide and got to the end of the "Clone the starter repository" step, it then asks to run `fern ...` but there is no prior mention on how to install the CLI, thought it might be helpful to mention it.