### PR TITLE
Fix link checker false positives and add automated PR creation for broken links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -53,6 +53,9 @@ jobs:
           ]
           EOF
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Fetch sitemap and extract URLs
         run: |
           curl -s https://buildwithfern.com/learn/sitemap.xml | grep -oP '(?<=<loc>)[^<]+' > urls.txt
@@ -81,60 +84,92 @@ jobs:
           # Extract all 429 URLs from the raw lychee report
           grep '\[429\]' ./lychee-raw.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429-all.txt || true
           
-          # Filter out repo-internal GitHub URLs that are often rate limited but valid
-          # These are links to the repo's own files which GitHub rate-limits aggressively
-          grep -vE '^https://github\.com/fern-api/docs/' urls-429-all.txt > urls-429.txt || true
+          # Initialize counters for repo-internal GitHub URLs
+          verified_locally=0
+          missing_locally=0
           
-          # Count ignored repo URLs for reporting
-          ignored_count=$(grep -cE '^https://github\.com/fern-api/docs/' urls-429-all.txt || echo "0")
-          echo "Ignored $ignored_count repo-internal GitHub URLs (rate-limited but assumed valid)"
-          echo "ignored_repo_urls=$ignored_count" >> $GITHUB_OUTPUT
-          
-          count=$(wc -l < urls-429.txt | tr -d ' ')
-          echo "Found $count URLs with 429 status (excluding repo-internal GitHub URLs)"
-          echo "rate_limited_count=$count" >> $GITHUB_OUTPUT
-          
-          if [ "$count" -eq "0" ] || [ ! -s urls-429.txt ]; then
-            echo "No 429 URLs to retry"
-            echo "has_429_failures=false" >> $GITHUB_OUTPUT
-            echo "still_failing_429=0" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          echo "Retrying $count URLs with exponential backoff..."
-          > urls-429-still-failing.txt
+          # Process repo-internal GitHub URLs by checking if files exist locally
+          # This avoids false positives from GitHub rate limiting while still catching real broken links
+          > urls-429.txt
+          > urls-429-repo-missing.txt
           
           while IFS= read -r url; do
             [ -z "$url" ] && continue
-            delay=15
-            max_attempts=4
-            success=false
             
