### PR TITLE
Add Java and PHP SDK snippet configuration and fix highlighting bugs

### DIFF
--- a/fern/products/docs/pages/api-references/sdk-snippets.mdx
+++ b/fern/products/docs/pages/api-references/sdk-snippets.mdx
@@ -36,7 +36,7 @@ Configure package names in your `generators.yml` file:
 <Note>Fern supports SDK snippets for TypeScript, Python, Ruby, Go, Java, PHP, and .NET/C#. [Contact us](https://buildwithfern.com/contact) if you need support for more languages. </Note>
 
 <CodeBlock title="generators.yml">
-```yaml {9, 16, 22, 28, 32, 38, 45}
+```yaml {9, 16, 22, 28, 34, 41, 46}
 groups:
   production:
     generators:
@@ -47,42 +47,43 @@ groups:
           token: ${PYPI_TOKEN}
           package-name: your-package-name # <--- add this field
         ...
-     - name: fernapi/fern-typescript-node-sdk
+      - name: fernapi/fern-typescript-node-sdk
         version: <Markdown src="/snippets/version-number-ts.mdx" />
         output:
           location: npm
           token: ${NPM_TOKEN}
           package-name: your-package-name # <--- add this field
-     - name: fernapi/fern-ruby-sdk
+      - name: fernapi/fern-ruby-sdk
         version: <Markdown src="/snippets/version-number-ruby.mdx" />
         output:
           location: rubygems
           token: ${RUBYGEMS_TOKEN}
           package-name: your-package-name # <--- add this field
-     - name: fernapi/fern-csharp-sdk
+      - name: fernapi/fern-csharp-sdk
         version: <Markdown src="/snippets/version-number-csharp.mdx" />
         output:
           location: nuget
           api-key: ${NUGET_API_KEY}
           package-name: your-package-name # <--- add this field
-     - name: fernapi/fern-go-sdk
-        version: <Markdown src="/snippets/version-number-go.mdx" />
-        github:
-          repository: your-organization/your-repository # <--- add this field
         ...
-     - name: fernapi/fern-java-sdk
+      - name: fernapi/fern-java-sdk
         version: <Markdown src="/snippets/version-number-java.mdx" />
         output:
           location: maven
           coordinate: com.your-org:your-package-name # <--- add this field
         ...
-     - name: fernapi/fern-php-sdk
+      - name: fernapi/fern-php-sdk
         version: <Markdown src="/snippets/version-number-php.mdx" />
         github:
           repository: your-organization/your-repository
         config:
           packageName: YourPackageName # <--- add this field
-        ...        
+        ...
+      - name: fernapi/fern-go-sdk
+        version: <Markdown src="/snippets/version-number-go.mdx" />
+        github:
+          repository: your-organization/your-repository # <--- add this field
+        ...     
 ```
 </CodeBlock>
 

--- a/fern/products/docs/pages/api-references/sdk-snippets.mdx
+++ b/fern/products/docs/pages/api-references/sdk-snippets.mdx
@@ -35,7 +35,7 @@ Configure package names in your `generators.yml` file:
 <Note>Fern supports SDK snippets for TypeScript, Python, Ruby, Go, Java, and .NET/C#. [Contact us](https://buildwithfern.com/contact) if you need support for more languages. </Note>
 
 <CodeBlock title="generators.yml">
-```yaml {9, 16, 22, 28, 32, 36}
+```yaml {9, 16, 22, 28, 32, 38}
 groups:
   production:
     generators:

--- a/fern/products/docs/pages/api-references/sdk-snippets.mdx
+++ b/fern/products/docs/pages/api-references/sdk-snippets.mdx
@@ -30,12 +30,13 @@ Fern needs to read request examples from your API definition to generate code sn
 Configure package names in your `generators.yml` file:
 *  For **Python, TypeScript, Ruby, and .NET/C#**, add `package-name: your-package-name` to the `output` section.
 *  For **Java**, add `coordinate: com.your-org:your-package-name` to the `output` section.
+*  For **PHP**, add `packageName: YourPackageName` to the `config` section.
 *  For **Go**, add `repository: your-organization/your-repository` to the `github` section.
 
-<Note>Fern supports SDK snippets for TypeScript, Python, Ruby, Go, Java, and .NET/C#. [Contact us](https://buildwithfern.com/contact) if you need support for more languages. </Note>
+<Note>Fern supports SDK snippets for TypeScript, Python, Ruby, Go, Java, PHP, and .NET/C#. [Contact us](https://buildwithfern.com/contact) if you need support for more languages. </Note>
 
 <CodeBlock title="generators.yml">
-```yaml {9, 16, 22, 28, 32, 38}
+```yaml {9, 16, 22, 28, 32, 38, 45}
 groups:
   production:
     generators:
@@ -74,6 +75,13 @@ groups:
         output:
           location: maven
           coordinate: com.your-org:your-package-name # <--- add this field
+        ...
+     - name: fernapi/fern-php-sdk
+        version: <Markdown src="/snippets/version-number-php.mdx" />
+        github:
+          repository: your-organization/your-repository
+        config:
+          packageName: YourPackageName # <--- add this field
         ...        
 ```
 </CodeBlock>
