### PR TITLE
docs: add CSS selectors documentation for changelog filter components

### DIFF
--- a/fern/products/docs/pages/component-library/custom-components/css-selectors.mdx
+++ b/fern/products/docs/pages/component-library/custom-components/css-selectors.mdx
@@ -1232,202 +1232,6 @@ Radio button group within the product selector dropdown. Can be customized with 
 </Accordion>
 </AccordionGroup>
 
-## Changelog filter components
-
-Selectors for customizing the changelog filter UI, including the filter dropdown button, filter badges, and dropdown menu items. These selectors only appear on [changelog pages](/learn/docs/configuration/changelogs) that have tags configured.
-
-<AccordionGroup>
-<Accordion title=".fern-filter-dropdown-button">
-
-The button that opens the changelog filter dropdown menu. This selector is applied when there are more than 5 filter options.
-
-```css Default CSS
-.fern-filter-dropdown-button {
-  /* Inherits from .fern-button with variant="outlined" */
-}
-```
-
-**Example: Customize the filter button appearance**
-
-```css
-/* Style the filter dropdown button */
-.fern-filter-dropdown-button {
-  border-color: var(--accent-a7);
-  background-color: var(--accent-a2);
-}
-
-.fern-filter-dropdown-button:hover {
-  border-color: var(--accent-a9);
-  background-color: var(--accent-a3);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-dropdown-button-text">
-
-The text content inside the filter dropdown button (e.g., "Select filters" or the selected filter names).
-
-```css Default CSS
-.fern-filter-dropdown-button-text {
-  /* Inherits text styles from parent button */
-}
-```
-
-**Example: Visually replace the default label text**
-
-```css
-/* Replace "Select filters" with custom text using CSS */
-.fern-filter-dropdown-button-text {
-  font-size: 0;
-}
-
-.fern-filter-dropdown-button-text::after {
-  content: "Select product";
-  font-size: 0.875rem;
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-dropdown-button-icon">
-
-The chevron icon inside the filter dropdown button.
-
-```css Default CSS
-.fern-filter-dropdown-button-icon {
-  width: 1rem;
-  height: 1rem;
-}
-```
-
-**Example: Customize the chevron icon**
-
-```css
-/* Change the chevron color */
-.fern-filter-dropdown-button-icon {
-  color: var(--accent-a11);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-dropdown-item">
-
-Individual filter option items inside the dropdown menu.
-
-```css Default CSS
-.fern-filter-dropdown-item {
-  /* Inherits from .fern-dropdown-item */
-}
-```
-
-**Example: Style filter dropdown items**
-
-```css
-/* Customize filter dropdown items */
-.fern-filter-dropdown-item {
-  padding: 0.5rem 0.75rem;
-}
-
-.fern-filter-dropdown-item[data-highlighted] {
-  background-color: var(--accent-a4);
-  color: var(--accent-a12);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-badge">
-
-Base class applied to all filter badges displayed on changelog entries. Use this selector in combination with `.fern-filter-badge-selected` or `.fern-filter-badge-unselected` for state-specific styling.
-
-```css Default CSS
-.fern-filter-badge {
-  display: inline;
-  max-width: 100%;
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-badge-selected">
-
-Applied to filter badges that are selected, in addition to `.fern-filter-badge`.
-
-```css Default CSS
-.fern-filter-badge-selected {
-  /* Inherits from .fern-docs-badge with variant="outlined" */
-}
-```
-
-**Example: Style selected filter badges with your brand color**
-
-```css
-/* Make selected badges use your accent color */
-.fern-filter-badge.fern-filter-badge-selected {
-  background-color: var(--accent-a9);
-  color: var(--accent-contrast);
-  border-color: var(--accent-a9);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-badge-unselected">
-
-Applied to filter badges that aren't selected, in addition to `.fern-filter-badge`.
-
-```css Default CSS
-.fern-filter-badge-unselected {
-  /* Inherits from .fern-docs-badge with variant="outlined-subtle" */
-}
-```
-
-**Example: Mute unselected filter badges**
-
-```css
-/* Style unselected badges with muted appearance */
-.fern-filter-badge.fern-filter-badge-unselected {
-  background-color: transparent;
-  color: var(--grayscale-a10);
-  border-color: var(--grayscale-a6);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-dropdown-checkmark">
-
-The checkmark icon shown for selected items in filter dropdowns and other multi-select dropdowns.
-
-```css Default CSS
-.fern-dropdown-checkmark {
-  width: 1rem;
-  height: 1rem;
-}
-```
-
-**Example: Customize the checkmark color**
-
-```css
-/* Change the checkmark color to match your brand */
-.fern-dropdown-checkmark {
-  color: var(--accent-a11);
-}
-
-/* Or target only changelog filter checkmarks */
-.fern-filter-dropdown-item .fern-dropdown-checkmark {
-  color: var(--accent-a11);
-}
-```
-
-</Accordion>
-</AccordionGroup>
-
 ## Accordion components
 
 Selectors for [expandable accordion containers](/learn/docs/writing-content/components/accordions), items, triggers, and animations.
@@ -2257,6 +2061,202 @@ Container for documentation footer.
 </AccordionGroup>
 
 
+
+## Changelog filter components
+
+Selectors for customizing the changelog filter UI, including the filter dropdown button, filter badges, and dropdown menu items. These selectors only appear on [changelog pages](/learn/docs/configuration/changelogs) that have tags configured.
+
+<AccordionGroup>
+<Accordion title=".fern-filter-dropdown-button">
+
+The button that opens the changelog filter dropdown menu. This selector is applied when there are more than 5 filter options.
+
+```css Default CSS
+.fern-filter-dropdown-button {
+  /* Inherits from .fern-button with variant="outlined" */
+}
+```
+
+**Example: Customize the filter button appearance**
+
+```css
+/* Style the filter dropdown button */
+.fern-filter-dropdown-button {
+  border-color: var(--accent-a7);
+  background-color: var(--accent-a2);
+}
+
+.fern-filter-dropdown-button:hover {
+  border-color: var(--accent-a9);
+  background-color: var(--accent-a3);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-dropdown-button-text">
+
+The text content inside the filter dropdown button (e.g., "Select filters" or the selected filter names).
+
+```css Default CSS
+.fern-filter-dropdown-button-text {
+  /* Inherits text styles from parent button */
+}
+```
+
+**Example: Visually replace the default label text**
+
+```css
+/* Replace "Select filters" with custom text using CSS */
+.fern-filter-dropdown-button-text {
+  font-size: 0;
+}
+
+.fern-filter-dropdown-button-text::after {
+  content: "Select product";
+  font-size: 0.875rem;
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-dropdown-button-icon">
+
+The chevron icon inside the filter dropdown button.
+
+```css Default CSS
+.fern-filter-dropdown-button-icon {
+  width: 1rem;
+  height: 1rem;
+}
+```
+
+**Example: Customize the chevron icon**
+
+```css
+/* Change the chevron color */
+.fern-filter-dropdown-button-icon {
+  color: var(--accent-a11);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-dropdown-item">
+
+Individual filter option items inside the dropdown menu.
+
+```css Default CSS
+.fern-filter-dropdown-item {
+  /* Inherits from .fern-dropdown-item */
+}
+```
+
+**Example: Style filter dropdown items**
+
+```css
+/* Customize filter dropdown items */
+.fern-filter-dropdown-item {
+  padding: 0.5rem 0.75rem;
+}
+
+.fern-filter-dropdown-item[data-highlighted] {
+  background-color: var(--accent-a4);
+  color: var(--accent-a12);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-badge">
+
+Base class applied to all filter badges displayed on changelog entries. Use this selector in combination with `.fern-filter-badge-selected` or `.fern-filter-badge-unselected` for state-specific styling.
+
+```css Default CSS
+.fern-filter-badge {
+  display: inline;
+  max-width: 100%;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-badge-selected">
+
+Applied to filter badges that are selected, in addition to `.fern-filter-badge`.
+
+```css Default CSS
+.fern-filter-badge-selected {
+  /* Inherits from .fern-docs-badge with variant="outlined" */
+}
+```
+
+**Example: Style selected filter badges with your brand color**
+
+```css
+/* Make selected badges use your accent color */
+.fern-filter-badge.fern-filter-badge-selected {
+  background-color: var(--accent-a9);
+  color: var(--accent-contrast);
+  border-color: var(--accent-a9);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-badge-unselected">
+
+Applied to filter badges that aren't selected, in addition to `.fern-filter-badge`.
+
+```css Default CSS
+.fern-filter-badge-unselected {
+  /* Inherits from .fern-docs-badge with variant="outlined-subtle" */
+}
+```
+
+**Example: Mute unselected filter badges**
+
+```css
+/* Style unselected badges with muted appearance */
+.fern-filter-badge.fern-filter-badge-unselected {
+  background-color: transparent;
+  color: var(--grayscale-a10);
+  border-color: var(--grayscale-a6);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-dropdown-checkmark">
+
+The checkmark icon shown for selected items in filter dropdowns and other multi-select dropdowns.
+
+```css Default CSS
+.fern-dropdown-checkmark {
+  width: 1rem;
+  height: 1rem;
+}
+```
+
+**Example: Customize the checkmark color**
+
+```css
+/* Change the checkmark color to match your brand */
+.fern-dropdown-checkmark {
+  color: var(--accent-a11);
+}
+
+/* Or target only changelog filter checkmarks */
+.fern-filter-dropdown-item .fern-dropdown-checkmark {
+  color: var(--accent-a11);
+}
+```
+
+</Accordion>
+</AccordionGroup>
 
 ## Light and dark mode customization
 

--- a/fern/products/docs/pages/component-library/custom-components/css-selectors.mdx
+++ b/fern/products/docs/pages/component-library/custom-components/css-selectors.mdx
@@ -1796,6 +1796,189 @@ Styled table element with consistent spacing and borders. Supports a `.sticky` m
 </Accordion>
 </AccordionGroup>
 
+## Changelog filter components
+
+Selectors for customizing the changelog filter UI, including the filter dropdown button, filter badges, and dropdown menu items. These selectors only appear on [changelog pages](/learn/docs/configuration/changelogs) that have tags configured.
+
+<AccordionGroup>
+<Accordion title=".fern-filter-dropdown-button">
+
+The button that opens the changelog filter dropdown menu. This selector is applied when there are more than 5 filter options.
+
+```css Default CSS
+.fern-filter-dropdown-button {
+  /* Inherits from .fern-button with variant="outlined" */
+}
+```
+
+```css Example: Customize the filter button appearance
+/* Style the filter dropdown button */
+.fern-filter-dropdown-button {
+  border-color: var(--accent-a7);
+  background-color: var(--accent-a2);
+}
+
+.fern-filter-dropdown-button:hover {
+  border-color: var(--accent-a9);
+  background-color: var(--accent-a3);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-dropdown-button-text">
+
+The text content inside the filter dropdown button (e.g., "Select filters" or the selected filter names).
+
+```css Default CSS
+.fern-filter-dropdown-button-text {
+  /* Inherits text styles from parent button */
+}
+```
+
+```css Example: Visually replace the default label text
+/* Replace "Select filters" with custom text using CSS */
+.fern-filter-dropdown-button-text {
+  font-size: 0;
+}
+
+.fern-filter-dropdown-button-text::after {
+  content: "Select product";
+  font-size: 0.875rem;
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-dropdown-button-icon">
+
+The chevron icon inside the filter dropdown button.
+
+```css Default CSS
+.fern-filter-dropdown-button-icon {
+  width: 1rem;
+  height: 1rem;
+}
+```
+
+```css Example: Customize the chevron icon
+/* Change the chevron color */
+.fern-filter-dropdown-button-icon {
+  color: var(--accent-a11);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-dropdown-item">
+
+Individual filter option items inside the dropdown menu.
+
+```css Default CSS
+.fern-filter-dropdown-item {
+  /* Inherits from .fern-dropdown-item */
+}
+```
+
+```css Example: Style filter dropdown items
+/* Customize filter dropdown items */
+.fern-filter-dropdown-item {
+  padding: 0.5rem 0.75rem;
+}
+
+.fern-filter-dropdown-item[data-highlighted] {
+  background-color: var(--accent-a4);
+  color: var(--accent-a12);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-badge">
+
+Base class applied to all filter badges displayed on changelog entries. Use this selector in combination with `.fern-filter-badge-selected` or `.fern-filter-badge-unselected` for state-specific styling.
+
+```css Default CSS
+.fern-filter-badge {
+  display: inline;
+  max-width: 100%;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-badge-selected">
+
+Applied to filter badges that are selected, in addition to `.fern-filter-badge`.
+
+```css Default CSS
+.fern-filter-badge-selected {
+  /* Inherits from .fern-docs-badge with variant="outlined" */
+}
+```
+
+```css Example: Style selected filter badges with your brand color
+/* Make selected badges use your accent color */
+.fern-filter-badge.fern-filter-badge-selected {
+  background-color: var(--accent-a9);
+  color: var(--accent-contrast);
+  border-color: var(--accent-a9);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-badge-unselected">
+
+Applied to filter badges that aren't selected, in addition to `.fern-filter-badge`.
+
+```css Default CSS
+.fern-filter-badge-unselected {
+  /* Inherits from .fern-docs-badge with variant="outlined-subtle" */
+}
+```
+
+```css Example: Mute unselected filter badges
+/* Style unselected badges with muted appearance */
+.fern-filter-badge.fern-filter-badge-unselected {
+  background-color: transparent;
+  color: var(--grayscale-a10);
+  border-color: var(--grayscale-a6);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-dropdown-checkmark">
+
+The checkmark icon shown for selected items in filter dropdowns and other multi-select dropdowns.
+
+```css Default CSS
+.fern-dropdown-checkmark {
+  width: 1rem;
+  height: 1rem;
+}
+```
+
+```css Example: Customize the checkmark color
+/* Change the checkmark color to match your brand */
+.fern-dropdown-checkmark {
+  color: var(--accent-a11);
+}
+
+/* Or target only changelog filter checkmarks */
+.fern-filter-dropdown-item .fern-dropdown-checkmark {
+  color: var(--accent-a11);
+}
+```
+
+</Accordion>
+</AccordionGroup>
+
+
 ## API Reference components
 
 Selectors for [API Reference documentation](/learn/docs/api-references/generate-api-ref), including property names, metadata, and containers.
@@ -2054,204 +2237,6 @@ Container for documentation footer.
 ```css Default CSS
 .fern-layout-footer.not-prose {
   margin-top: 4rem !important;
-}
-```
-
-</Accordion>
-</AccordionGroup>
-
-
-
-## Changelog filter components
-
-Selectors for customizing the changelog filter UI, including the filter dropdown button, filter badges, and dropdown menu items. These selectors only appear on [changelog pages](/learn/docs/configuration/changelogs) that have tags configured.
-
-<AccordionGroup>
-<Accordion title=".fern-filter-dropdown-button">
-
-The button that opens the changelog filter dropdown menu. This selector is applied when there are more than 5 filter options.
-
-```css Default CSS
-.fern-filter-dropdown-button {
-  /* Inherits from .fern-button with variant="outlined" */
-}
-```
-
-**Example: Customize the filter button appearance**
-
-```css
-/* Style the filter dropdown button */
-.fern-filter-dropdown-button {
-  border-color: var(--accent-a7);
-  background-color: var(--accent-a2);
-}
-
-.fern-filter-dropdown-button:hover {
-  border-color: var(--accent-a9);
-  background-color: var(--accent-a3);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-dropdown-button-text">
-
-The text content inside the filter dropdown button (e.g., "Select filters" or the selected filter names).
-
-```css Default CSS
-.fern-filter-dropdown-button-text {
-  /* Inherits text styles from parent button */
-}
-```
-
-**Example: Visually replace the default label text**
-
-```css
-/* Replace "Select filters" with custom text using CSS */
-.fern-filter-dropdown-button-text {
-  font-size: 0;
-}
-
-.fern-filter-dropdown-button-text::after {
-  content: "Select product";
-  font-size: 0.875rem;
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-dropdown-button-icon">
-
-The chevron icon inside the filter dropdown button.
-
-```css Default CSS
-.fern-filter-dropdown-button-icon {
-  width: 1rem;
-  height: 1rem;
-}
-```
-
-**Example: Customize the chevron icon**
-
-```css
-/* Change the chevron color */
-.fern-filter-dropdown-button-icon {
-  color: var(--accent-a11);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-dropdown-item">
-
-Individual filter option items inside the dropdown menu.
-
-```css Default CSS
-.fern-filter-dropdown-item {
-  /* Inherits from .fern-dropdown-item */
-}
-```
-
-**Example: Style filter dropdown items**
-
-```css
-/* Customize filter dropdown items */
-.fern-filter-dropdown-item {
-  padding: 0.5rem 0.75rem;
-}
-
-.fern-filter-dropdown-item[data-highlighted] {
-  background-color: var(--accent-a4);
-  color: var(--accent-a12);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-badge">
-
-Base class applied to all filter badges displayed on changelog entries. Use this selector in combination with `.fern-filter-badge-selected` or `.fern-filter-badge-unselected` for state-specific styling.
-
-```css Default CSS
-.fern-filter-badge {
-  display: inline;
-  max-width: 100%;
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-badge-selected">
-
-Applied to filter badges that are selected, in addition to `.fern-filter-badge`.
-
-```css Default CSS
-.fern-filter-badge-selected {
-  /* Inherits from .fern-docs-badge with variant="outlined" */
-}
-```
-
-**Example: Style selected filter badges with your brand color**
-
-```css
-/* Make selected badges use your accent color */
-.fern-filter-badge.fern-filter-badge-selected {
-  background-color: var(--accent-a9);
-  color: var(--accent-contrast);
-  border-color: var(--accent-a9);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-filter-badge-unselected">
-
-Applied to filter badges that aren't selected, in addition to `.fern-filter-badge`.
-
-```css Default CSS
-.fern-filter-badge-unselected {
-  /* Inherits from .fern-docs-badge with variant="outlined-subtle" */
-}
-```
-
-**Example: Mute unselected filter badges**
-
-```css
-/* Style unselected badges with muted appearance */
-.fern-filter-badge.fern-filter-badge-unselected {
-  background-color: transparent;
-  color: var(--grayscale-a10);
-  border-color: var(--grayscale-a6);
-}
-```
-
-</Accordion>
-
-<Accordion title=".fern-dropdown-checkmark">
-
-The checkmark icon shown for selected items in filter dropdowns and other multi-select dropdowns.
-
-```css Default CSS
-.fern-dropdown-checkmark {
-  width: 1rem;
-  height: 1rem;
-}
-```
-
-**Example: Customize the checkmark color**
-
-```css
-/* Change the checkmark color to match your brand */
-.fern-dropdown-checkmark {
-  color: var(--accent-a11);
-}
-
-/* Or target only changelog filter checkmarks */
-.fern-filter-dropdown-item .fern-dropdown-checkmark {
-  color: var(--accent-a11);
 }
 ```
 

--- a/fern/products/docs/pages/component-library/custom-components/css-selectors.mdx
+++ b/fern/products/docs/pages/component-library/custom-components/css-selectors.mdx
@@ -1232,6 +1232,202 @@ Radio button group within the product selector dropdown. Can be customized with 
 </Accordion>
 </AccordionGroup>
 
+## Changelog filter components
+
+Selectors for customizing the changelog filter UI, including the filter dropdown button, filter badges, and dropdown menu items. These selectors only appear on [changelog pages](/learn/docs/configuration/changelogs) that have tags configured.
+
+<AccordionGroup>
+<Accordion title=".fern-filter-dropdown-button">
+
+The button that opens the changelog filter dropdown menu. This selector is applied when there are more than 5 filter options.
+
+```css Default CSS
+.fern-filter-dropdown-button {
+  /* Inherits from .fern-button with variant="outlined" */
+}
+```
+
+**Example: Customize the filter button appearance**
+
+```css
+/* Style the filter dropdown button */
+.fern-filter-dropdown-button {
+  border-color: var(--accent-a7);
+  background-color: var(--accent-a2);
+}
+
+.fern-filter-dropdown-button:hover {
+  border-color: var(--accent-a9);
+  background-color: var(--accent-a3);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-dropdown-button-text">
+
+The text content inside the filter dropdown button (e.g., "Select filters" or the selected filter names).
+
+```css Default CSS
+.fern-filter-dropdown-button-text {
+  /* Inherits text styles from parent button */
+}
+```
+
+**Example: Visually replace the default label text**
+
+```css
+/* Replace "Select filters" with custom text using CSS */
+.fern-filter-dropdown-button-text {
+  font-size: 0;
+}
+
+.fern-filter-dropdown-button-text::after {
+  content: "Select product";
+  font-size: 0.875rem;
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-dropdown-button-icon">
+
+The chevron icon inside the filter dropdown button.
+
+```css Default CSS
+.fern-filter-dropdown-button-icon {
+  width: 1rem;
+  height: 1rem;
+}
+```
+
+**Example: Customize the chevron icon**
+
+```css
+/* Change the chevron color */
+.fern-filter-dropdown-button-icon {
+  color: var(--accent-a11);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-dropdown-item">
+
+Individual filter option items inside the dropdown menu.
+
+```css Default CSS
+.fern-filter-dropdown-item {
+  /* Inherits from .fern-dropdown-item */
+}
+```
+
+**Example: Style filter dropdown items**
+
+```css
+/* Customize filter dropdown items */
+.fern-filter-dropdown-item {
+  padding: 0.5rem 0.75rem;
+}
+
+.fern-filter-dropdown-item[data-highlighted] {
+  background-color: var(--accent-a4);
+  color: var(--accent-a12);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-badge">
+
+Base class applied to all filter badges displayed on changelog entries. Use this selector in combination with `.fern-filter-badge-selected` or `.fern-filter-badge-unselected` for state-specific styling.
+
+```css Default CSS
+.fern-filter-badge {
+  display: inline;
+  max-width: 100%;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-badge-selected">
+
+Applied to filter badges that are currently selected, in addition to `.fern-filter-badge`.
+
+```css Default CSS
+.fern-filter-badge-selected {
+  /* Inherits from .fern-docs-badge with variant="outlined" */
+}
+```
+
+**Example: Style selected filter badges with your brand color**
+
+```css
+/* Make selected badges use your accent color */
+.fern-filter-badge.fern-filter-badge-selected {
+  background-color: var(--accent-a9);
+  color: var(--accent-contrast);
+  border-color: var(--accent-a9);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-filter-badge-unselected">
+
+Applied to filter badges that are not currently selected, in addition to `.fern-filter-badge`.
+
+```css Default CSS
+.fern-filter-badge-unselected {
+  /* Inherits from .fern-docs-badge with variant="outlined-subtle" */
+}
+```
+
+**Example: Mute unselected filter badges**
+
+```css
+/* Style unselected badges with muted appearance */
+.fern-filter-badge.fern-filter-badge-unselected {
+  background-color: transparent;
+  color: var(--grayscale-a10);
+  border-color: var(--grayscale-a6);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-dropdown-checkmark">
+
+The checkmark icon shown for selected items in filter dropdowns and other multi-select dropdowns.
+
+```css Default CSS
+.fern-dropdown-checkmark {
+  width: 1rem;
+  height: 1rem;
+}
+```
+
+**Example: Customize the checkmark color**
+
+```css
+/* Change the checkmark color to match your brand */
+.fern-dropdown-checkmark {
+  color: var(--accent-a11);
+}
+
+/* Or target only changelog filter checkmarks */
+.fern-filter-dropdown-item .fern-dropdown-checkmark {
+  color: var(--accent-a11);
+}
+```
+
+</Accordion>
+</AccordionGroup>
+
 ## Accordion components
 
 Selectors for [expandable accordion containers](/learn/docs/writing-content/components/accordions), items, triggers, and animations.

--- a/fern/products/docs/pages/component-library/custom-components/css-selectors.mdx
+++ b/fern/products/docs/pages/component-library/custom-components/css-selectors.mdx
@@ -1356,7 +1356,7 @@ Base class applied to all filter badges displayed on changelog entries. Use this
 
 <Accordion title=".fern-filter-badge-selected">
 
-Applied to filter badges that are currently selected, in addition to `.fern-filter-badge`.
+Applied to filter badges that are selected, in addition to `.fern-filter-badge`.
 
 ```css Default CSS
 .fern-filter-badge-selected {
@@ -1379,7 +1379,7 @@ Applied to filter badges that are currently selected, in addition to `.fern-filt
 
 <Accordion title=".fern-filter-badge-unselected">
 
-Applied to filter badges that are not currently selected, in addition to `.fern-filter-badge`.
+Applied to filter badges that aren't selected, in addition to `.fern-filter-badge`.
 
 ```css Default CSS
 .fern-filter-badge-unselected {

--- a/fern/products/docs/pages/navigation/changelogs.mdx
+++ b/fern/products/docs/pages/navigation/changelogs.mdx
@@ -131,6 +131,10 @@ tags: ["plants-api", "breaking-change", "inventory-management"]
 
 When you have multiple changelog entries, users can filter the changelog page by selecting specific tags. Use specific, descriptive tags that your users would naturally search for. Consider tagging by feature type, product area, release stage, affected platform, or user impact.
 
+<Note>
+Customize the filter UI using [changelog filter CSS selectors](/learn/docs/customization/css-selectors-reference#changelog-filter-components). These selectors only apply when tags are configured.
+</Note>
+
 ### Linking to an Entry
 
 Each changelog entry has a unique URL you can direct users to. For example, `https://elevenlabs.io/docs/changelog/2025/3/31`


### PR DESCRIPTION
## Summary

Adds documentation for the stable CSS selectors that were introduced in [fern-platform#5779](https://github.com/fern-api/fern-platform/pull/5779) for customizing changelog filter UI components. This enables customers to style the filter dropdown button, filter badges, and dropdown checkmarks without relying on fragile CSS overrides.

The new "Changelog filter components" section is added to the existing CSS selectors reference page and documents:
- `.fern-filter-dropdown-button` - the filter dropdown trigger button
- `.fern-filter-dropdown-button-text` - the button text
- `.fern-filter-dropdown-button-icon` - the chevron icon
- `.fern-filter-dropdown-item` - dropdown menu items
- `.fern-filter-badge` / `.fern-filter-badge-selected` / `.fern-filter-badge-unselected` - badge state classes
- `.fern-dropdown-checkmark` - the checkmark icon in dropdowns

Each selector includes default CSS and practical examples showing common customization patterns (e.g., replacing label text, styling badges with brand colors, customizing checkmark colors).

## Updates since last revision

- Fixed Vale style issues: removed time-relative term "currently" and used contraction "aren't" instead of "are not"
- Moved the "Changelog filter components" section to the bottom of the page (before "Light and dark mode customization") since it's a niche feature

## Review & Testing Checklist for Human

- [ ] Verify the documented selector names exactly match the implementation in fern-platform (check `PageFilters.tsx` and `FernDropdown.tsx`)
- [ ] Confirm whether `.fern-dropdown-item-indicator` should also be documented (it was added in fern-platform but not included here)
- [ ] Review the CSS examples for accuracy - especially the text replacement technique using `font-size: 0` and `::after`
- [ ] Check the link to `/learn/docs/configuration/changelogs` resolves correctly

**Suggested test plan**: Deploy the PR preview and navigate to the CSS selectors reference page to verify the new section renders correctly at the bottom of the page (before "Light and dark mode customization") and the accordion components work as expected.

### Notes

- This documentation supports a customer request from Deepgram who wanted stable selectors for customizing their changelog filter UI
- Link to Devin run: https://app.devin.ai/sessions/b2cde88f6ad347bbb3122004e2cb7f75
- Requested by: Sarah Bawabe (sarah@buildwithfern.com) / @sbawabe