-            for attempt in $(seq 1 $max_attempts); do
-              echo "[$attempt/$max_attempts] Checking: $url"
-              status=$(curl -s -o /dev/null -w "%{http_code}" \
-                -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" \
-                --max-time 30 \
-                "$url" || echo "000")
+            # Check if this is a repo-internal GitHub URL (blob/main pattern)
+            if echo "$url" | grep -qE '^https://github\.com/fern-api/docs/blob/main/'; then
+              # Extract relative path from URL (strip prefix and query string)
+              rel_path="${url#https://github.com/fern-api/docs/blob/main/}"
+              rel_path="${rel_path%%\?*}"
               
-              if [ "$status" -lt 400 ]; then
-                echo "OK on retry (status $status): $url"
-                success=true
-                break
-              elif [ "$status" -eq 429 ]; then
-                echo "Still 429, sleeping ${delay}s before next attempt..."
-                sleep "$delay"
-                delay=$((delay * 2))
+              if [ -f "$rel_path" ]; then
+                echo "Verified locally (file exists): $url -> $rel_path"
+                verified_locally=$((verified_locally + 1))
               else
-                echo "Non-429 failure (status $status): $url"
-                break
+                echo "MISSING locally: $url -> $rel_path"
+                echo "- [LOCAL_MISSING] $url (expected path: $rel_path)" >> urls-429-repo-missing.txt
+                missing_locally=$((missing_locally + 1))
               fi
-            done
-            
-            if [ "$success" = false ]; then
-              echo "- [${status}] $url" >> urls-429-still-failing.txt
+            else
+              # Non-repo URL, add to retry list
+              echo "$url" >> urls-429.txt
             fi
-          done < urls-429.txt
+          done < urls-429-all.txt
+          
+          echo "Repo-internal GitHub URLs verified locally: $verified_locally"
+          echo "Repo-internal GitHub URLs missing locally: $missing_locally"
+          echo "verified_locally=$verified_locally" >> $GITHUB_OUTPUT
+          echo "missing_locally=$missing_locally" >> $GITHUB_OUTPUT
+          
+          count=$(wc -l < urls-429.txt | tr -d ' ')
+          echo "Found $count other URLs with 429 status to retry"
+          echo "rate_limited_count=$count" >> $GITHUB_OUTPUT
+          
+          # Initialize still-failing file
+          > urls-429-still-failing.txt
+          
+          # Add any locally-missing repo URLs to the still-failing list
+          if [ -s urls-429-repo-missing.txt ]; then
+            cat urls-429-repo-missing.txt >> urls-429-still-failing.txt
+          fi
+          
+          if [ "$count" -eq "0" ] || [ ! -s urls-429.txt ]; then
+            echo "No other 429 URLs to retry"
+          else
+            echo "Retrying $count URLs with exponential backoff..."
+            
+            while IFS= read -r url; do
+              [ -z "$url" ] && continue
+              delay=15
+              max_attempts=4
+              success=false
+              
+              for attempt in $(seq 1 $max_attempts); do
+                echo "[$attempt/$max_attempts] Checking: $url"
+                status=$(curl -s -o /dev/null -w "%{http_code}" \
+                  -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" \
+                  --max-time 30 \
+                  "$url" || echo "000")
+                
+                if [ "$status" -lt 400 ]; then
+                  echo "OK on retry (status $status): $url"
+                  success=true
+                  break
+                elif [ "$status" -eq 429 ]; then
+                  echo "Still 429, sleeping ${delay}s before next attempt..."
+                  sleep "$delay"
+                  delay=$((delay * 2))
+                else
+                  echo "Non-429 failure (status $status): $url"
+                  break
+                fi
+              done
+              
+              if [ "$success" = false ]; then
+                echo "- [${status}] $url" >> urls-429-still-failing.txt
+              fi
+            done < urls-429.txt
+          fi
           
           still_failing=$(wc -l < urls-429-still-failing.txt | tr -d ' ')
           echo "URLs still failing after retry: $still_failing"
@@ -214,12 +249,15 @@ jobs:
           echo ""
           cat lychee-summary-table.md
           echo ""
-          # Get ignored repo URLs count
-          ignored_repo_urls="${{ steps.retry429.outputs.ignored_repo_urls }}"
-          ignored_repo_urls=${ignored_repo_urls:-0}
+          # Get repo-internal GitHub URL counts
+          verified_locally="${{ steps.retry429.outputs.verified_locally }}"
+          verified_locally=${verified_locally:-0}
+          missing_locally="${{ steps.retry429.outputs.missing_locally }}"
+          missing_locally=${missing_locally:-0}
           
           echo "429 Recovery Info:"
-          echo "  Repo-internal GitHub URLs (ignored): $ignored_repo_urls"
+          echo "  Repo-internal GitHub URLs (verified locally): $verified_locally"
+          echo "  Repo-internal GitHub URLs (missing locally): $missing_locally"
           echo "  Rate-limited (429) - recovered after retry: $recovered_429"
           echo "  Rate-limited (429) - still failing: $still_failing_429"
           
@@ -246,7 +284,8 @@ jobs:
             echo ""
             echo "| Status | Count |"
             echo "|--------|------:|"
-            echo "| Repo-internal GitHub URLs (ignored) | $ignored_repo_urls |"
+            echo "| Repo-internal GitHub URLs (verified locally) | $verified_locally |"
+            echo "| Repo-internal GitHub URLs (missing locally) | $missing_locally |"
             echo "| Recovered after retry | $recovered_429 |"
             echo "| Still failing | $still_failing_429 |"
             echo ""

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -325,22 +325,9 @@ jobs:
           path: ./lychee-report.md
           if-no-files-found: ignore
 
-      # ============================================================
-      # TEMPORARY TEST FLAG - REMOVE BEFORE MERGING
-      # This step creates fake broken links to test PR creation and Slack notification
-      # ============================================================
-      - name: "[TEST] Create fake broken links for testing"
-        id: test-flag
-        run: |
-          echo "Creating fake broken links for testing..."
-          echo "* [404] <https://example.com/fake-broken-link-1> | Not Found" > broken-links.txt
-          echo "* [500] <https://example.com/fake-broken-link-2> | Server Error" >> broken-links.txt
-          echo "- [429] https://example.com/fake-rate-limited | Rate limited" > urls-429-still-failing.txt
-          echo "test_mode=true" >> $GITHUB_OUTPUT
-
       - name: Create PR for broken links
         id: create-pr
-        if: steps.test-flag.outputs.test_mode == 'true' || steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
+        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
         uses: actions/github-script@v7
         env:
           DEVIN_PROMPT: |
@@ -604,8 +591,7 @@ jobs:
             }
 
       - name: Fail if there are broken links
-        # TEMPORARY: Skip failure during test mode - REMOVE BEFORE MERGING
-        if: steps.test-flag.outputs.test_mode != 'true' && (steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true')
+        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
         run: |
           echo "Link check failed!"
           if [ "${{ steps.check_failures.outputs.has_other_failures }}" == "true" ]; then

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 10 * * 1,2,3,4,5'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-links:
     name: Check links
@@ -320,6 +324,271 @@ jobs:
           name: lychee-report
           path: ./lychee-report.md
           if-no-files-found: ignore
+
+      - name: Create PR for broken links
+        id: create-pr
+        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
+        uses: actions/github-script@v7
+        env:
+          DEVIN_PROMPT: |
+            @devin-ai-integration Please fix the broken links detected by the scheduled link checker.
+
+            **Instructions:**
+            1. For each URL listed below, identify the source file containing the broken link
+            2. Either update the link to point to the correct URL, or remove the link if the resource no longer exists
+            3. If a link is rate-limited (429), check if the URL is actually valid - if so, consider adding it to the exclude list in the workflow
+            4. Run `fern docs dev` locally to verify your changes don't break anything
+            5. Push your fix to this PR branch and tag @davidkonigsberg for review
+            6. Delete the scaffold file (.github/broken-links/broken-links.md) as part of your fix
+
+            **Broken Links:**
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const devinPrompt = process.env.DEVIN_PROMPT;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const baseBranch = 'main';
+            const branchName = 'devin/fix-broken-links';
+            const filePath = '.github/broken-links/broken-links.md';
+
+            // Read broken links files
+            let brokenLinksContent = '';
+            let urls429Content = '';
+            
+            try {
+              brokenLinksContent = fs.readFileSync('broken-links.txt', 'utf8');
+            } catch (e) {
+              console.log('No broken-links.txt found');
+            }
+            
+            try {
+              urls429Content = fs.readFileSync('urls-429-still-failing.txt', 'utf8');
+            } catch (e) {
+              console.log('No urls-429-still-failing.txt found');
+            }
+
+            if (!brokenLinksContent && !urls429Content) {
+              console.log('No broken links to report');
+              return;
+            }
+
+            // Build the scaffold file content
+            let scaffoldContent = devinPrompt + '\n';
+            
+            if (brokenLinksContent.trim()) {
+              scaffoldContent += '\n## Non-429 Broken Links\n\n';
+              // Format: extract status code and URL from lychee output
+              const lines = brokenLinksContent.trim().split('\n');
+              for (const line of lines) {
+                const match = line.match(/\[(\d+)\].*<([^>]+)>/);
+                if (match) {
+                  scaffoldContent += `- [${match[1]}] ${match[2]}\n`;
+                } else {
+                  scaffoldContent += `- ${line}\n`;
+                }
+              }
+            }
+            
+            if (urls429Content.trim()) {
+              scaffoldContent += '\n## Rate-Limited URLs (429) Still Failing After Retry\n\n';
+              scaffoldContent += urls429Content.trim() + '\n';
+            }
+
+            scaffoldContent += '\n---\n';
+            scaffoldContent += `[View workflow run](https://github.com/${owner}/${repo}/actions/runs/${context.runId})\n`;
+
+            // Get the base branch ref
+            const baseRef = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: `heads/${baseBranch}`,
+            });
+            const baseCommitSha = baseRef.data.object.sha;
+
+            const baseCommit = await github.rest.git.getCommit({
+              owner,
+              repo,
+              commit_sha: baseCommitSha,
+            });
+            const baseTreeSha = baseCommit.data.tree.sha;
+
+            // Check if branch already exists
+            let branchExists = false;
+            let existingPR = null;
+            
+            try {
+              await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `heads/${branchName}`,
+              });
+              branchExists = true;
+              
+              // Check for existing open PR
+              const prs = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                head: `${owner}:${branchName}`,
+              });
+              if (prs.data.length > 0) {
+                existingPR = prs.data[0];
+              }
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            // If branch exists but no open PR, delete the old branch
+            if (branchExists && !existingPR) {
+              console.log(`Deleting old branch ${branchName}...`);
+              await github.rest.git.deleteRef({
+                owner,
+                repo,
+                ref: `heads/${branchName}`,
+              });
+              branchExists = false;
+            }
+
+            let prUrl = '';
+            let prNumber = 0;
+
+            if (existingPR) {
+              // Update existing PR by updating the file
+              console.log(`Updating existing PR #${existingPR.number}...`);
+              
+              // Get the current file SHA if it exists
+              let fileSha = null;
+              try {
+                const fileContent = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path: filePath,
+                  ref: branchName,
+                });
+                fileSha = fileContent.data.sha;
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+
+              await github.rest.repos.createOrUpdateFileContents({
+                owner,
+                repo,
+                path: filePath,
+                message: `Update broken links list from workflow run ${context.runId}`,
+                content: Buffer.from(scaffoldContent).toString('base64'),
+                branch: branchName,
+                sha: fileSha,
+              });
+
+              prUrl = existingPR.html_url;
+              prNumber = existingPR.number;
+              console.log(`Updated PR: ${prUrl}`);
+            } else {
+              // Create new branch and PR
+              console.log('Creating new branch and PR...');
+
+              // Create a blob with the scaffold content
+              const blob = await github.rest.git.createBlob({
+                owner,
+                repo,
+                content: scaffoldContent,
+                encoding: 'utf-8',
+              });
+
+              // Create a tree with the new file
+              const tree = await github.rest.git.createTree({
+                owner,
+                repo,
+                base_tree: baseTreeSha,
+                tree: [
+                  {
+                    path: filePath,
+                    mode: '100644',
+                    type: 'blob',
+                    sha: blob.data.sha,
+                  },
+                ],
+              });
+
+              // Create a commit
+              const commit = await github.rest.git.createCommit({
+                owner,
+                repo,
+                message: `Add broken links scaffold for Devin to fix`,
+                tree: tree.data.sha,
+                parents: [baseCommitSha],
+              });
+
+              // Create the branch
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/heads/${branchName}`,
+                sha: commit.data.sha,
+              });
+
+              // Create the PR
+              const pr = await github.rest.pulls.create({
+                owner,
+                repo,
+                title: 'Fix broken links (Devin)',
+                head: branchName,
+                base: baseBranch,
+                body: scaffoldContent,
+                draft: true,
+              });
+
+              prUrl = pr.data.html_url;
+              prNumber = pr.data.number;
+              console.log(`Created PR: ${prUrl}`);
+            }
+
+            core.setOutput('pr_url', prUrl);
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('pr_created', 'true');
+
+      - name: Send Slack notification for broken links
+        if: steps.create-pr.outputs.pr_created == 'true'
+        uses: actions/github-script@v7
+        env:
+          SLACK_TOKEN: ${{ secrets.DEVIN_AI_PR_BOT_SLACK_TOKEN }}
+          PR_URL: ${{ steps.create-pr.outputs.pr_url }}
+        with:
+          script: |
+            const slackToken = process.env.SLACK_TOKEN;
+            const prUrl = process.env.PR_URL;
+            const channelId = 'C0A23CZEFNF';
+            
+            // Devin Slack App member ID for proper mention
+            const devinMention = '<@U088PL5FS3B>';
+            
+            const message = `${devinMention} *Broken Links Detected in Docs*\nThe scheduled link checker found broken links in the docs repo. Please fix them by following the instructions in the <${prUrl}|PR>.`;
+            
+            try {
+              const response = await fetch('https://slack.com/api/chat.postMessage', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Authorization': `Bearer ${slackToken}`
+                },
+                body: JSON.stringify({
+                  channel: channelId,
+                  text: message,
+                  mrkdwn: true
+                })
+              });
+              
+              const result = await response.json();
+              if (result.ok) {
+                console.log(`Sent Slack notification for broken links PR`);
+              } else {
+                console.error(`Failed to send Slack notification: ${result.error}`);
+              }
+            } catch (error) {
+              console.error(`Error sending Slack notification: ${error.message}`);
+            }
 
       - name: Fail if there are broken links
         if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -325,9 +325,22 @@ jobs:
           path: ./lychee-report.md
           if-no-files-found: ignore
 
+      # ============================================================
+      # TEMPORARY TEST FLAG - REMOVE BEFORE MERGING
+      # This step creates fake broken links to test PR creation and Slack notification
+      # ============================================================
+      - name: "[TEST] Create fake broken links for testing"
+        id: test-flag
+        run: |
+          echo "Creating fake broken links for testing..."
+          echo "* [404] <https://example.com/fake-broken-link-1> | Not Found" > broken-links.txt
+          echo "* [500] <https://example.com/fake-broken-link-2> | Server Error" >> broken-links.txt
+          echo "- [429] https://example.com/fake-rate-limited | Rate limited" > urls-429-still-failing.txt
+          echo "test_mode=true" >> $GITHUB_OUTPUT
+
       - name: Create PR for broken links
         id: create-pr
-        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
+        if: steps.test-flag.outputs.test_mode == 'true' || steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
         uses: actions/github-script@v7
         env:
           DEVIN_PROMPT: |
@@ -591,7 +604,8 @@ jobs:
             }
 
       - name: Fail if there are broken links
-        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
+        # TEMPORARY: Skip failure during test mode - REMOVE BEFORE MERGING
+        if: steps.test-flag.outputs.test_mode != 'true' && (steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true')
         run: |
           echo "Link check failed!"
           if [ "${{ steps.check_failures.outputs.has_other_failures }}" == "true" ]; then

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,6 +11,9 @@ jobs:
     name: Check links
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Create lychee config
         run: |
           cat > lychee.toml << 'EOF'
@@ -52,9 +55,6 @@ jobs:
             "^#"
           ]
           EOF
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
 
       - name: Fetch sitemap and extract URLs
         run: |

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -78,11 +78,20 @@ jobs:
       - name: Extract 429 URLs and retry with exponential backoff
         id: retry429
         run: |
-          # Extract URLs that returned 429 from the raw lychee report
-          grep '\[429\]' ./lychee-raw.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429.txt || true
+          # Extract all 429 URLs from the raw lychee report
+          grep '\[429\]' ./lychee-raw.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429-all.txt || true
+          
+          # Filter out repo-internal GitHub URLs that are often rate limited but valid
+          # These are links to the repo's own files which GitHub rate-limits aggressively
+          grep -vE '^https://github\.com/fern-api/docs/' urls-429-all.txt > urls-429.txt || true
+          
+          # Count ignored repo URLs for reporting
+          ignored_count=$(grep -cE '^https://github\.com/fern-api/docs/' urls-429-all.txt || echo "0")
+          echo "Ignored $ignored_count repo-internal GitHub URLs (rate-limited but assumed valid)"
+          echo "ignored_repo_urls=$ignored_count" >> $GITHUB_OUTPUT
           
           count=$(wc -l < urls-429.txt | tr -d ' ')
-          echo "Found $count URLs with 429 status"
+          echo "Found $count URLs with 429 status (excluding repo-internal GitHub URLs)"
           echo "rate_limited_count=$count" >> $GITHUB_OUTPUT
           
           if [ "$count" -eq "0" ] || [ ! -s urls-429.txt ]; then
@@ -205,7 +214,12 @@ jobs:
           echo ""
           cat lychee-summary-table.md
           echo ""
+          # Get ignored repo URLs count
+          ignored_repo_urls="${{ steps.retry429.outputs.ignored_repo_urls }}"
+          ignored_repo_urls=${ignored_repo_urls:-0}
+          
           echo "429 Recovery Info:"
+          echo "  Repo-internal GitHub URLs (ignored): $ignored_repo_urls"
           echo "  Rate-limited (429) - recovered after retry: $recovered_429"
           echo "  Rate-limited (429) - still failing: $still_failing_429"
           
@@ -232,6 +246,7 @@ jobs:
             echo ""
             echo "| Status | Count |"
             echo "|--------|------:|"
+            echo "| Repo-internal GitHub URLs (ignored) | $ignored_repo_urls |"
             echo "| Recovered after retry | $recovered_429 |"
             echo "| Still failing | $still_failing_429 |"
             echo ""


### PR DESCRIPTION
## Summary

Fixes the link checker workflow failing with false positives when GitHub returns 429 (Too Many Requests) for links to the repo's own files. The [failed workflow run](https://github.com/fern-api/docs/actions/runs/20059539475) showed 5 errors, all of which were 429s for valid links like `https://github.com/fern-api/docs/blob/main/fern/products/cli-api-reference/cli-changelog/2023-02-16.mdx?plain=1`.

Instead of blindly ignoring all 429s from repo-internal URLs, the workflow now:
1. Checks out the repository to access local files
2. For each repo-internal GitHub URL (`blob/main/` pattern) that returns 429, extracts the file path
3. Verifies the file exists locally before treating the 429 as a false positive
4. If the file doesn't exist locally, treats it as a real error (`LOCAL_MISSING`)

This ensures the workflow will still:
- Fail on real broken links (404, 500, etc.) including GitHub links
- Fail if a repo-internal link points to a file that doesn't exist (even if masked by 429)
- Retry and fail on 429s from other domains
- Report counts of verified vs missing repo URLs in the summary for visibility

### Automated PR Creation and Slack Notification

When broken links are detected, the workflow now automatically:
1. Creates a draft PR on branch `devin/fix-broken-links` with a scaffold file (`.github/broken-links/broken-links.md`) listing all broken URLs and instructions for Devin
2. Sends a Slack notification to trigger a Devin session to fix the broken links
3. If a PR already exists, updates the scaffold file instead of creating a new PR

This follows the same pattern as the [dependabot-alerts-to-issues workflow](https://github.com/fern-api/fern-platform/blob/app/.github/workflows/dependabot-alerts-to-issues.yml) in fern-platform.

### Updates since last revision

- **Tested PR creation and Slack notification successfully**: Triggered the workflow manually and confirmed both features work ([test PR #2615](https://github.com/fern-api/docs/pull/2615) was created, Slack notification was sent)
- Removed the temporary test flag after successful testing

## Review & Testing Checklist for Human

- [ ] **Verify `DEVIN_AI_PR_BOT_SLACK_TOKEN` secret exists** in this repo's settings (required for Slack notifications)
- [ ] **Verify the Slack channel ID `C0A23CZEFNF`** is correct for docs-related Devin notifications (same channel as fern-platform dependabot workflow)
- [ ] **Close the test PR #2615** created during testing (it contains fake broken links)
- [ ] Consider whether the `blob/main/` pattern is sufficient - links to other branches/refs would still be retried via HTTP

**Recommended test plan**: After merging, trigger the workflow manually via workflow_dispatch and verify it passes without false positives. To test the PR creation flow end-to-end with real broken links, temporarily introduce a broken link and run the workflow.

### Notes

- The summary now shows "verified locally" and "missing locally" counts in both workflow logs and GitHub Step Summary table
- If the repo is ever renamed/moved, the hardcoded pattern would need updating
- **Fixed step ordering**: The checkout step must come before lychee config creation, otherwise checkout clears the working directory and deletes the config file
- Added `permissions` block for `contents: write` and `pull-requests: write` to allow PR creation
- Uses `GITHUB_TOKEN` (not `FERN_GITHUB_TOKEN`) since we don't need Dependabot alert access

Link to Devin run: https://app.devin.ai/sessions/57d2c6eb860b47b2ac0b72a582e03415
Requested by: David Konigsberg (@davidkonigsberg)