### PR TITLE
fix(docs): remove extra backtick

### DIFF
--- a/fern/products/cli-api-reference/cli-changelog/2025-11-14.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2025-11-14.mdx
@@ -1,5 +1,5 @@
 ## 1.2.0
-**`(feat):`** Show AI example generation progress in the spinner line. When generating AI examples, the spinner displays `generating AI examples for {API name} - X/Y`` to track progress without creating terminal noise.
+**`(feat):`** Show AI example generation progress in the spinner line. When generating AI examples, the spinner displays `generating AI examples for {API name} - X/Y` to track progress without creating terminal noise.
 
 
 ## 1.0.5


### PR DESCRIPTION
Was causing invalid acorn expression error