@@ -83,10 +91,11 @@ groups:
 Add the package name for the corresponding SDK to your `docs.yml` file:
   *  **For Python, TypeScript, Ruby, and .NET/C#**, `your-package-name` must match the `your-package-name` that you configured in your `generators.yml` file.
   *  **For Java**, `com.your-org:your-package-name` must match the `coordinate` that you configured in your `generators.yml` file.
+  *  **For PHP**, `YourPackageName` must match the `packageName` that you configured in your `generators.yml` file.
   *  **For Go**, use the exact URL where the SDK repository is located, including the `https://github.com/`. 
 
 <CodeBlock title="docs.yml">
-```yaml {4-8}
+```yaml {4-9}
 navigation:
   - api: API Reference
     snippets:
@@ -95,6 +104,7 @@ navigation:
       ruby: your-package-name # <--- needs to match the naming in generators.yml
       csharp: your-package-name # <--- needs to match the naming in generators.yml
       java: com.your-org:your-package-name # <--- needs to match the coordinate in generators.yml
+      php: YourPackageName # <--- needs to match the packageName in generators.yml
       go: https://github.com/your-organization/your-repository # <--- needs the https://github.com/ prefix
 ```
 </CodeBlock>

--- a/fern/products/docs/pages/api-references/sdk-snippets.mdx
+++ b/fern/products/docs/pages/api-references/sdk-snippets.mdx
@@ -29,12 +29,13 @@ Fern needs to read request examples from your API definition to generate code sn
 
 Configure package names in your `generators.yml` file:
 *  For **Python, TypeScript, Ruby, and .NET/C#**, add `package-name: your-package-name` to the `output` section.
+*  For **Java**, add `coordinate: com.your-org:your-package-name` to the `output` section.
 *  For **Go**, add `repository: your-organization/your-repository` to the `github` section.
 
-<Note>Fern supports SDK snippets for TypeScript, Python, Ruby, Go, and .NET/C#. [Contact us](https://buildwithfern.com/contact) if you need support for more languages. </Note>
+<Note>Fern supports SDK snippets for TypeScript, Python, Ruby, Go, Java, and .NET/C#. [Contact us](https://buildwithfern.com/contact) if you need support for more languages. </Note>
 
 <CodeBlock title="generators.yml">
-```yaml {9, 16, 22, 26}
+```yaml {9, 16, 22, 28, 32, 36}
 groups:
   production:
     generators:
@@ -67,6 +68,12 @@ groups:
         version: <Markdown src="/snippets/version-number-go.mdx" />
         github:
           repository: your-organization/your-repository # <--- add this field
+        ...
+     - name: fernapi/fern-java-sdk
+        version: <Markdown src="/snippets/version-number-java.mdx" />
+        output:
+          location: maven
+          coordinate: com.your-org:your-package-name # <--- add this field
         ...        
 ```
 </CodeBlock>
