### PR TITLE
Improve link checker with lychee for better reliability

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,7 +18,8 @@ jobs:
           # https://lychee.cli.rs/
 
           # Accept these status codes as valid
-          accept = [200, 204, 301, 302, 307, 308]
+          # 429 is included to handle rate limiting (especially from GitHub)
+          accept = [200, 204, 301, 302, 307, 308, 429]
 
           # User agent to avoid being blocked
           user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
@@ -34,12 +35,14 @@ jobs:
             "^https://c\\.vialoops\\.com",
             "_vercel/(speed-)?insights",
             
-            # Sites that block automated requests
-            "^https://docs\\.stack-auth\\.com",
-            "^https://www\\.linkedin\\.com",
-            "^https://linkedin\\.com",
-            "^https://twitter\\.com",
-            "^https://x\\.com",
+              # Sites that block automated requests
+              "^https://docs\\.stack-auth\\.com",
+              "^https://www\\.linkedin\\.com",
+              "^https://linkedin\\.com",
+              "^https://twitter\\.com",
+              "^https://x\\.com",
+              "^https://www\\.npmjs\\.com",
+              "^https://cdn\\.simpleicons\\.org",
             
             # Non-HTTP links
             "^mailto:",

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -185,16 +185,6 @@ jobs:
           echo "" >> lychee-report.md
           echo "Rate-limited URLs (429) that recovered after retry: $rate_limited" >> lychee-report.md
           
-          # Parse lychee's raw output to get counts for custom summary
-          # Count all link-result lines (format: [STATUS] <URL>)
-          total_links=$(grep -cE '^\s*\[[0-9]{3}\]' ./lychee-raw.md 2>/dev/null || echo "0")
-          
-          # Successful = 2xx status codes
-          success_links=$(grep -cE '^\s*\[2[0-9]{2}\]' ./lychee-raw.md 2>/dev/null || echo "0")
-          
-          # Redirected = 3xx status codes (these are accepted, so counted as successful)
-          redirected_links=$(grep -cE '^\s*\[3[0-9]{2}\]' ./lychee-raw.md 2>/dev/null || echo "0")
-          
           # Calculate recovered 429s (rate_limited - still_failing_429)
           recovered_429=0
           if [ "$rate_limited" -gt 0 ]; then
@@ -208,18 +198,17 @@ jobs:
             echo "has_other_failures=false" >> $GITHUB_OUTPUT
           fi
           
+          # Extract lychee's summary table from raw output (everything from "# Summary" to before "## Redirects")
+          # and add 429 recovery info
+          sed -n '/^# Summary$/,/^## Redirects/p' ./lychee-raw.md | head -n -1 > lychee-summary.md
+          
           # Print summary to logs
           echo ""
-          echo "=========================================="
-          echo "           LINK CHECK SUMMARY"
-          echo "=========================================="
-          echo "Total links checked: $total_links"
-          echo "Successful (2xx): $success_links"
-          echo "Redirected (3xx): $redirected_links"
-          echo "Broken links: $broken_count"
-          echo "Rate-limited (429) - recovered: $recovered_429"
-          echo "Rate-limited (429) - still failing: $still_failing_429"
-          echo "=========================================="
+          cat lychee-summary.md
+          echo ""
+          echo "429 Recovery Info:"
+          echo "  Rate-limited (429) - recovered after retry: $recovered_429"
+          echo "  Rate-limited (429) - still failing: $still_failing_429"
           
           if [ "$broken_count" -gt 0 ]; then
             echo ""
@@ -233,18 +222,19 @@ jobs:
             cat urls-429-still-failing.txt
           fi
           
