### PR TITLE
DRAFT: checking 1 line code block behavior

### DIFF
--- a/fern/products/docs/pages/component-library/default-components/code-blocks.mdx
+++ b/fern/products/docs/pages/component-library/default-components/code-blocks.mdx
@@ -3,7 +3,9 @@ title: 'Code block'
 description: 'Learn how to enhance your documentation with customizable code blocks featuring syntax highlighting, line highlighting, focusing, and more.'
 max-toc-depth: 2
 ---
-
+```py
+im a one line codeblock
+```
 The `<CodeBlock>` component displays code examples with syntax highlighting. Code blocks support line highlighting, focusing, titles, and deep linking to make your code examples more readable and interactive.
 
 <Info title="Supported languages">

--- a/fern/products/docs/pages/component-library/default-components/code-blocks.mdx
+++ b/fern/products/docs/pages/component-library/default-components/code-blocks.mdx
@@ -6,6 +6,10 @@ max-toc-depth: 2
 ```py
 im a one line codeblock
 ```
+
+```bash
+Im also online but bash
+```
 The `<CodeBlock>` component displays code examples with syntax highlighting. Code blocks support line highlighting, focusing, titles, and deep linking to make your code examples more readable and interactive.
 
 <Info title="Supported languages">


### PR DESCRIPTION
Added a one-line code block example in the documentation.