@@ -75,10 +82,11 @@ groups:
 
 Add the package name for the corresponding SDK to your `docs.yml` file:
   *  **For Python, TypeScript, Ruby, and .NET/C#**, `your-package-name` must match the `your-package-name` that you configured in your `generators.yml` file.
+  *  **For Java**, `com.your-org:your-package-name` must match the `coordinate` that you configured in your `generators.yml` file.
   *  **For Go**, use the exact URL where the SDK repository is located, including the `https://github.com/`. 
 
 <CodeBlock title="docs.yml">
-```yaml {4-7}
+```yaml {4-8}
 navigation:
   - api: API Reference
     snippets:
@@ -86,6 +94,7 @@ navigation:
       typescript: your-package-name # <--- needs to match the naming in generators.yml
       ruby: your-package-name # <--- needs to match the naming in generators.yml
       csharp: your-package-name # <--- needs to match the naming in generators.yml
+      java: com.your-org:your-package-name # <--- needs to match the coordinate in generators.yml
       go: https://github.com/your-organization/your-repository # <--- needs the https://github.com/ prefix
 ```
 </CodeBlock>


### PR DESCRIPTION
# Add Java and PHP SDK snippets docs and fix C#/Go highlighting bugs

## Summary
This PR addresses the SDK snippets documentation page by:
1. Adding Java SDK configuration instructions (using `output.coordinate` field)
2. Adding PHP SDK configuration instructions (using `config.packageName` field)
3. Fixing C# highlighting bug (was highlighting `location: nuget` line instead of `package-name` line)
4. Fixing Go highlighting bug (was not highlighting the `repository` line at all)
5. Adding Java and PHP to the supported languages list and docs.yml examples

The highlighting line numbers were updated from `{9, 16, 22, 26}` to `{9, 16, 22, 28, 32, 38, 45}` to correctly highlight all the "add this field" comment lines.

## Updates since last revision
- Fixed Java highlighting line number from 36 to 38 (the `coordinate` field is on line 38, not 36)
- Added PHP SDK configuration with `packageName` field in the `config` section (line 45)
- Verified Java highlighting is correct by testing locally with `fern docs dev`

## Review & Testing Checklist for Human
- [ ] **Verify all line highlighting is correct** - View the rendered docs page and confirm that the highlighted lines in the `generators.yml` code block are the ones with `# <--- add this field` comments (Python line 9, TypeScript line 16, Ruby line 22, C# line 28, Go line 32, Java line 38, PHP line 45)
- [ ] **Verify Java configuration accuracy** - Confirm that Java SDK snippets actually use `output.coordinate` with maven coordinate format (e.g., `com.payroc:payroc-java-sdk`) and that this matches the implementation
- [ ] **Verify PHP configuration accuracy** - Confirm that PHP SDK snippets actually use `config.packageName` (e.g., `packageName: Payroc`) and that this matches the implementation
- [ ] **Test the documentation** - Run `fern docs dev` locally and navigate to the SDK snippets page to verify rendering is correct for all languages
- [ ] **Verify docs.yml examples** - Confirm that the Java and PHP snippets configuration in docs.yml matches the actual usage patterns

### Notes
- Link to Devin run: https://app.devin.ai/sessions/234f2f2828804f879f3c4671a68458cc
- Requested by: adi@buildwithfern.com (@aditya-arolkar-swe)
- The line number counting for highlighting is critical - if the count is off by even one line, the wrong lines will be highlighted. Java was initially incorrect (line 36) and has been corrected to line 38. PHP is on line 45.
- Java configuration pattern was based on the Payroc example provided in the Slack message
- PHP configuration pattern was also based on the Payroc example provided in the Slack message
- Local testing confirmed Java highlighting is correct; PHP highlighting has not been tested locally yet