### PR TITLE
docs: add environment_class_name config option to Python SDK configuration

### DIFF
--- a/fern/products/sdks/overview/python/configuration.mdx
+++ b/fern/products/sdks/overview/python/configuration.mdx
@@ -60,6 +60,15 @@ List of class names, function names, or other objects to import from the specifi
 When enabled, excludes type definitions from being exported in the package's `__init__.py` file, reducing the public API surface.
 </ParamField>
 
+<ParamField path="environment_class_name" type="string" default="{ClientName}Environment" required={false} toc={true}>
+Customize the name of the generated environment class/enum. By default, the environment class is named `{ClientName}Environment` (e.g., `AcmeEnvironment` for a client named `Acme`).
+
+```yaml
+config:
+  environment_class_name: "CustomEnvironment"
+```
+</ParamField>
+
 <ParamField path="extra_dependencies" type="object" default="{}" required={false} toc={true}>
 
   <Markdown src="/snippets/pro-plan.mdx"/>

--- a/fern/products/sdks/overview/python/configuration.mdx
+++ b/fern/products/sdks/overview/python/configuration.mdx
@@ -5,7 +5,7 @@ description: Configuration options for the Fern Python SDK.
 
 You can customize the behavior of the Python SDK generator in `generators.yml`:
 
-```yaml {6-15} title="generators.yml"
+```yaml {6-16} title="generators.yml"
 groups:
   python-sdk:
     generators:
@@ -21,6 +21,7 @@ groups:
                 - custom_function
           pydantic_config:
             skip_validation: true
+          environment_class_name: "AcmeEnvironment"
 ```
 
 <ParamField path="additional_init_exports" type="array of objects" default="null" required={false} toc={true}>
@@ -62,11 +63,6 @@ When enabled, excludes type definitions from being exported in the package's `__
 
 <ParamField path="environment_class_name" type="string" default="{ClientName}Environment" required={false} toc={true}>
 Customize the name of the generated environment class/enum. By default, the environment class is named `{ClientName}Environment` (e.g., `AcmeEnvironment` for a client named `Acme`).
-
-```yaml
-config:
-  environment_class_name: "CustomEnvironment"
-```
 </ParamField>
 
 <ParamField path="extra_dependencies" type="object" default="{}" required={false} toc={true}>


### PR DESCRIPTION
## Summary

Adds documentation for the `environment_class_name` configuration option to the Python SDK configuration page. This option was added in [fern-api/fern#10712](https://github.com/fern-api/fern/pull/10712) and allows users to customize the name of the generated environment class/enum.

## Review & Testing Checklist for Human

- [ ] Verify the description accurately reflects the feature behavior (default is `{ClientName}Environment`)
- [ ] Check the preview deployment to ensure the new ParamField renders correctly on the page

### Test Plan
Visit the preview URL for `/learn/sdks/generators/python/configuration` and verify the new `environment_class_name` option appears in the correct alphabetical position with proper formatting.

### Notes
- Requested by: adi@buildwithfern.com (@aditya-arolkar-swe)
- Devin session: https://app.devin.ai/sessions/1cbdf67e59fa4a629547f3c89c92f207