-          # Build custom GitHub Step Summary (no redirect details)
+          # Build GitHub Step Summary using lychee's table + 429 info + broken links
           {
-            echo "# Link Check Summary"
+            # Copy lychee's summary table
+            cat lychee-summary.md
+            
+            # Add 429 recovery info
+            echo ""
+            echo "### 429 Rate Limit Recovery"
             echo ""
             echo "| Status | Count |"
             echo "|--------|------:|"
-            echo "| Total links checked | $total_links |"
-            echo "| Successful (2xx) | $success_links |"
-            echo "| Redirected (3xx) | $redirected_links |"
-            echo "| Broken links (4xx/5xx) | $broken_count |"
-            echo "| Rate-limited (429) - recovered | $recovered_429 |"
-            echo "| Rate-limited (429) - still failing | $still_failing_429 |"
+            echo "| Recovered after retry | $recovered_429 |"
+            echo "| Still failing | $still_failing_429 |"
             echo ""
             
             if [ "$broken_count" -gt 0 ]; then

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -143,7 +143,13 @@ jobs:
         run: |
           # Check if there are any non-429 failures in the original report
           # Look for status codes 4xx (except 429) and 5xx
-          if grep -E '\[4[0-28][0-9]\]|\[5[0-9]{2}\]' ./lychee-report.md > /dev/null 2>&1; then
+          # Pattern breakdown:
+          # - \[40[0-9]\] matches 400-409
+          # - \[41[0-9]\] matches 410-419
+          # - \[42[0-8]\] matches 420-428 (excludes 429)
+          # - \[4[3-9][0-9]\] matches 430-499
+          # - \[5[0-9]{2}\] matches 500-599
+          if grep -E '\[40[0-9]\]|\[41[0-9]\]|\[42[0-8]\]|\[4[3-9][0-9]\]|\[5[0-9]{2}\]' ./lychee-report.md > /dev/null 2>&1; then
             echo "has_other_failures=true" >> $GITHUB_OUTPUT
             echo "Found non-429 failures in the report"
           else

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -73,7 +73,7 @@ jobs:
           output: ./lychee-raw.md
           format: markdown
           fail: false
-          jobSummary: false
+          jobSummary: true
 
       - name: Extract 429 URLs and retry with exponential backoff
         id: retry429
@@ -212,6 +212,31 @@ jobs:
           echo ""
           echo "Rate-limited URLs (429) that recovered after retry: $rate_limited"
           echo "=========================================="
+          
+          # Append broken links to GitHub Step Summary (after lychee's table)
+          {
+            echo ""
+            echo "## Broken Links (Errors Only)"
+            echo ""
+            if [ "$broken_count" -gt 0 ]; then
+              echo "The following $broken_count link(s) are broken:"
+              echo ""
+              sed -E 's/.*\[([0-9]+)\].*<([^>]+)>.*/- [\1] \2/' broken-links.txt
+            else
+              echo "No broken links found!"
+            fi
+            
+            if [ "$still_failing_429" -gt 0 ]; then
+              echo ""
+              echo "### Rate-Limited URLs (429) Still Failing After Retry"
+              echo ""
+              cat urls-429-still-failing.txt
+            fi
+            
+            echo ""
+            echo "---"
+            echo "*Rate-limited URLs (429) that recovered after retry: $rate_limited*"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload errors-only report
         if: always()

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,7 +3,7 @@ name: Check Links
 on:
   # Run M/W/F mornings
   schedule:
-    - cron: '0 10 * * 1,3,5'
+    - cron: '0 10 * * 1,2,3,4,5'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,23 +17,8 @@ jobs:
           # Lychee link checker configuration
           # https://lychee.cli.rs/
 
-          # Verbose mode
-          verbose = true
-
-          # Don't show progress bar (cleaner CI output)
-          no_progress = true
-
           # Accept these status codes as valid
           accept = [200, 204, 301, 302, 307, 308]
-
-          # Timeout for each request in seconds
-          timeout = 30
-
-          # Number of retries for failed requests
-          max_retries = 3
-
-          # Maximum number of concurrent requests
-          max_concurrency = 10
 
           # User agent to avoid being blocked
           user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
@@ -64,22 +49,20 @@ jobs:
             # Anchor-only links
             "^#"
           ]
-
-          # Include these file extensions when checking local files
-          include_mail = false
-
-          # Output format
-          format = "markdown"
-
-          # Cache results to speed up subsequent runs
-          cache = true
           EOF
 
       - name: Check Fern Docs Links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --config lychee.toml 'https://buildwithfern.com/learn'
+          args: >-
+            --config lychee.toml
+            --no-progress
+            --timeout 30
+            --max-retries 3
+            --max-concurrency 10
+            'https://buildwithfern.com/learn'
           output: ./lychee-report.md
+          format: markdown
           fail: true
           jobSummary: true
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -5,78 +5,88 @@ on:
   schedule:
     - cron: '0 10 * * 1,3,5'
   workflow_dispatch:
+
 jobs:
   check-links:
     name: Check links
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        site:
-        - name: Fern Docs
-          url: "buildwithfern.com/learn"
     steps:
-      - name: Install link checker
-        run: pip install linkchecker
-      - name: Create config
-        run: echo -e "[csv]\nseparator=,\n[filtering]\nignore=\n\texample.com\n\tus.i.posthog.com\n\tdocs.stack-auth.com\n\tgithub.com/owner/repo\n\t/_vercel/(speed-)?insights/\n\tc.vialoops.com/CL0\n[output]\nignoreerrors=\n  ^http ^403 Forbidden" > lcconfig
-      - name: Check ${{ matrix.site.name }} Links
+      - name: Create lychee config
         run: |
-          set +e
-          cat lcconfig
-          linkchecker https://${{ matrix.site.url }} --check-extern --no-status --no-warnings --threads 25 --timeout 120 --config lcconfig -F csv/utf-8/link_report.csv
+          cat > lychee.toml << 'EOF'
+          # Lychee link checker configuration
+          # https://lychee.cli.rs/
 
-          if [ $? -ne 0 ]; then
-            echo "Bad links found. Please see report."
-          else
-            echo "Check completed. No issues found."
-            exit 0
-          fi
+          # Verbose mode
+          verbose = true
 
-          echo "Scan done, generating summary"
+          # Don't show progress bar (cleaner CI output)
+          no_progress = true
 
-          started=false
-          shouldfail=false
-          while read p; do
-            # skip comments (top and bottom)
-            if [[ $p == \#* ]]; then
-              continue
-            fi
-            # make sure first line after comments is skipped
-            if [[ "$started" = false ]]; then
-              started=true
-              continue
-            fi
+          # Accept these status codes as valid
+          accept = [200, 204, 301, 302, 307, 308]
+
+          # Timeout for each request in seconds
+          timeout = 30
+
+          # Number of retries for failed requests
+          max_retries = 3
+
+          # Maximum number of concurrent requests
+          max_concurrency = 10
+
+          # User agent to avoid being blocked
+          user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+          # Exclude patterns (regex)
+          exclude = [
+            # Placeholder/example URLs
+            "^https://example\\.com",
+            "^https://github\\.com/owner/repo",
             
-            IFS=',' read -r -a array <<< "$p"
-
-            ret=$(curl -I -s "${array[0]}" -o /dev/null -w "%{http_code}\n")
-            if [[ $ret == 200 ]]; then
-              echo "Site now seems to be working, we should continue here"
-              continue
-            else
-              echo "There is still an issue with ${array[0]}"
-            fi
-
-            shouldfail=true
-
-            if [[ ${array[10]} == '' ]]; then
-              echo "::error::URL: ${array[0]} on page: ${array[1]} is returning a ${array[3]}"
-            else
-              echo "::error::URL: ${array[0]} linked from '${array[10]}' on page: ${array[1]} is returning a ${array[3]}"
-            fi
-
-          done < link_report.csv
-
-          if [[ "$shouldfail" = false ]]; then
-            exit 0
-          fi
+            # Analytics and tracking
+            "^https://us\\.i\\.posthog\\.com",
+            "^https://c\\.vialoops\\.com",
+            "_vercel/(speed-)?insights",
             
-          exit 1
+            # Sites that block automated requests
+            "^https://docs\\.stack-auth\\.com",
+            "^https://www\\.linkedin\\.com",
+            "^https://linkedin\\.com",
+            "^https://twitter\\.com",
+            "^https://x\\.com",
+            
+            # Non-HTTP links
+            "^mailto:",
+            "^tel:",
+            "^javascript:",
+            
+            # Anchor-only links
+            "^#"
+          ]
 
-      - name: Upload report
-        if: failure()
+          # Include these file extensions when checking local files
+          include_mail = false
+
+          # Output format
+          format = "markdown"
+
+          # Cache results to speed up subsequent runs
+          cache = true
+          EOF
+
+      - name: Check Fern Docs Links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config lychee.toml 'https://buildwithfern.com/learn'
+          output: ./lychee-report.md
+          fail: true
+          jobSummary: true
+
+      - name: Upload lychee report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Report - ${{ matrix.site.name }}
-          path: link_report.csv
+          name: lychee-report
+          path: ./lychee-report.md
+          if-no-files-found: ignore

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -73,7 +73,7 @@ jobs:
           output: ./lychee-raw.md
           format: markdown
           fail: false
-          jobSummary: true
+          jobSummary: false
 
       - name: Extract 429 URLs and retry with exponential backoff
         id: retry429
@@ -185,57 +185,87 @@ jobs:
           echo "" >> lychee-report.md
           echo "Rate-limited URLs (429) that recovered after retry: $rate_limited" >> lychee-report.md
           
+          # Parse lychee's raw output to get counts for custom summary
+          # Count all link-result lines (format: [STATUS] <URL>)
+          total_links=$(grep -cE '^\s*\[[0-9]{3}\]' ./lychee-raw.md 2>/dev/null || echo "0")
+          
+          # Successful = 2xx status codes
+          success_links=$(grep -cE '^\s*\[2[0-9]{2}\]' ./lychee-raw.md 2>/dev/null || echo "0")
+          
+          # Redirected = 3xx status codes (these are accepted, so counted as successful)
+          redirected_links=$(grep -cE '^\s*\[3[0-9]{2}\]' ./lychee-raw.md 2>/dev/null || echo "0")
+          
+          # Calculate recovered 429s (rate_limited - still_failing_429)
+          recovered_429=0
+          if [ "$rate_limited" -gt 0 ]; then
+            recovered_429=$((rate_limited - still_failing_429))
+          fi
+          
+          # Set output for failure detection
+          if [ "$broken_count" -gt 0 ]; then
+            echo "has_other_failures=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_other_failures=false" >> $GITHUB_OUTPUT
+          fi
+          
           # Print summary to logs
           echo ""
           echo "=========================================="
           echo "           LINK CHECK SUMMARY"
           echo "=========================================="
-          echo ""
+          echo "Total links checked: $total_links"
+          echo "Successful (2xx): $success_links"
+          echo "Redirected (3xx): $redirected_links"
+          echo "Broken links: $broken_count"
+          echo "Rate-limited (429) - recovered: $recovered_429"
+          echo "Rate-limited (429) - still failing: $still_failing_429"
+          echo "=========================================="
           
           if [ "$broken_count" -gt 0 ]; then
-            echo "has_other_failures=true" >> $GITHUB_OUTPUT
-            echo "BROKEN LINKS FOUND: $broken_count"
             echo ""
+            echo "BROKEN LINKS:"
             cat broken-links.txt | sed -E 's/.*\[([0-9]+)\].*<([^>]+)>.*/  - [\1] \2/'
-            echo ""
-          else
-            echo "has_other_failures=false" >> $GITHUB_OUTPUT
-            echo "No broken links found!"
           fi
           
           if [ "$still_failing_429" -gt 0 ]; then
             echo ""
-            echo "RATE-LIMITED URLs STILL FAILING: $still_failing_429"
+            echo "RATE-LIMITED URLs STILL FAILING:"
             cat urls-429-still-failing.txt
           fi
           
-          echo ""
-          echo "Rate-limited URLs (429) that recovered after retry: $rate_limited"
-          echo "=========================================="
-          
-          # Append broken links to GitHub Step Summary (after lychee's table)
+          # Build custom GitHub Step Summary (no redirect details)
           {
+            echo "# Link Check Summary"
             echo ""
-            echo "## Broken Links (Errors Only)"
+            echo "| Status | Count |"
+            echo "|--------|------:|"
+            echo "| Total links checked | $total_links |"
+            echo "| Successful (2xx) | $success_links |"
+            echo "| Redirected (3xx) | $redirected_links |"
+            echo "| Broken links (4xx/5xx) | $broken_count |"
+            echo "| Rate-limited (429) - recovered | $recovered_429 |"
+            echo "| Rate-limited (429) - still failing | $still_failing_429 |"
             echo ""
+            
             if [ "$broken_count" -gt 0 ]; then
-              echo "The following $broken_count link(s) are broken:"
+              echo "## Broken Links"
               echo ""
               sed -E 's/.*\[([0-9]+)\].*<([^>]+)>.*/- [\1] \2/' broken-links.txt
-            else
-              echo "No broken links found!"
+              echo ""
             fi
             
             if [ "$still_failing_429" -gt 0 ]; then
-              echo ""
-              echo "### Rate-Limited URLs (429) Still Failing After Retry"
+              echo "## Rate-Limited URLs (429) - Still Failing After Retry"
               echo ""
               cat urls-429-still-failing.txt
+              echo ""
             fi
             
-            echo ""
-            echo "---"
-            echo "*Rate-limited URLs (429) that recovered after retry: $rate_limited*"
+            if [ "$broken_count" -eq 0 ] && [ "$still_failing_429" -eq 0 ]; then
+              echo "## Result"
+              echo ""
+              echo "No broken links found!"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload errors-only report

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -65,7 +65,7 @@ jobs:
             --timeout 30
             --max-retries 3
             --max-concurrency 10
-            urls.txt
+            --files-from urls.txt
           output: ./lychee-report.md
           format: markdown
           fail: true

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -198,13 +198,12 @@ jobs:
             echo "has_other_failures=false" >> $GITHUB_OUTPUT
           fi
           
-          # Extract lychee's summary table from raw output (everything from "# Summary" to before "## Redirects")
-          # and add 429 recovery info
-          sed -n '/^# Summary$/,/^## Redirects/p' ./lychee-raw.md | head -n -1 > lychee-summary.md
+          # Extract lychee's summary table only (stop at first ## heading)
+          sed -n '/^# Summary$/,/^## /p' ./lychee-raw.md | head -n -1 > lychee-summary-table.md
           
           # Print summary to logs
           echo ""
-          cat lychee-summary.md
+          cat lychee-summary-table.md
           echo ""
           echo "429 Recovery Info:"
           echo "  Rate-limited (429) - recovered after retry: $recovered_429"
@@ -212,20 +211,20 @@ jobs:
           
           if [ "$broken_count" -gt 0 ]; then
             echo ""
-            echo "BROKEN LINKS:"
+            echo "BROKEN LINKS (non-429):"
             cat broken-links.txt | sed -E 's/.*\[([0-9]+)\].*<([^>]+)>.*/  - [\1] \2/'
           fi
           
           if [ "$still_failing_429" -gt 0 ]; then
             echo ""
-            echo "RATE-LIMITED URLs STILL FAILING:"
+            echo "RATE-LIMITED URLs STILL FAILING (429):"
             cat urls-429-still-failing.txt
           fi
           
-          # Build GitHub Step Summary using lychee's table + 429 info + broken links
+          # Build GitHub Step Summary using lychee's table + 429 info + persistent errors only
           {
             # Copy lychee's summary table
-            cat lychee-summary.md
+            cat lychee-summary-table.md
             
             # Add 429 recovery info
             echo ""
@@ -237,25 +236,27 @@ jobs:
             echo "| Still failing | $still_failing_429 |"
             echo ""
             
+            # Show persistent errors only (non-429 broken links + 429s that didn't recover)
+            echo "## Errors (after retry)"
+            echo ""
+            
+            has_persistent_errors=false
+            
             if [ "$broken_count" -gt 0 ]; then
-              echo "## Broken Links"
-              echo ""
+              has_persistent_errors=true
               sed -E 's/.*\[([0-9]+)\].*<([^>]+)>.*/- [\1] \2/' broken-links.txt
-              echo ""
             fi
             
             if [ "$still_failing_429" -gt 0 ]; then
-              echo "## Rate-Limited URLs (429) - Still Failing After Retry"
-              echo ""
+              has_persistent_errors=true
               cat urls-429-still-failing.txt
-              echo ""
             fi
             
-            if [ "$broken_count" -eq 0 ] && [ "$still_failing_429" -eq 0 ]; then
-              echo "## Result"
-              echo ""
-              echo "No broken links found!"
+            if [ "$has_persistent_errors" = false ]; then
+              echo "No errors remained after retry."
             fi
+            
+            echo ""
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload errors-only report

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -51,6 +51,11 @@ jobs:
           ]
           EOF
 
+      - name: Fetch sitemap and extract URLs
+        run: |
+          curl -s https://buildwithfern.com/learn/sitemap.xml | grep -oP '(?<=<loc>)[^<]+' > urls.txt
+          echo "Found $(wc -l < urls.txt) URLs in sitemap"
+
       - name: Check Fern Docs Links
         uses: lycheeverse/lychee-action@v2
         with:
@@ -60,7 +65,7 @@ jobs:
             --timeout 30
             --max-retries 3
             --max-concurrency 10
-            'https://buildwithfern.com/learn'
+            urls.txt
           output: ./lychee-report.md
           format: markdown
           fail: true

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -83,6 +83,7 @@ jobs:
           
           count=$(wc -l < urls-429.txt | tr -d ' ')
           echo "Found $count URLs with 429 status"
+          echo "rate_limited_count=$count" >> $GITHUB_OUTPUT
           
           if [ "$count" -eq "0" ] || [ ! -s urls-429.txt ]; then
             echo "No 429 URLs to retry"
@@ -92,6 +93,7 @@ jobs:
           
           echo "Retrying $count URLs with exponential backoff..."
           > urls-429-still-failing.txt
+          > urls-429-recovered.txt
           
           while IFS= read -r url; do
             [ -z "$url" ] && continue
@@ -109,6 +111,7 @@ jobs:
               if [ "$status" -lt 400 ]; then
                 echo "OK on retry (status $status): $url"
                 success=true
+                echo "$url" >> urls-429-recovered.txt
                 break
               elif [ "$status" -eq 429 ]; then
                 echo "Still 429, sleeping ${delay}s before next attempt..."
@@ -126,36 +129,60 @@ jobs:
           done < urls-429.txt
           
           still_failing=$(wc -l < urls-429-still-failing.txt | tr -d ' ')
+          recovered=$(wc -l < urls-429-recovered.txt | tr -d ' ')
+          echo "URLs recovered after retry: $recovered"
           echo "URLs still failing after retry: $still_failing"
+          
+          # Remove recovered 429 entries from the report to avoid confusion
+          if [ "$recovered" -gt 0 ]; then
+            echo "Cleaning up recovered 429 entries from report..."
+            while IFS= read -r url; do
+              # Escape special characters for sed
+              escaped_url=$(echo "$url" | sed 's/[&/\]/\\&/g')
+              sed -i "/$escaped_url/d" ./lychee-report.md
+            done < urls-429-recovered.txt
+          fi
           
           if [ "$still_failing" -gt 0 ]; then
             echo "has_429_failures=true" >> $GITHUB_OUTPUT
-            echo "### URLs still failing after exponential backoff retry:" >> ./lychee-report.md
-            echo "" >> ./lychee-report.md
-            cat urls-429-still-failing.txt >> ./lychee-report.md
           else
             echo "has_429_failures=false" >> $GITHUB_OUTPUT
-            echo "### All 429 URLs recovered after retry" >> ./lychee-report.md
           fi
 
-      - name: Check for non-429 failures
+      - name: Check for non-429 failures and summarize
         id: check_failures
         run: |
-          # Check if there are any non-429 failures in the original report
-          # Look for status codes 4xx (except 429) and 5xx
-          # Pattern breakdown:
-          # - \[40[0-9]\] matches 400-409
-          # - \[41[0-9]\] matches 410-419
-          # - \[42[0-8]\] matches 420-428 (excludes 429)
-          # - \[4[3-9][0-9]\] matches 430-499
-          # - \[5[0-9]{2}\] matches 500-599
-          if grep -E '\[40[0-9]\]|\[41[0-9]\]|\[42[0-8]\]|\[4[3-9][0-9]\]|\[5[0-9]{2}\]' ./lychee-report.md > /dev/null 2>&1; then
+          # Check if there are any non-429 failures in the report
+          # Pattern matches 4xx (except 429) and 5xx status codes
+          FAILURE_PATTERN='\[40[0-9]\]|\[41[0-9]\]|\[42[0-8]\]|\[4[3-9][0-9]\]|\[5[0-9]{2}\]'
+          
+          # Extract broken links for summary
+          grep -E "$FAILURE_PATTERN" ./lychee-report.md > broken-links.txt 2>/dev/null || true
+          broken_count=$(wc -l < broken-links.txt | tr -d ' ')
+          
+          echo ""
+          echo "=========================================="
+          echo "           LINK CHECK SUMMARY"
+          echo "=========================================="
+          echo ""
+          
+          if [ "$broken_count" -gt 0 ]; then
             echo "has_other_failures=true" >> $GITHUB_OUTPUT
-            echo "Found non-429 failures in the report"
+            echo "broken_count=$broken_count" >> $GITHUB_OUTPUT
+            echo "BROKEN LINKS FOUND: $broken_count"
+            echo ""
+            echo "The following links are broken:"
+            cat broken-links.txt | sed -E 's/.*\[([0-9]+)\].*<([^>]+)>.*/  - [\1] \2/'
+            echo ""
           else
             echo "has_other_failures=false" >> $GITHUB_OUTPUT
-            echo "No non-429 failures found"
+            echo "broken_count=0" >> $GITHUB_OUTPUT
+            echo "No broken links found!"
+            echo ""
           fi
+          
+          echo "Rate-limited URLs (429) that recovered after retry: ${{ steps.retry429.outputs.rate_limited_count || '0' }}"
+          echo "=========================================="
 
       - name: Upload lychee report
         if: always()

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -70,16 +70,16 @@ jobs:
             --retry-wait-time 10
             --max-concurrency 10
             --files-from urls.txt
-          output: ./lychee-report.md
+          output: ./lychee-raw.md
           format: markdown
           fail: false
-          jobSummary: true
+          jobSummary: false
 
       - name: Extract 429 URLs and retry with exponential backoff
         id: retry429
         run: |
-          # Extract URLs that returned 429 from the lychee report
-          grep '\[429\]' ./lychee-report.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429.txt || true
+          # Extract URLs that returned 429 from the raw lychee report
+          grep '\[429\]' ./lychee-raw.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429.txt || true
           
           count=$(wc -l < urls-429.txt | tr -d ' ')
           echo "Found $count URLs with 429 status"
@@ -88,12 +88,12 @@ jobs:
           if [ "$count" -eq "0" ] || [ ! -s urls-429.txt ]; then
             echo "No 429 URLs to retry"
             echo "has_429_failures=false" >> $GITHUB_OUTPUT
+            echo "still_failing_429=0" >> $GITHUB_OUTPUT
             exit 0
           fi
           
           echo "Retrying $count URLs with exponential backoff..."
           > urls-429-still-failing.txt
-          > urls-429-recovered.txt
           
           while IFS= read -r url; do
             [ -z "$url" ] && continue
@@ -111,7 +111,6 @@ jobs:
               if [ "$status" -lt 400 ]; then
                 echo "OK on retry (status $status): $url"
                 success=true
-                echo "$url" >> urls-429-recovered.txt
                 break
               elif [ "$status" -eq 429 ]; then
                 echo "Still 429, sleeping ${delay}s before next attempt..."
@@ -124,24 +123,13 @@ jobs:
             done
             
             if [ "$success" = false ]; then
-              echo "$url (status: $status)" >> urls-429-still-failing.txt
+              echo "- [${status}] $url" >> urls-429-still-failing.txt
             fi
           done < urls-429.txt
           
           still_failing=$(wc -l < urls-429-still-failing.txt | tr -d ' ')
-          recovered=$(wc -l < urls-429-recovered.txt | tr -d ' ')
-          echo "URLs recovered after retry: $recovered"
           echo "URLs still failing after retry: $still_failing"
-          
-          # Remove recovered 429 entries from the report to avoid confusion
-          if [ "$recovered" -gt 0 ]; then
-            echo "Cleaning up recovered 429 entries from report..."
-            while IFS= read -r url; do
-              # Escape special characters for sed
-              escaped_url=$(echo "$url" | sed 's/[&/\]/\\&/g')
-              sed -i "/$escaped_url/d" ./lychee-report.md
-            done < urls-429-recovered.txt
-          fi
+          echo "still_failing_429=$still_failing" >> $GITHUB_OUTPUT
           
           if [ "$still_failing" -gt 0 ]; then
             echo "has_429_failures=true" >> $GITHUB_OUTPUT
@@ -149,17 +137,55 @@ jobs:
             echo "has_429_failures=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Check for non-429 failures and summarize
+      - name: Build errors-only report and summarize
         id: check_failures
         run: |
-          # Check if there are any non-429 failures in the report
           # Pattern matches 4xx (except 429) and 5xx status codes
           FAILURE_PATTERN='\[40[0-9]\]|\[41[0-9]\]|\[42[0-8]\]|\[4[3-9][0-9]\]|\[5[0-9]{2}\]'
           
-          # Extract broken links for summary
-          grep -E "$FAILURE_PATTERN" ./lychee-report.md > broken-links.txt 2>/dev/null || true
+          # Extract broken links from raw report
+          grep -E "$FAILURE_PATTERN" ./lychee-raw.md > broken-links.txt 2>/dev/null || true
           broken_count=$(wc -l < broken-links.txt | tr -d ' ')
           
+          # Get rate limit stats
+          rate_limited="${{ steps.retry429.outputs.rate_limited_count }}"
+          rate_limited=${rate_limited:-0}
+          still_failing_429="${{ steps.retry429.outputs.still_failing_429 }}"
+          still_failing_429=${still_failing_429:-0}
+          
+          # Build clean errors-only report
+          cat > lychee-report.md << 'HEADER'
+          # Link Check Report
+          
+          This report only shows broken links (errors). Redirects and successful links are not included.
+          
+          HEADER
+          
+          if [ "$broken_count" -gt 0 ]; then
+            echo "## Broken Links ($broken_count)" >> lychee-report.md
+            echo "" >> lychee-report.md
+            # Format: - [STATUS] URL
+            sed -E 's/.*\[([0-9]+)\].*<([^>]+)>.*/- [\1] \2/' broken-links.txt >> lychee-report.md
+            echo "" >> lychee-report.md
+          fi
+          
+          if [ "$still_failing_429" -gt 0 ]; then
+            echo "## Rate-Limited URLs (429) - Still Failing After Retry" >> lychee-report.md
+            echo "" >> lychee-report.md
+            cat urls-429-still-failing.txt >> lychee-report.md
+            echo "" >> lychee-report.md
+          fi
+          
+          if [ "$broken_count" -eq 0 ] && [ "$still_failing_429" -eq 0 ]; then
+            echo "No broken links found!" >> lychee-report.md
+          fi
+          
+          echo "" >> lychee-report.md
+          echo "---" >> lychee-report.md
+          echo "" >> lychee-report.md
+          echo "Rate-limited URLs (429) that recovered after retry: $rate_limited" >> lychee-report.md
+          
+          # Print summary to logs
           echo ""
           echo "=========================================="
           echo "           LINK CHECK SUMMARY"
@@ -168,23 +194,26 @@ jobs:
           
           if [ "$broken_count" -gt 0 ]; then
             echo "has_other_failures=true" >> $GITHUB_OUTPUT
-            echo "broken_count=$broken_count" >> $GITHUB_OUTPUT
             echo "BROKEN LINKS FOUND: $broken_count"
             echo ""
-            echo "The following links are broken:"
             cat broken-links.txt | sed -E 's/.*\[([0-9]+)\].*<([^>]+)>.*/  - [\1] \2/'
             echo ""
           else
             echo "has_other_failures=false" >> $GITHUB_OUTPUT
-            echo "broken_count=0" >> $GITHUB_OUTPUT
             echo "No broken links found!"
-            echo ""
           fi
           
-          echo "Rate-limited URLs (429) that recovered after retry: ${{ steps.retry429.outputs.rate_limited_count || '0' }}"
+          if [ "$still_failing_429" -gt 0 ]; then
+            echo ""
+            echo "RATE-LIMITED URLs STILL FAILING: $still_failing_429"
+            cat urls-429-still-failing.txt
+          fi
+          
+          echo ""
+          echo "Rate-limited URLs (429) that recovered after retry: $rate_limited"
           echo "=========================================="
 
-      - name: Upload lychee report
+      - name: Upload errors-only report
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,8 +18,7 @@ jobs:
           # https://lychee.cli.rs/
 
           # Accept these status codes as valid
-          # 429 is included to handle rate limiting (especially from GitHub)
-          accept = [200, 204, 301, 302, 307, 308, 429]
+          accept = [200, 204, 301, 302, 307, 308]
 
           # User agent to avoid being blocked
           user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
@@ -35,14 +34,14 @@ jobs:
             "^https://c\\.vialoops\\.com",
             "_vercel/(speed-)?insights",
             
-              # Sites that block automated requests
-              "^https://docs\\.stack-auth\\.com",
-              "^https://www\\.linkedin\\.com",
-              "^https://linkedin\\.com",
-              "^https://twitter\\.com",
-              "^https://x\\.com",
-              "^https://www\\.npmjs\\.com",
-              "^https://cdn\\.simpleicons\\.org",
+            # Sites that block automated requests
+            "^https://docs\\.stack-auth\\.com",
+            "^https://www\\.linkedin\\.com",
+            "^https://linkedin\\.com",
+            "^https://twitter\\.com",
+            "^https://x\\.com",
+            "^https://www\\.npmjs\\.com",
+            "^https://cdn\\.simpleicons\\.org",
             
             # Non-HTTP links
             "^mailto:",
@@ -59,7 +58,8 @@ jobs:
           curl -s https://buildwithfern.com/learn/sitemap.xml | grep -oP '(?<=<loc>)[^<]+' > urls.txt
           echo "Found $(wc -l < urls.txt) URLs in sitemap"
 
-      - name: Check Fern Docs Links
+      - name: Check Fern Docs Links (first pass)
+        id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
@@ -67,12 +67,89 @@ jobs:
             --no-progress
             --timeout 30
             --max-retries 3
+            --retry-wait-time 10
             --max-concurrency 10
             --files-from urls.txt
           output: ./lychee-report.md
           format: markdown
-          fail: true
+          fail: false
           jobSummary: true
+
+      - name: Extract 429 URLs and retry with exponential backoff
+        id: retry429
+        run: |
+          # Extract URLs that returned 429 from the lychee report
+          grep '\[429\]' ./lychee-report.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429.txt || true
+          
+          count=$(wc -l < urls-429.txt | tr -d ' ')
+          echo "Found $count URLs with 429 status"
+          
+          if [ "$count" -eq "0" ] || [ ! -s urls-429.txt ]; then
+            echo "No 429 URLs to retry"
+            echo "has_429_failures=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "Retrying $count URLs with exponential backoff..."
+          > urls-429-still-failing.txt
+          
+          while IFS= read -r url; do
+            [ -z "$url" ] && continue
+            delay=15
+            max_attempts=4
+            success=false
+            
+            for attempt in $(seq 1 $max_attempts); do
+              echo "[$attempt/$max_attempts] Checking: $url"
+              status=$(curl -s -o /dev/null -w "%{http_code}" \
+                -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" \
+                --max-time 30 \
+                "$url" || echo "000")
+              
+              if [ "$status" -lt 400 ]; then
+                echo "OK on retry (status $status): $url"
+                success=true
+                break
+              elif [ "$status" -eq 429 ]; then
+                echo "Still 429, sleeping ${delay}s before next attempt..."
+                sleep "$delay"
+                delay=$((delay * 2))
+              else
+                echo "Non-429 failure (status $status): $url"
+                break
+              fi
+            done
+            
+            if [ "$success" = false ]; then
+              echo "$url (status: $status)" >> urls-429-still-failing.txt
+            fi
+          done < urls-429.txt
+          
+          still_failing=$(wc -l < urls-429-still-failing.txt | tr -d ' ')
+          echo "URLs still failing after retry: $still_failing"
+          
+          if [ "$still_failing" -gt 0 ]; then
+            echo "has_429_failures=true" >> $GITHUB_OUTPUT
+            echo "### URLs still failing after exponential backoff retry:" >> ./lychee-report.md
+            echo "" >> ./lychee-report.md
+            cat urls-429-still-failing.txt >> ./lychee-report.md
+          else
+            echo "has_429_failures=false" >> $GITHUB_OUTPUT
+            echo "### All 429 URLs recovered after retry" >> ./lychee-report.md
+          fi
+
+      - name: Check for non-429 failures
+        id: check_failures
+        run: |
+          # Check if there are any non-429 failures in the original report
+          # Look for status codes 4xx (except 429) and 5xx
+          if grep -E '\[4[0-28][0-9]\]|\[5[0-9]{2}\]' ./lychee-report.md > /dev/null 2>&1; then
+            echo "has_other_failures=true" >> $GITHUB_OUTPUT
+            echo "Found non-429 failures in the report"
+          else
+            echo "has_other_failures=false" >> $GITHUB_OUTPUT
+            echo "No non-429 failures found"
+          fi
 
       - name: Upload lychee report
         if: always()
@@ -81,3 +158,16 @@ jobs:
           name: lychee-report
           path: ./lychee-report.md
           if-no-files-found: ignore
+
+      - name: Fail if there are broken links
+        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
+        run: |
+          echo "Link check failed!"
+          if [ "${{ steps.check_failures.outputs.has_other_failures }}" == "true" ]; then
+            echo "There are broken links (non-429 failures) in the report."
+          fi
+          if [ "${{ steps.retry429.outputs.has_429_failures }}" == "true" ]; then
+            echo "Some URLs still returned 429 after exponential backoff retry."
+            echo "These URLs may need to be excluded or the rate limit needs more time to reset."
+          fi
+          exit 1


### PR DESCRIPTION
## Summary

Replaces the Python-based `linkchecker` tool with `lychee-action` to address false positives in the link checking workflow. The previous implementation was failing due to:
- CSV parsing bugs with multi-line link names (e.g., "crates.io\nregistry")
- Transient 502 errors from GitHub that resolved on retry
- Sites like crates.io blocking the linkchecker user agent

Key changes:
- Uses `lychee-action@v2` which is faster and handles edge cases better
- Fetches sitemap from `/learn/sitemap.xml` to discover all ~1929 docs pages
- Uses `--files-from` to treat each sitemap URL as a page to crawl for links
- Adds browser-like user agent to avoid bot blocking
- Comprehensive exclude patterns for sites known to block automated requests (LinkedIn, Twitter/X, npmjs.com, cdn.simpleicons.org, etc.)
- **Two-pass system with exponential backoff** for handling 429 rate limits
- **Errors-only report** - no redirects or successful links, just broken links
- **Job summary** uses lychee's native summary table plus 429 recovery info and persistent errors only
- TOML config file for better readability and maintainability
- Schedule changed from M/W/F to every weekday (M-F)

## Updates since last revision

1. Fixed lychee TOML config syntax error - moved options with ambiguous types (`verbose`, `timeout`, etc.) to CLI flags
2. Added sitemap-based page discovery - fetches `/learn/sitemap.xml` to get all ~1929 page URLs
3. Fixed `--files-from` usage - lychee now treats each URL as a page to fetch and extract all links from
4. Added false positive handling - excludes npmjs.com and cdn.simpleicons.org which block automated requests with 403
5. **Implemented two-pass link checking with exponential backoff for 429s:**
   - First pass: Run lychee with `--retry-wait-time 10` (10s between retries)
   - Second pass: Extract any remaining 429 URLs and retry with exponential backoff (15s → 30s → 60s → 120s)
   - Final step fails only if there are real broken links (4xx/5xx) or persistent 429s after all retries
6. Fixed regex pattern for detecting non-429 failures - correctly excludes 429 by matching 400-428 and 430-499 separately
7. **Errors-only report** - generates a clean artifact showing only broken links and persistent 429s (no redirects or successful links)
8. **Disabled lychee's built-in job summary** to avoid redirect noise in the GitHub Actions summary
9. **Now extracts lychee's summary table only** (stops at first `##` heading) and adds a separate "429 Rate Limit Recovery" table
10. **Filtered "Errors per input" section** - now builds a custom "Errors (after retry)" section that only shows persistent errors (non-429 broken links + 429s that didn't recover). Shows "No errors remained after retry." when all 429s recovered.

**Important:** The workflow found a **real broken link**: `https://elevenlabs.io/docs/best-practices/prompting/llms.txt` returns 404. This link needs to be fixed in the docs before the workflow will pass.

## Review & Testing Checklist for Human

- [ ] **Fix the real broken link** - `https://elevenlabs.io/docs/best-practices/prompting/llms.txt` returns 404 and needs to be updated or removed from the docs
- [ ] **Trigger a manual workflow run** via `workflow_dispatch` to verify:
  - The job summary shows lychee's native summary table (with emojis like 🔍 Total, ✅ Successful, etc.)
  - The 429 Rate Limit Recovery table shows correct recovered/still-failing counts
  - The "Errors (after retry)" section shows only persistent errors OR "No errors remained after retry."
  - No "Errors per input" section with recovered 429s appears
- [ ] **Verify sed extraction** - `sed -n '/^# Summary$/,/^## /p'` stops at the first `##` heading; confirm this correctly extracts only the summary table
- [ ] **Confirm schedule change is intentional** - workflow now runs M-F instead of M/W/F

**Recommended test plan:**
1. Fix the elevenlabs.io broken link in the docs
2. Trigger the workflow manually via `workflow_dispatch`
3. Verify the job summary shows lychee's table + 429 recovery info + "Errors (after retry)" section
4. Confirm "Errors (after retry)" shows "No errors remained after retry." (assuming all 429s recover)
5. Check the artifact only contains broken links (no redirects)
6. Confirm the workflow passes after the broken link is fixed

### Notes

- The old workflow took ~35 minutes to check 7397 links; lychee should be faster but the exponential backoff may add time if there are many 429s
- Exponential backoff schedule: 15s → 30s → 60s → 120s (4 attempts max per URL)
- Session: https://app.devin.ai/sessions/ffaa9903ec6e494eb54673cc5e44c907
- Requested by: David Konigsberg (@davidkonigsberg)