### PR TITLE
Verify all GitHub blob/tree/tag URLs locally instead of via HTTP

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -83,6 +83,16 @@ jobs:
             > urls-github-non-code.txt || true
           echo "GitHub non-code URLs: $(wc -l < urls-github-non-code.txt)"
 
+      - name: Upload URL lists (early, for debugging)
+        uses: actions/upload-artifact@v4
+        with:
+          name: url-lists-early
+          path: |
+            urls.txt
+            urls-non-github.txt
+            urls-github-non-code.txt
+          if-no-files-found: ignore
+
       - name: Extract and verify GitHub blob/tree/tag URLs locally
         id: verify_github
         run: |
@@ -632,15 +642,12 @@ jobs:
           path: ./lychee-report.md
           if-no-files-found: ignore
 
-      - name: Upload URL files for debugging
+      - name: Upload lychee outputs and verification results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: url-files
+          name: lychee-outputs
           path: |
-            urls.txt
-            urls-non-github.txt
-            urls-github-non-code.txt
             github-urls.txt
             github-verified.txt
             github-missing.txt

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -254,6 +254,24 @@ jobs:
           # Cleanup cloned repos
           rm -rf .github-repos
 
+      - name: Check GitHub links (very low concurrency to avoid 503 rate limiting)
+        id: lychee_github
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --timeout 30
+            --max-retries 5
+            --retry-wait-time 20
+            --max-concurrency 1
+            --include "^https://github\\.com/[^/]+/[^/]+/?$"
+            --include "^https://github\\.com/[^/]+/[^/]+/(issues|pull|pulls|compare|commit|commits|discussions)/"
+            --files-from urls.txt
+          output: ./lychee-raw-github.md
+          format: markdown
+          fail: false
+          jobSummary: false
+
       - name: Check non-GitHub links (high concurrency)
         id: lychee_main
         uses: lycheeverse/lychee-action@v2
@@ -267,25 +285,6 @@ jobs:
             --exclude "^https://github\\.com/"
             --files-from urls.txt
           output: ./lychee-raw-main.md
-          format: markdown
-          fail: false
-          jobSummary: false
-
-      - name: Check GitHub links (very low concurrency to avoid 503 rate limiting)
-        id: lychee_github
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: >-
-            --no-progress
-            --timeout 30
-            --max-retries 5
-            --retry-wait-time 20
-            --max-concurrency 1
-            --include "^https://github\\.com/"
-            --exclude "^https://github\\.com/[^/]+/[^/]+/(blob|tree)/"
-            --exclude "^https://github\\.com/[^/]+/[^/]+/releases/tag/"
-            --files-from urls.txt
-          output: ./lychee-raw-github.md
           format: markdown
           fail: false
           jobSummary: false

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -263,8 +263,8 @@ jobs:
             --timeout 30
             --max-retries 5
             --retry-wait-time 20
-            --max-concurrency 1
-            --include "^https://github\\.com/[^/]+/[^/]+/(issues|pull|pulls|compare|commit|commits|discussions)/"
+            --max-concurrency 10
+            --include "^https://github\\.com/[^/]+/[^/]+/(issues|compare|commit|commits|discussions)/"
             --files-from urls.txt
           output: ./lychee-raw-github.md
           format: markdown

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -259,7 +259,6 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
-            --config lychee.toml
             --no-progress
             --timeout 30
             --max-retries 3
@@ -277,13 +276,14 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
-            --config lychee.toml
             --no-progress
             --timeout 30
             --max-retries 5
             --retry-wait-time 20
             --max-concurrency 1
             --include "^https://github\\.com/"
+            --exclude "^https://github\\.com/[^/]+/[^/]+/(blob|tree)/"
+            --exclude "^https://github\\.com/[^/]+/[^/]+/releases/tag/"
             --files-from urls.txt
           output: ./lychee-raw-github.md
           format: markdown

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -71,13 +71,6 @@ jobs:
           curl -s https://buildwithfern.com/learn/sitemap.xml | grep -oP '(?<=<loc>)[^<]+' > urls.txt
           echo "Found $(wc -l < urls.txt) URLs in sitemap"
 
-      - name: Upload sitemap URLs (early, for debugging)
-        uses: actions/upload-artifact@v4
-        with:
-          name: sitemap-urls
-          path: urls.txt
-          if-no-files-found: ignore
-
       - name: Extract and verify GitHub blob/tree/tag URLs locally
         id: verify_github
         run: |
@@ -299,6 +292,17 @@ jobs:
             echo "URLs to check:"
             cat github-http-urls.txt
           fi
+
+
+      - name: Upload URLs (early, for debugging)
+        uses: actions/upload-artifact@v4
+        with:
+          name: urls
+          path: |
+            github-urls.txt
+            github-http-urls.txt
+            urls.txt
+          if-no-files-found: ignore
 
       - name: Check GitHub links (very low concurrency to avoid 503 rate limiting)
         id: lychee_github
@@ -677,8 +681,6 @@ jobs:
         with:
           name: lychee-outputs
           path: |
-            github-urls.txt
-            github-http-urls.txt
             github-verified.txt
             github-missing.txt
             lychee-raw-main.md

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -372,12 +372,12 @@ jobs:
           [ -f lychee-raw-github.md ] && cat lychee-raw-github.md >> lychee-raw.md
           echo "Combined lychee outputs into lychee-raw.md"
 
-      - name: Extract 403/429 URLs and retry with exponential backoff
+      - name: Extract 429 URLs and retry with exponential backoff
         id: retry429
         run: |
-          # Extract all 403 and 429 URLs from the raw lychee report
-          # 403s are often from bot-blocking sites (npmjs, simpleicons) and should be treated like 429s
-          grep -E '\[403\]|\[429\]' ./lychee-raw.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429-all.txt || true
+          # Extract all 429 URLs from the raw lychee report
+          # Note: 403s are excluded from broken links report but NOT retried (bot-blocking sites won't change)
+          grep '\[429\]' ./lychee-raw.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429-all.txt || true
           
           # Initialize counters for repo-internal GitHub URLs
           verified_locally=0
@@ -450,12 +450,12 @@ jobs:
                     echo "OK on retry (status $status): $url"
                     success=true
                     break
-                  elif [ "$status" -eq 429 ] || [ "$status" -eq 403 ]; then
-                    echo "Still $status, sleeping ${delay}s before next attempt..."
+                  elif [ "$status" -eq 429 ]; then
+                    echo "Still 429, sleeping ${delay}s before next attempt..."
                     sleep "$delay"
                     delay=$((delay * 2))
                   else
-                    echo "Non-retryable failure (status $status): $url"
+                    echo "Non-429 failure (status $status): $url"
                     break
                   fi
               done

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -50,6 +50,10 @@ jobs:
             "^https://www\\.npmjs\\.com",
             "^https://cdn\\.simpleicons\\.org",
             
+            # fern-api org GitHub file/tree links - verified locally instead of via HTTP
+            # This avoids 503 errors from GitHub rate limiting automated requests
+            "^https://github\\.com/fern-api/[^/]+/(blob|tree)/",
+            
             # Non-HTTP links
             "^mailto:",
             "^tel:",
@@ -64,6 +68,134 @@ jobs:
         run: |
           curl -s https://buildwithfern.com/learn/sitemap.xml | grep -oP '(?<=<loc>)[^<]+' > urls.txt
           echo "Found $(wc -l < urls.txt) URLs in sitemap"
+
+      - name: Extract and verify fern-api GitHub URLs locally
+        id: verify_fern_api
+        run: |
+          # Extract all fern-api GitHub blob/tree URLs from the documentation pages
+          # These are excluded from lychee and verified locally instead to avoid 503 errors
+          
+          echo "Fetching documentation pages to extract fern-api GitHub URLs..."
+          > fern-api-urls.txt
+          
+          # Fetch each page and extract fern-api GitHub blob/tree URLs
+          while IFS= read -r page_url; do
+            [ -z "$page_url" ] && continue
+            curl -s "$page_url" | grep -oE 'https://github\.com/fern-api/[^/]+/(blob|tree)/[^"<>[:space:]]+' >> fern-api-urls.txt 2>/dev/null || true
+          done < urls.txt
+          
+          # Deduplicate URLs
+          sort -u fern-api-urls.txt > fern-api-urls-unique.txt
+          mv fern-api-urls-unique.txt fern-api-urls.txt
+          
+          total_urls=$(wc -l < fern-api-urls.txt | tr -d ' ')
+          echo "Found $total_urls unique fern-api GitHub URLs to verify locally"
+          
+          if [ "$total_urls" -eq 0 ]; then
+            echo "No fern-api GitHub URLs to verify"
+            echo "verified_count=0" >> $GITHUB_OUTPUT
+            echo "missing_count=0" >> $GITHUB_OUTPUT
+            echo "has_missing=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Extract unique repos that need to be cloned
+          grep -oE 'https://github\.com/fern-api/[^/]+' fern-api-urls.txt | sort -u > fern-api-repos.txt
+          
+          echo "Repos to clone:"
+          cat fern-api-repos.txt
+          
+          # Clone each repo (shallow clone for efficiency)
+          mkdir -p .fern-api-repos
+          while IFS= read -r repo_url; do
+            [ -z "$repo_url" ] && continue
+            repo_name="${repo_url##*/}"
+            echo "Cloning $repo_name..."
+            
+            # Use sparse checkout for efficiency - we only need to check if paths exist
+            git clone --depth 1 --filter=blob:none --sparse "$repo_url.git" ".fern-api-repos/$repo_name" 2>/dev/null || {
+              echo "Warning: Failed to clone $repo_url, will mark URLs from this repo as unverifiable"
+              continue
+            }
+          done < fern-api-repos.txt
+          
+          # Verify each URL by checking if the path exists in the cloned repo
+          verified_count=0
+          missing_count=0
+          > fern-api-missing.txt
+          > fern-api-verified.txt
+          
+          while IFS= read -r url; do
+            [ -z "$url" ] && continue
+            
+            # Parse URL: https://github.com/fern-api/REPO/(blob|tree)/BRANCH/PATH
+            # Remove any URL fragments or query strings
+            clean_url="${url%%#*}"
+            clean_url="${clean_url%%\?*}"
+            
+            # Extract repo name and path
+            # Format: https://github.com/fern-api/REPO/(blob|tree)/BRANCH/PATH
+            repo_name=$(echo "$clean_url" | sed -E 's|https://github\.com/fern-api/([^/]+)/.*|\1|')
+            # Extract path after branch (everything after blob/BRANCH/ or tree/BRANCH/)
+            rel_path=$(echo "$clean_url" | sed -E 's|https://github\.com/fern-api/[^/]+/(blob|tree)/[^/]+/(.*)|\2|')
+            
+            # Check if we have the repo cloned
+            if [ ! -d ".fern-api-repos/$repo_name" ]; then
+              echo "Repo not cloned, cannot verify: $url"
+              echo "- [UNVERIFIABLE] $url (repo clone failed)" >> fern-api-missing.txt
+              missing_count=$((missing_count + 1))
+              continue
+            fi
+            
+            # For sparse checkout, we need to fetch the specific path to check if it exists
+            # Use git ls-tree to check if the path exists without fetching content
+            cd ".fern-api-repos/$repo_name"
+            
+            # Get the default branch
+            default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+            
+            # Check if path exists using git ls-tree (works with sparse checkout)
+            if git ls-tree -r --name-only "$default_branch" -- "$rel_path" 2>/dev/null | grep -q "^${rel_path}$" || \
+               git ls-tree -d --name-only "$default_branch" -- "$rel_path" 2>/dev/null | grep -q "^${rel_path}$"; then
+              echo "Verified: $url -> $rel_path"
+              echo "$url" >> ../../fern-api-verified.txt
+              verified_count=$((verified_count + 1))
+            else
+              # Also check if it's a directory (tree link)
+              if git ls-tree -d "$default_branch" -- "$rel_path" 2>/dev/null | grep -q .; then
+                echo "Verified (directory): $url -> $rel_path"
+                echo "$url" >> ../../fern-api-verified.txt
+                verified_count=$((verified_count + 1))
+              else
+                echo "MISSING: $url -> $rel_path"
+                echo "- [LOCAL_MISSING] $url (path: $rel_path in $repo_name)" >> ../../fern-api-missing.txt
+                missing_count=$((missing_count + 1))
+              fi
+            fi
+            
+            cd ../..
+          done < fern-api-urls.txt
+          
+          echo ""
+          echo "=== fern-api GitHub URL Verification Summary ==="
+          echo "Total URLs checked: $total_urls"
+          echo "Verified locally: $verified_count"
+          echo "Missing/unverifiable: $missing_count"
+          
+          echo "verified_count=$verified_count" >> $GITHUB_OUTPUT
+          echo "missing_count=$missing_count" >> $GITHUB_OUTPUT
+          
+          if [ "$missing_count" -gt 0 ]; then
+            echo "has_missing=true" >> $GITHUB_OUTPUT
+            echo ""
+            echo "Missing URLs:"
+            cat fern-api-missing.txt
+          else
+            echo "has_missing=false" >> $GITHUB_OUTPUT
+          fi
+          
+          # Cleanup cloned repos
+          rm -rf .fern-api-repos
 
       - name: Check Fern Docs Links (first pass)
         id: lychee
@@ -234,6 +366,12 @@ jobs:
           still_failing_429="${{ steps.retry429.outputs.still_failing_429 }}"
           still_failing_429=${still_failing_429:-0}
           
+          # Get fern-api local verification stats
+          fern_api_verified="${{ steps.verify_fern_api.outputs.verified_count }}"
+          fern_api_verified=${fern_api_verified:-0}
+          fern_api_missing="${{ steps.verify_fern_api.outputs.missing_count }}"
+          fern_api_missing=${fern_api_missing:-0}
+          
           # Build clean errors-only report
           cat > lychee-report.md << 'HEADER'
           # Link Check Report
@@ -257,7 +395,14 @@ jobs:
             echo "" >> lychee-report.md
           fi
           
-          if [ "$broken_count" -eq 0 ] && [ "$still_failing_429" -eq 0 ]; then
+          if [ "$fern_api_missing" -gt 0 ]; then
+            echo "## fern-api GitHub URLs - Missing Locally ($fern_api_missing)" >> lychee-report.md
+            echo "" >> lychee-report.md
+            cat fern-api-missing.txt >> lychee-report.md
+            echo "" >> lychee-report.md
+          fi
+          
+          if [ "$broken_count" -eq 0 ] && [ "$still_failing_429" -eq 0 ] && [ "$fern_api_missing" -eq 0 ]; then
             echo "No broken links found!" >> lychee-report.md
           fi
           
@@ -298,6 +443,8 @@ jobs:
           echo "  Repo-internal GitHub URLs (5xx verified locally): $verified_5xx"
           echo "  Rate-limited (429) - recovered after retry: $recovered_429"
           echo "  Rate-limited (429) - still failing: $still_failing_429"
+          echo "  fern-api GitHub URLs verified locally: $fern_api_verified"
+          echo "  fern-api GitHub URLs missing locally: $fern_api_missing"
           
           if [ "$broken_count" -gt 0 ]; then
             echo ""
@@ -309,6 +456,12 @@ jobs:
             echo ""
             echo "RATE-LIMITED URLs STILL FAILING (429):"
             cat urls-429-still-failing.txt
+          fi
+          
+          if [ "$fern_api_missing" -gt 0 ]; then
+            echo ""
+            echo "FERN-API GITHUB URLs MISSING LOCALLY:"
+            cat fern-api-missing.txt
           fi
           
           # Build GitHub Step Summary using lychee's table + 429 info + persistent errors only
@@ -327,6 +480,8 @@ jobs:
             echo "| Repo-internal GitHub URLs (5xx verified locally) | $verified_5xx |"
             echo "| Rate-limited (429) recovered after retry | $recovered_429 |"
             echo "| Rate-limited (429) still failing | $still_failing_429 |"
+            echo "| fern-api GitHub URLs verified locally | $fern_api_verified |"
+            echo "| fern-api GitHub URLs missing locally | $fern_api_missing |"
             echo ""
             
             # Show persistent errors only (non-429 broken links + 429s that didn't recover)
@@ -343,6 +498,11 @@ jobs:
             if [ "$still_failing_429" -gt 0 ]; then
               has_persistent_errors=true
               cat urls-429-still-failing.txt
+            fi
+            
+            if [ "$fern_api_missing" -gt 0 ]; then
+              has_persistent_errors=true
+              cat fern-api-missing.txt
             fi
             
             if [ "$has_persistent_errors" = false ]; then
@@ -362,7 +522,7 @@ jobs:
 
       - name: Create PR for broken links
         id: create-pr
-        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
+        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_fern_api.outputs.has_missing == 'true'
         uses: actions/github-script@v7
         env:
           DEVIN_PROMPT: |
@@ -393,6 +553,7 @@ jobs:
             // Read broken links files
             let brokenLinksContent = '';
             let urls429Content = '';
+            let fernApiMissingContent = '';
             
             try {
               brokenLinksContent = fs.readFileSync('broken-links.txt', 'utf8');
@@ -405,8 +566,14 @@ jobs:
             } catch (e) {
               console.log('No urls-429-still-failing.txt found');
             }
+            
+            try {
+              fernApiMissingContent = fs.readFileSync('fern-api-missing.txt', 'utf8');
+            } catch (e) {
+              console.log('No fern-api-missing.txt found');
+            }
 
-            if (!brokenLinksContent && !urls429Content) {
+            if (!brokenLinksContent && !urls429Content && !fernApiMissingContent) {
               console.log('No broken links to report');
               return;
             }
@@ -431,6 +598,11 @@ jobs:
             if (urls429Content.trim()) {
               scaffoldContent += '\n## Rate-Limited URLs (429) Still Failing After Retry\n\n';
               scaffoldContent += urls429Content.trim() + '\n';
+            }
+            
+            if (fernApiMissingContent.trim()) {
+              scaffoldContent += '\n## fern-api GitHub URLs Missing Locally\n\n';
+              scaffoldContent += fernApiMissingContent.trim() + '\n';
             }
 
             scaffoldContent += '\n---\n';
@@ -628,7 +800,7 @@ jobs:
             }
 
       - name: Fail if there are broken links
-        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true'
+        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_fern_api.outputs.has_missing == 'true'
         run: |
           echo "Link check failed!"
           if [ "${{ steps.check_failures.outputs.has_other_failures }}" == "true" ]; then
@@ -637,5 +809,8 @@ jobs:
           if [ "${{ steps.retry429.outputs.has_429_failures }}" == "true" ]; then
             echo "Some URLs still returned 429 after exponential backoff retry."
             echo "These URLs may need to be excluded or the rate limit needs more time to reset."
+          fi
+          if [ "${{ steps.verify_fern_api.outputs.has_missing }}" == "true" ]; then
+            echo "Some fern-api GitHub URLs point to paths that don't exist in the repos."
           fi
           exit 1

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -214,9 +214,10 @@ jobs:
                 git fetch --depth 1 origin "$ref" 2>/dev/null || true
               fi
               
-              # Check if path exists using git ls-tree (works with sparse checkout)
-              if git ls-tree -r --name-only "$ref" -- "$rel_path" 2>/dev/null | grep -q "^${rel_path}$" || \
-                 git ls-tree -d --name-only "$ref" -- "$rel_path" 2>/dev/null | grep -q "^${rel_path}$"; then
+                # Check if path exists using git ls-tree (works with sparse checkout)
+                # Use grep -qxF for literal string matching (paths may contain regex chars like [ and ])
+                if git ls-tree -r --name-only "$ref" -- "$rel_path" 2>/dev/null | grep -qxF "$rel_path" || \
+                   git ls-tree -d --name-only "$ref" -- "$rel_path" 2>/dev/null | grep -qxF "$rel_path"; then
                 echo "Verified: $url -> $rel_path (ref: $ref)"
                 echo "$url" >> ../../../github-verified.txt
                 verified_count=$((verified_count + 1))
@@ -371,11 +372,12 @@ jobs:
           [ -f lychee-raw-github.md ] && cat lychee-raw-github.md >> lychee-raw.md
           echo "Combined lychee outputs into lychee-raw.md"
 
-      - name: Extract 429 URLs and retry with exponential backoff
+      - name: Extract 403/429 URLs and retry with exponential backoff
         id: retry429
         run: |
-          # Extract all 429 URLs from the raw lychee report
-          grep '\[429\]' ./lychee-raw.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429-all.txt || true
+          # Extract all 403 and 429 URLs from the raw lychee report
+          # 403s are often from bot-blocking sites (npmjs, simpleicons) and should be treated like 429s
+          grep -E '\[403\]|\[429\]' ./lychee-raw.md | sed -E 's/.*<([^>]+)>.*/\1/' | sort -u > urls-429-all.txt || true
           
           # Initialize counters for repo-internal GitHub URLs
           verified_locally=0
@@ -444,18 +446,18 @@ jobs:
                   --max-time 30 \
                   "$url" || echo "000")
                 
-                if [ "$status" -lt 400 ]; then
-                  echo "OK on retry (status $status): $url"
-                  success=true
-                  break
-                elif [ "$status" -eq 429 ]; then
-                  echo "Still 429, sleeping ${delay}s before next attempt..."
-                  sleep "$delay"
-                  delay=$((delay * 2))
-                else
-                  echo "Non-429 failure (status $status): $url"
-                  break
-                fi
+                  if [ "$status" -lt 400 ]; then
+                    echo "OK on retry (status $status): $url"
+                    success=true
+                    break
+                  elif [ "$status" -eq 429 ] || [ "$status" -eq 403 ]; then
+                    echo "Still $status, sleeping ${delay}s before next attempt..."
+                    sleep "$delay"
+                    delay=$((delay * 2))
+                  else
+                    echo "Non-retryable failure (status $status): $url"
+                    break
+                  fi
               done
               
               if [ "$success" = false ]; then
@@ -477,8 +479,9 @@ jobs:
       - name: Build errors-only report and summarize
         id: check_failures
         run: |
-          # Pattern matches 4xx (except 429) and 5xx status codes
-          FAILURE_PATTERN='\[40[0-9]\]|\[41[0-9]\]|\[42[0-8]\]|\[4[3-9][0-9]\]|\[5[0-9]{2}\]'
+          # Pattern matches 4xx (except 403 and 429) and 5xx status codes
+          # 403 and 429 are handled separately (retried with exponential backoff)
+          FAILURE_PATTERN='\[400\]|\[401\]|\[402\]|\[40[4-9]\]|\[41[0-9]\]|\[42[0-8]\]|\[4[3-9][0-9]\]|\[5[0-9]{2}\]'
           
           # Extract broken links from raw report
           grep -E "$FAILURE_PATTERN" ./lychee-raw.md > broken-links-raw.txt 2>/dev/null || true

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -70,27 +70,12 @@ jobs:
         run: |
           curl -s https://buildwithfern.com/learn/sitemap.xml | grep -oP '(?<=<loc>)[^<]+' > urls.txt
           echo "Found $(wc -l < urls.txt) URLs in sitemap"
-          
-          # Split URLs into separate files for different lychee runs
-          # Non-GitHub URLs (for high-concurrency run)
-          grep -v '^https://github\.com/' urls.txt > urls-non-github.txt || true
-          echo "Non-GitHub URLs: $(wc -l < urls-non-github.txt)"
-          
-          # GitHub URLs excluding blob/tree/tag (for low-concurrency run)
-          # These are issues, PRs, compare, commits, repo roots, etc.
-          grep '^https://github\.com/' urls.txt \
-            | grep -vE '/blob/|/tree/|/releases/tag/' \
-            > urls-github-non-code.txt || true
-          echo "GitHub non-code URLs: $(wc -l < urls-github-non-code.txt)"
 
-      - name: Upload URL lists (early, for debugging)
+      - name: Upload sitemap URLs (early, for debugging)
         uses: actions/upload-artifact@v4
         with:
-          name: url-lists-early
-          path: |
-            urls.txt
-            urls-non-github.txt
-            urls-github-non-code.txt
+          name: sitemap-urls
+          path: urls.txt
           if-no-files-found: ignore
 
       - name: Extract and verify GitHub blob/tree/tag URLs locally
@@ -280,11 +265,11 @@ jobs:
             --max-retries 3
             --retry-wait-time 10
             --max-concurrency 20
-            --files-from urls-non-github.txt
+            --exclude "^https://github\\.com/"
+            --files-from urls.txt
           output: ./lychee-raw-main.md
           format: markdown
           fail: false
-          failIfEmpty: false
           jobSummary: false
 
       - name: Check GitHub links (very low concurrency to avoid 503 rate limiting)
@@ -298,11 +283,11 @@ jobs:
             --max-retries 5
             --retry-wait-time 20
             --max-concurrency 1
-            --files-from urls-github-non-code.txt
+            --include "^https://github\\.com/"
+            --files-from urls.txt
           output: ./lychee-raw-github.md
           format: markdown
           fail: false
-          failIfEmpty: false
           jobSummary: false
 
       - name: Combine lychee outputs

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -264,7 +264,6 @@ jobs:
             --max-retries 5
             --retry-wait-time 20
             --max-concurrency 1
-            --include "^https://github\\.com/[^/]+/[^/]+/?$"
             --include "^https://github\\.com/[^/]+/[^/]+/(issues|pull|pulls|compare|commit|commits|discussions)/"
             --files-from urls.txt
           output: ./lychee-raw-github.md

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -200,6 +200,10 @@ jobs:
               ref=$(echo "$clean_url" | sed -E 's#https://github\.com/[^/]+/[^/]+/(blob|tree)/([^/]+)/.*#\2#')
               rel_path=$(echo "$clean_url" | sed -E 's#https://github\.com/[^/]+/[^/]+/(blob|tree)/[^/]+/(.*)#\2#')
               
+              # URL-decode the relative path (handles %5B -> [, %5D -> ], spaces, etc.)
+              # This is needed because GitHub URLs encode special characters like [ and ]
+              rel_path=$(python3 -c "import sys, urllib.parse; print(urllib.parse.unquote(sys.argv[1]))" "$rel_path")
+              
               # Handle HEAD ref specially
               if [ "$ref" = "HEAD" ]; then
                 ref=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -103,6 +103,13 @@ jobs:
           # Deduplicate URLs
           sort -u github-urls.txt -o github-urls.txt
           
+          # Remove example/placeholder URLs (e.g., github.com/your-org/...)
+          # These are documentation examples, not real repos to verify
+          if [ -s github-urls.txt ]; then
+            grep -v 'github\.com/your-org/' github-urls.txt > github-urls.filtered || true
+            mv github-urls.filtered github-urls.txt
+          fi
+          
           total_urls=$(wc -l < github-urls.txt | tr -d ' ')
           end_time=$(date +%s)
           echo "Found $total_urls unique GitHub URLs to verify locally (took $((end_time - start_time))s)"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -257,7 +257,7 @@ jobs:
             --timeout 30
             --max-retries 3
             --retry-wait-time 10
-            --max-concurrency 10
+            --max-concurrency 20
             --exclude "^https://github\\.com/"
             --files-from urls.txt
           output: ./lychee-raw-main.md
@@ -277,6 +277,8 @@ jobs:
             --retry-wait-time 15
             --max-concurrency 2
             --include "^https://github\\.com/"
+            --exclude "^https://github\\.com/[^/]+/[^/]+/(blob|tree)/"
+            --exclude "^https://github\\.com/[^/]+/[^/]+/releases/tag/"
             --files-from urls.txt
           output: ./lychee-raw-github.md
           format: markdown

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -50,10 +50,11 @@ jobs:
             "^https://www\\.npmjs\\.com",
             "^https://cdn\\.simpleicons\\.org",
             
-            # All fern-api org GitHub links - skip HTTP checks to avoid 503 rate limiting
-            # blob/tree links are verified locally; PR/issue/compare links are not checked
-            # (they rarely break and checking them triggers GitHub rate limiting)
-            "^https://github\\.com/fern-api/",
+            # All GitHub blob/tree/tag URLs - verified locally before lychee runs
+            # This avoids 503 rate limiting from GitHub's automated request detection
+            # Issues/PRs/compare links are still checked via HTTP (they rarely break)
+            "^https://github\\.com/[^/]+/[^/]+/(blob|tree)/",
+            "^https://github\\.com/[^/]+/[^/]+/releases/tag/",
             
             # Non-HTTP links
             "^mailto:",
@@ -70,122 +71,163 @@ jobs:
           curl -s https://buildwithfern.com/learn/sitemap.xml | grep -oP '(?<=<loc>)[^<]+' > urls.txt
           echo "Found $(wc -l < urls.txt) URLs in sitemap"
 
-      - name: Extract and verify fern-api GitHub URLs locally
-        id: verify_fern_api
+      - name: Extract and verify GitHub blob/tree/tag URLs locally
+        id: verify_github
         run: |
-          # Extract all fern-api GitHub blob/tree URLs from the repo source files
+          # Extract all GitHub blob/tree/tag URLs from the repo source files
           # This is much faster than fetching all published pages via HTTP (~11 min -> seconds)
           # These URLs are excluded from lychee and verified locally instead to avoid 503 errors
           
-          echo "Scanning repo for fern-api GitHub URLs..."
+          echo "Scanning repo for GitHub blob/tree/tag URLs..."
           start_time=$(date +%s)
-          > fern-api-urls.txt
+          > github-urls.txt
           
-          # Search the content directories for fern-api blob/tree URLs
+          # Search the content directories for GitHub blob/tree URLs
           # Include fern/ (main docs) and README.md (root)
           # Exclude .git and any cloned repos
-          grep -RhoE 'https://github\.com/fern-api/[^/]+/(blob|tree)/[^"'"'"')<>[:space:]]+' \
+          grep -RhoE 'https://github\.com/[^/]+/[^/]+/(blob|tree)/[^"'"'"')<>[:space:]]+' \
             fern/ \
             README.md \
             --exclude-dir=.git \
-            --exclude-dir=.fern-api-repos \
-            >> fern-api-urls.txt 2>/dev/null || true
+            --exclude-dir=.github-repos \
+            >> github-urls.txt 2>/dev/null || true
+          
+          # Also search for releases/tag URLs
+          grep -RhoE 'https://github\.com/[^/]+/[^/]+/releases/tag/[^"'"'"')<>[:space:]]+' \
+            fern/ \
+            README.md \
+            --exclude-dir=.git \
+            --exclude-dir=.github-repos \
+            >> github-urls.txt 2>/dev/null || true
           
           # Deduplicate URLs
-          sort -u fern-api-urls.txt -o fern-api-urls.txt
+          sort -u github-urls.txt -o github-urls.txt
           
-          total_urls=$(wc -l < fern-api-urls.txt | tr -d ' ')
+          total_urls=$(wc -l < github-urls.txt | tr -d ' ')
           end_time=$(date +%s)
-          echo "Found $total_urls unique fern-api GitHub URLs to verify locally (took $((end_time - start_time))s)"
+          echo "Found $total_urls unique GitHub URLs to verify locally (took $((end_time - start_time))s)"
           
           if [ "$total_urls" -eq 0 ]; then
-            echo "No fern-api GitHub URLs to verify"
+            echo "No GitHub URLs to verify"
             echo "verified_count=0" >> $GITHUB_OUTPUT
             echo "missing_count=0" >> $GITHUB_OUTPUT
             echo "has_missing=false" >> $GITHUB_OUTPUT
             exit 0
           fi
           
-          # Extract unique repos that need to be cloned
-          grep -oE 'https://github\.com/fern-api/[^/]+' fern-api-urls.txt | sort -u > fern-api-repos.txt
+          # Extract unique repos that need to be cloned (org/repo format)
+          grep -oE 'https://github\.com/[^/]+/[^/]+' github-urls.txt | sort -u > github-repos.txt
           
           echo "Repos to clone:"
-          cat fern-api-repos.txt
+          cat github-repos.txt
           
           # Clone each repo (shallow clone for efficiency)
-          mkdir -p .fern-api-repos
+          mkdir -p .github-repos
           while IFS= read -r repo_url; do
             [ -z "$repo_url" ] && continue
-            repo_name="${repo_url##*/}"
-            echo "Cloning $repo_name..."
+            # Extract org/repo for directory structure
+            org_repo=$(echo "$repo_url" | sed -E 's#https://github\.com/##')
+            org=$(echo "$org_repo" | cut -d'/' -f1)
+            repo_name=$(echo "$org_repo" | cut -d'/' -f2)
+            
+            echo "Cloning $org/$repo_name..."
+            mkdir -p ".github-repos/$org"
             
             # Use sparse checkout for efficiency - we only need to check if paths exist
-            git clone --depth 1 --filter=blob:none --sparse "$repo_url.git" ".fern-api-repos/$repo_name" 2>/dev/null || {
+            git clone --depth 1 --filter=blob:none --sparse "$repo_url.git" ".github-repos/$org/$repo_name" 2>/dev/null || {
               echo "Warning: Failed to clone $repo_url, will mark URLs from this repo as unverifiable"
               continue
             }
-          done < fern-api-repos.txt
+            
+            # Fetch all tags for tag verification (lightweight fetch)
+            cd ".github-repos/$org/$repo_name"
+            git fetch --tags --depth 1 2>/dev/null || true
+            cd ../../..
+          done < github-repos.txt
           
           # Verify each URL by checking if the path exists in the cloned repo
           verified_count=0
           missing_count=0
-          > fern-api-missing.txt
-          > fern-api-verified.txt
+          > github-missing.txt
+          > github-verified.txt
           
           while IFS= read -r url; do
             [ -z "$url" ] && continue
             
-            # Parse URL: https://github.com/fern-api/REPO/(blob|tree)/BRANCH/PATH
             # Remove any URL fragments or query strings
             clean_url="${url%%#*}"
             clean_url="${clean_url%%\?*}"
             
-            # Extract repo name and path
-            # Format: https://github.com/fern-api/REPO/(blob|tree)/BRANCH/PATH
-            # Use # as delimiter since | conflicts with regex alternation in (blob|tree)
-            repo_name=$(echo "$clean_url" | sed -E 's#https://github\.com/fern-api/([^/]+)/.*#\1#')
-            # Extract path after branch (everything after blob/BRANCH/ or tree/BRANCH/)
-            rel_path=$(echo "$clean_url" | sed -E 's#https://github\.com/fern-api/[^/]+/(blob|tree)/[^/]+/(.*)#\2#')
+            # Extract org, repo name, and determine URL type
+            org=$(echo "$clean_url" | sed -E 's#https://github\.com/([^/]+)/.*#\1#')
+            repo_name=$(echo "$clean_url" | sed -E 's#https://github\.com/[^/]+/([^/]+)/.*#\1#')
             
             # Check if we have the repo cloned
-            if [ ! -d ".fern-api-repos/$repo_name" ]; then
+            if [ ! -d ".github-repos/$org/$repo_name" ]; then
               echo "Repo not cloned, cannot verify: $url"
-              echo "- [UNVERIFIABLE] $url (repo clone failed)" >> fern-api-missing.txt
+              echo "- [UNVERIFIABLE] $url (repo clone failed)" >> github-missing.txt
               missing_count=$((missing_count + 1))
               continue
             fi
             
-            # For sparse checkout, we need to fetch the specific path to check if it exists
-            # Use git ls-tree to check if the path exists without fetching content
-            cd ".fern-api-repos/$repo_name"
+            cd ".github-repos/$org/$repo_name"
             
-            # Get the default branch
-            default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
-            
-            # Check if path exists using git ls-tree (works with sparse checkout)
-            if git ls-tree -r --name-only "$default_branch" -- "$rel_path" 2>/dev/null | grep -q "^${rel_path}$" || \
-               git ls-tree -d --name-only "$default_branch" -- "$rel_path" 2>/dev/null | grep -q "^${rel_path}$"; then
-              echo "Verified: $url -> $rel_path"
-              echo "$url" >> ../../fern-api-verified.txt
-              verified_count=$((verified_count + 1))
-            else
-              # Also check if it's a directory (tree link)
-              if git ls-tree -d "$default_branch" -- "$rel_path" 2>/dev/null | grep -q .; then
-                echo "Verified (directory): $url -> $rel_path"
-                echo "$url" >> ../../fern-api-verified.txt
+            # Check if this is a releases/tag URL
+            if echo "$clean_url" | grep -qE '/releases/tag/'; then
+              # Extract tag name
+              tag_name=$(echo "$clean_url" | sed -E 's#.*/releases/tag/(.*)#\1#')
+              
+              # Check if tag exists
+              if git tag -l "$tag_name" | grep -q "^${tag_name}$"; then
+                echo "Verified (tag): $url -> tag $tag_name"
+                echo "$url" >> ../../../github-verified.txt
                 verified_count=$((verified_count + 1))
               else
-                echo "MISSING: $url -> $rel_path"
-                echo "- [LOCAL_MISSING] $url (path: $rel_path in $repo_name)" >> ../../fern-api-missing.txt
+                echo "MISSING (tag): $url -> tag $tag_name"
+                echo "- [LOCAL_MISSING] $url (tag: $tag_name in $org/$repo_name)" >> ../../../github-missing.txt
                 missing_count=$((missing_count + 1))
+              fi
+            else
+              # This is a blob/tree URL - extract ref and path
+              # Format: https://github.com/ORG/REPO/(blob|tree)/REF/PATH
+              ref=$(echo "$clean_url" | sed -E 's#https://github\.com/[^/]+/[^/]+/(blob|tree)/([^/]+)/.*#\2#')
+              rel_path=$(echo "$clean_url" | sed -E 's#https://github\.com/[^/]+/[^/]+/(blob|tree)/[^/]+/(.*)#\2#')
+              
+              # Handle HEAD ref specially
+              if [ "$ref" = "HEAD" ]; then
+                ref=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+              fi
+              
+              # For specific commit SHAs, we need to fetch them
+              if echo "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+                git fetch --depth 1 origin "$ref" 2>/dev/null || true
+              fi
+              
+              # Check if path exists using git ls-tree (works with sparse checkout)
+              if git ls-tree -r --name-only "$ref" -- "$rel_path" 2>/dev/null | grep -q "^${rel_path}$" || \
+                 git ls-tree -d --name-only "$ref" -- "$rel_path" 2>/dev/null | grep -q "^${rel_path}$"; then
+                echo "Verified: $url -> $rel_path (ref: $ref)"
+                echo "$url" >> ../../../github-verified.txt
+                verified_count=$((verified_count + 1))
+              else
+                # Also check if it's a directory (tree link)
+                if git ls-tree -d "$ref" -- "$rel_path" 2>/dev/null | grep -q .; then
+                  echo "Verified (directory): $url -> $rel_path (ref: $ref)"
+                  echo "$url" >> ../../../github-verified.txt
+                  verified_count=$((verified_count + 1))
+                else
+                  echo "MISSING: $url -> $rel_path (ref: $ref)"
+                  echo "- [LOCAL_MISSING] $url (path: $rel_path in $org/$repo_name, ref: $ref)" >> ../../../github-missing.txt
+                  missing_count=$((missing_count + 1))
+                fi
               fi
             fi
             
-            cd ../..
-          done < fern-api-urls.txt
+            cd ../../..
+          done < github-urls.txt
           
           echo ""
-          echo "=== fern-api GitHub URL Verification Summary ==="
+          echo "=== GitHub URL Verification Summary ==="
           echo "Total URLs checked: $total_urls"
           echo "Verified locally: $verified_count"
           echo "Missing/unverifiable: $missing_count"
@@ -197,13 +239,13 @@ jobs:
             echo "has_missing=true" >> $GITHUB_OUTPUT
             echo ""
             echo "Missing URLs:"
-            cat fern-api-missing.txt
+            cat github-missing.txt
           else
             echo "has_missing=false" >> $GITHUB_OUTPUT
           fi
           
           # Cleanup cloned repos
-          rm -rf .fern-api-repos
+          rm -rf .github-repos
 
       - name: Check Fern Docs Links (first pass)
         id: lychee
@@ -335,14 +377,17 @@ jobs:
           grep -E "$FAILURE_PATTERN" ./lychee-raw.md > broken-links-raw.txt 2>/dev/null || true
           
           # Filter out repo-internal GitHub URLs that exist locally (handles 5xx false positives)
-          # This is similar to how 429 errors are handled for repo-internal URLs
+          # Also separate 5xx errors from external GitHub repos (likely rate limiting, not broken)
           verified_5xx=0
+          external_5xx=0
           > broken-links.txt
+          > external-5xx-links.txt
           while IFS= read -r line; do
             [ -z "$line" ] && continue
             
-            # Extract URL from the line (format: ... [STATUS] <URL> ...)
+            # Extract URL and status code from the line (format: ... [STATUS] <URL> ...)
             url=$(echo "$line" | sed -E 's/.*<([^>]+)>.*/\1/')
+            status=$(echo "$line" | sed -E 's/.*\[([0-9]+)\].*/\1/')
             
             # Check if this is a repo-internal GitHub URL (blob/main pattern)
             if echo "$url" | grep -qE '^https://github\.com/fern-api/docs/blob/main/'; then
@@ -357,14 +402,21 @@ jobs:
                 # File doesn't exist locally, this is a real broken link
                 echo "$line" >> broken-links.txt
               fi
+            # Check if this is a 5xx error from an external GitHub repo (likely rate limiting)
+            elif echo "$status" | grep -qE '^5[0-9]{2}$' && echo "$url" | grep -qE '^https://github\.com/'; then
+              echo "External GitHub 5xx (likely rate limiting): $url"
+              echo "$line" >> external-5xx-links.txt
+              external_5xx=$((external_5xx + 1))
             else
-              # Not a repo-internal URL, keep it in the broken links list
+              # Not a repo-internal URL and not external GitHub 5xx, keep it in the broken links list
               echo "$line" >> broken-links.txt
             fi
           done < broken-links-raw.txt
           
           echo "Repo-internal GitHub URLs with 5xx verified locally: $verified_5xx"
+          echo "External GitHub URLs with 5xx (likely rate limiting): $external_5xx"
           echo "verified_5xx=$verified_5xx" >> $GITHUB_OUTPUT
+          echo "external_5xx=$external_5xx" >> $GITHUB_OUTPUT
           
           broken_count=$(wc -l < broken-links.txt | tr -d ' ')
           
@@ -374,11 +426,11 @@ jobs:
           still_failing_429="${{ steps.retry429.outputs.still_failing_429 }}"
           still_failing_429=${still_failing_429:-0}
           
-          # Get fern-api local verification stats
-          fern_api_verified="${{ steps.verify_fern_api.outputs.verified_count }}"
-          fern_api_verified=${fern_api_verified:-0}
-          fern_api_missing="${{ steps.verify_fern_api.outputs.missing_count }}"
-          fern_api_missing=${fern_api_missing:-0}
+          # Get GitHub local verification stats
+          github_verified="${{ steps.verify_github.outputs.verified_count }}"
+          github_verified=${github_verified:-0}
+          github_missing="${{ steps.verify_github.outputs.missing_count }}"
+          github_missing=${github_missing:-0}
           
           # Build clean errors-only report
           cat > lychee-report.md << 'HEADER'
@@ -403,14 +455,25 @@ jobs:
             echo "" >> lychee-report.md
           fi
           
-          if [ "$fern_api_missing" -gt 0 ]; then
-            echo "## fern-api GitHub URLs - Missing Locally ($fern_api_missing)" >> lychee-report.md
+          if [ "$github_missing" -gt 0 ]; then
+            echo "## GitHub URLs - Missing Locally ($github_missing)" >> lychee-report.md
             echo "" >> lychee-report.md
-            cat fern-api-missing.txt >> lychee-report.md
+            cat github-missing.txt >> lychee-report.md
             echo "" >> lychee-report.md
           fi
           
-          if [ "$broken_count" -eq 0 ] && [ "$still_failing_429" -eq 0 ] && [ "$fern_api_missing" -eq 0 ]; then
+          # External GitHub 5xx errors are informational only (likely rate limiting, not broken)
+          external_5xx_count=$(wc -l < external-5xx-links.txt | tr -d ' ')
+          if [ "$external_5xx_count" -gt 0 ]; then
+            echo "## External GitHub URLs - 5xx (Likely Rate Limiting, Manual Validation Recommended)" >> lychee-report.md
+            echo "" >> lychee-report.md
+            echo "_These links returned 5xx errors during automated checking. They are likely valid but rate-limited. Please validate manually._" >> lychee-report.md
+            echo "" >> lychee-report.md
+            sed -E 's/.*\[([0-9]+)\].*<([^>]+)>.*/- [\1] \2/' external-5xx-links.txt >> lychee-report.md
+            echo "" >> lychee-report.md
+          fi
+          
+          if [ "$broken_count" -eq 0 ] && [ "$still_failing_429" -eq 0 ] && [ "$github_missing" -eq 0 ]; then
             echo "No broken links found!" >> lychee-report.md
           fi
           
@@ -451,8 +514,9 @@ jobs:
           echo "  Repo-internal GitHub URLs (5xx verified locally): $verified_5xx"
           echo "  Rate-limited (429) - recovered after retry: $recovered_429"
           echo "  Rate-limited (429) - still failing: $still_failing_429"
-          echo "  fern-api GitHub URLs verified locally: $fern_api_verified"
-          echo "  fern-api GitHub URLs missing locally: $fern_api_missing"
+          echo "  GitHub URLs verified locally: $github_verified"
+          echo "  GitHub URLs missing locally: $github_missing"
+          echo "  External GitHub URLs with 5xx (likely rate limiting): $external_5xx_count"
           
           if [ "$broken_count" -gt 0 ]; then
             echo ""
@@ -466,10 +530,10 @@ jobs:
             cat urls-429-still-failing.txt
           fi
           
-          if [ "$fern_api_missing" -gt 0 ]; then
+          if [ "$github_missing" -gt 0 ]; then
             echo ""
-            echo "FERN-API GITHUB URLs MISSING LOCALLY:"
-            cat fern-api-missing.txt
+            echo "GITHUB URLs MISSING LOCALLY:"
+            cat github-missing.txt
           fi
           
           # Build GitHub Step Summary using lychee's table + 429 info + persistent errors only
@@ -488,8 +552,9 @@ jobs:
             echo "| Repo-internal GitHub URLs (5xx verified locally) | $verified_5xx |"
             echo "| Rate-limited (429) recovered after retry | $recovered_429 |"
             echo "| Rate-limited (429) still failing | $still_failing_429 |"
-            echo "| fern-api GitHub URLs verified locally | $fern_api_verified |"
-            echo "| fern-api GitHub URLs missing locally | $fern_api_missing |"
+            echo "| GitHub URLs verified locally | $github_verified |"
+            echo "| GitHub URLs missing locally | $github_missing |"
+            echo "| External GitHub URLs with 5xx (likely rate limiting) | $external_5xx_count |"
             echo ""
             
             # Show persistent errors only (non-429 broken links + 429s that didn't recover)
@@ -508,9 +573,9 @@ jobs:
               cat urls-429-still-failing.txt
             fi
             
-            if [ "$fern_api_missing" -gt 0 ]; then
+            if [ "$github_missing" -gt 0 ]; then
               has_persistent_errors=true
-              cat fern-api-missing.txt
+              cat github-missing.txt
             fi
             
             if [ "$has_persistent_errors" = false ]; then
@@ -530,7 +595,7 @@ jobs:
 
       - name: Create PR for broken links
         id: create-pr
-        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_fern_api.outputs.has_missing == 'true'
+        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_github.outputs.has_missing == 'true'
         uses: actions/github-script@v7
         env:
           DEVIN_PROMPT: |
@@ -538,13 +603,17 @@ jobs:
 
             **Instructions:**
             1. For each URL listed below, identify the source file containing the broken link
-            2. Either update the link to point to the correct URL, or remove the link if the resource no longer exists
-            3. Only update links/paths contained in this PR, not other links that follow a similar pattern
-            4. Run `fern docs dev` locally to verify your changes don't break anything
-            5. Push your fix to this PR branch
-            6. After CI posts a preview link, use it to verify that your changes actually fix the underlying issue, then post a comment to the PR mentioning that you have tested it using the preview link
-            7. When the PR is ready for review, request a review from @davidkonigsberg in GitHub and send a message in the Devin session that includes "<!here>" to alert everyone in the channel. 
-            8. Delete the scaffold file (.github/broken-links/broken-links.md) as part of your fix
+            2. Try to find the correct replacement URL. Common fixes include:
+               - Updating outdated commit SHAs to the latest commit
+               - Fixing URL-encoded paths
+               - Updating renamed file paths
+            3. **IMPORTANT: If you cannot confidently find a correct replacement** (e.g., the only signal is a 5xx/503 error, connection reset, or rate limiting), **do NOT remove or modify the link**. Instead, leave it unchanged and add a PR comment on the relevant line asking for manual validation.
+            4. Only update links/paths contained in this PR, not other links that follow a similar pattern
+            5. Run `fern docs dev` locally to verify your changes don't break anything
+            6. Push your fix to this PR branch
+            7. After CI posts a preview link, use it to verify that your changes actually fix the underlying issue, then post a comment to the PR mentioning that you have tested it using the preview link
+            8. When the PR is ready for review, request a review from @davidkonigsberg in GitHub and send a message in the Devin session that includes "<!here>" to alert everyone in the channel. 
+            9. Delete the scaffold file (.github/broken-links/broken-links.md) as part of your fix
 
             **Broken Links:**
         with:
@@ -561,7 +630,7 @@ jobs:
             // Read broken links files
             let brokenLinksContent = '';
             let urls429Content = '';
-            let fernApiMissingContent = '';
+            let githubMissingContent = '';
             
             try {
               brokenLinksContent = fs.readFileSync('broken-links.txt', 'utf8');
@@ -576,12 +645,12 @@ jobs:
             }
             
             try {
-              fernApiMissingContent = fs.readFileSync('fern-api-missing.txt', 'utf8');
+              githubMissingContent = fs.readFileSync('github-missing.txt', 'utf8');
             } catch (e) {
-              console.log('No fern-api-missing.txt found');
+              console.log('No github-missing.txt found');
             }
 
-            if (!brokenLinksContent && !urls429Content && !fernApiMissingContent) {
+            if (!brokenLinksContent && !urls429Content && !githubMissingContent) {
               console.log('No broken links to report');
               return;
             }
@@ -608,9 +677,9 @@ jobs:
               scaffoldContent += urls429Content.trim() + '\n';
             }
             
-            if (fernApiMissingContent.trim()) {
-              scaffoldContent += '\n## fern-api GitHub URLs Missing Locally\n\n';
-              scaffoldContent += fernApiMissingContent.trim() + '\n';
+            if (githubMissingContent.trim()) {
+              scaffoldContent += '\n## GitHub URLs Missing Locally\n\n';
+              scaffoldContent += githubMissingContent.trim() + '\n';
             }
 
             scaffoldContent += '\n---\n';
@@ -808,7 +877,7 @@ jobs:
             }
 
       - name: Fail if there are broken links
-        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_fern_api.outputs.has_missing == 'true'
+        if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_github.outputs.has_missing == 'true'
         run: |
           echo "Link check failed!"
           if [ "${{ steps.check_failures.outputs.has_other_failures }}" == "true" ]; then
@@ -818,7 +887,7 @@ jobs:
             echo "Some URLs still returned 429 after exponential backoff retry."
             echo "These URLs may need to be excluded or the rate limit needs more time to reset."
           fi
-          if [ "${{ steps.verify_fern_api.outputs.has_missing }}" == "true" ]; then
-            echo "Some fern-api GitHub URLs point to paths that don't exist in the repos."
+          if [ "${{ steps.verify_github.outputs.has_missing }}" == "true" ]; then
+            echo "Some GitHub URLs point to paths that don't exist in the repos."
           fi
           exit 1

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -678,6 +678,7 @@ jobs:
           name: lychee-outputs
           path: |
             github-urls.txt
+            github-http-urls.txt
             github-verified.txt
             github-missing.txt
             lychee-raw-main.md

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -288,6 +288,12 @@ jobs:
             2>/dev/null | grep -v 'github\.com/fern-api/' \
             >> github-http-urls.txt || true
           
+          # Remove example/placeholder URLs (e.g., github.com/your-org/...)
+          if [ -s github-http-urls.txt ]; then
+            grep -v 'github\.com/your-org/' github-http-urls.txt > github-http-urls.filtered || true
+            mv github-http-urls.filtered github-http-urls.txt
+          fi
+          
           # Deduplicate URLs
           sort -u github-http-urls.txt -o github-http-urls.txt
           

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -70,6 +70,18 @@ jobs:
         run: |
           curl -s https://buildwithfern.com/learn/sitemap.xml | grep -oP '(?<=<loc>)[^<]+' > urls.txt
           echo "Found $(wc -l < urls.txt) URLs in sitemap"
+          
+          # Split URLs into separate files for different lychee runs
+          # Non-GitHub URLs (for high-concurrency run)
+          grep -v '^https://github\.com/' urls.txt > urls-non-github.txt || true
+          echo "Non-GitHub URLs: $(wc -l < urls-non-github.txt)"
+          
+          # GitHub URLs excluding blob/tree/tag (for low-concurrency run)
+          # These are issues, PRs, compare, commits, repo roots, etc.
+          grep '^https://github\.com/' urls.txt \
+            | grep -vE '/blob/|/tree/|/releases/tag/' \
+            > urls-github-non-code.txt || true
+          echo "GitHub non-code URLs: $(wc -l < urls-github-non-code.txt)"
 
       - name: Extract and verify GitHub blob/tree/tag URLs locally
         id: verify_github
@@ -258,14 +270,14 @@ jobs:
             --max-retries 3
             --retry-wait-time 10
             --max-concurrency 20
-            --exclude "^https://github\\.com/"
-            --files-from urls.txt
+            --files-from urls-non-github.txt
           output: ./lychee-raw-main.md
           format: markdown
           fail: false
+          failIfEmpty: false
           jobSummary: false
 
-      - name: Check GitHub links (low concurrency to avoid 503 rate limiting)
+      - name: Check GitHub links (very low concurrency to avoid 503 rate limiting)
         id: lychee_github
         uses: lycheeverse/lychee-action@v2
         with:
@@ -274,15 +286,13 @@ jobs:
             --no-progress
             --timeout 30
             --max-retries 5
-            --retry-wait-time 15
-            --max-concurrency 2
-            --include "^https://github\\.com/"
-            --exclude "^https://github\\.com/[^/]+/[^/]+/(blob|tree)/"
-            --exclude "^https://github\\.com/[^/]+/[^/]+/releases/tag/"
-            --files-from urls.txt
+            --retry-wait-time 20
+            --max-concurrency 1
+            --files-from urls-github-non-code.txt
           output: ./lychee-raw-github.md
           format: markdown
           fail: false
+          failIfEmpty: false
           jobSummary: false
 
       - name: Combine lychee outputs

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -632,6 +632,22 @@ jobs:
           path: ./lychee-report.md
           if-no-files-found: ignore
 
+      - name: Upload URL files for debugging
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: url-files
+          path: |
+            urls.txt
+            urls-non-github.txt
+            urls-github-non-code.txt
+            github-urls.txt
+            github-verified.txt
+            github-missing.txt
+            lychee-raw-main.md
+            lychee-raw-github.md
+          if-no-files-found: ignore
+
       - name: Create PR for broken links
         id: create-pr
         if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_github.outputs.has_missing == 'true'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -135,9 +135,10 @@ jobs:
             
             # Extract repo name and path
             # Format: https://github.com/fern-api/REPO/(blob|tree)/BRANCH/PATH
-            repo_name=$(echo "$clean_url" | sed -E 's|https://github\.com/fern-api/([^/]+)/.*|\1|')
+            # Use # as delimiter since | conflicts with regex alternation in (blob|tree)
+            repo_name=$(echo "$clean_url" | sed -E 's#https://github\.com/fern-api/([^/]+)/.*#\1#')
             # Extract path after branch (everything after blob/BRANCH/ or tree/BRANCH/)
-            rel_path=$(echo "$clean_url" | sed -E 's|https://github\.com/fern-api/[^/]+/(blob|tree)/[^/]+/(.*)|\2|')
+            rel_path=$(echo "$clean_url" | sed -E 's#https://github\.com/fern-api/[^/]+/(blob|tree)/[^/]+/(.*)#\2#')
             
             # Check if we have the repo cloned
             if [ ! -d ".fern-api-repos/$repo_name" ]; then

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -247,14 +247,14 @@ jobs:
           # Cleanup cloned repos
           rm -rf .github-repos
 
-      - name: Extract GitHub issues/compare/commit/discussions URLs from source files
+      - name: Extract GitHub URLs for HTTP checking from source files
         id: extract_github_http
         run: |
-          # Extract GitHub URLs that need HTTP checking (issues, compare, commit, discussions)
+          # Extract GitHub URLs that need HTTP checking (issues, compare, commit, discussions, non-fern-api PRs)
           # These are extracted from source files and passed directly to lychee
           # This avoids the --include filter issue where lychee applies it to input pages, not discovered links
           
-          echo "Scanning repo for GitHub issues/compare/commit/discussions URLs..."
+          echo "Scanning repo for GitHub URLs to check via HTTP..."
           > github-http-urls.txt
           
           # Search for issues URLs
@@ -280,6 +280,13 @@ jobs:
             fern/ README.md \
             --exclude-dir=.git --exclude-dir=.github-repos \
             >> github-http-urls.txt 2>/dev/null || true
+          
+          # Search for pull request URLs (excluding fern-api org - those are too slow to check)
+          grep -RhoE 'https://github\.com/[^/]+/[^/]+/pull/[^"'"'"')<>[:space:]]+' \
+            fern/ README.md \
+            --exclude-dir=.git --exclude-dir=.github-repos \
+            2>/dev/null | grep -v 'github\.com/fern-api/' \
+            >> github-http-urls.txt || true
           
           # Deduplicate URLs
           sort -u github-http-urls.txt -o github-http-urls.txt

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -254,8 +254,55 @@ jobs:
           # Cleanup cloned repos
           rm -rf .github-repos
 
+      - name: Extract GitHub issues/compare/commit/discussions URLs from source files
+        id: extract_github_http
+        run: |
+          # Extract GitHub URLs that need HTTP checking (issues, compare, commit, discussions)
+          # These are extracted from source files and passed directly to lychee
+          # This avoids the --include filter issue where lychee applies it to input pages, not discovered links
+          
+          echo "Scanning repo for GitHub issues/compare/commit/discussions URLs..."
+          > github-http-urls.txt
+          
+          # Search for issues URLs
+          grep -RhoE 'https://github\.com/[^/]+/[^/]+/issues/[^"'"'"')<>[:space:]]+' \
+            fern/ README.md \
+            --exclude-dir=.git --exclude-dir=.github-repos \
+            >> github-http-urls.txt 2>/dev/null || true
+          
+          # Search for compare URLs
+          grep -RhoE 'https://github\.com/[^/]+/[^/]+/compare/[^"'"'"')<>[:space:]]+' \
+            fern/ README.md \
+            --exclude-dir=.git --exclude-dir=.github-repos \
+            >> github-http-urls.txt 2>/dev/null || true
+          
+          # Search for commit/commits URLs
+          grep -RhoE 'https://github\.com/[^/]+/[^/]+/commits?/[^"'"'"')<>[:space:]]+' \
+            fern/ README.md \
+            --exclude-dir=.git --exclude-dir=.github-repos \
+            >> github-http-urls.txt 2>/dev/null || true
+          
+          # Search for discussions URLs
+          grep -RhoE 'https://github\.com/[^/]+/[^/]+/discussions/[^"'"'"')<>[:space:]]+' \
+            fern/ README.md \
+            --exclude-dir=.git --exclude-dir=.github-repos \
+            >> github-http-urls.txt 2>/dev/null || true
+          
+          # Deduplicate URLs
+          sort -u github-http-urls.txt -o github-http-urls.txt
+          
+          total_urls=$(wc -l < github-http-urls.txt | tr -d ' ')
+          echo "Found $total_urls unique GitHub URLs to check via HTTP"
+          echo "github_http_count=$total_urls" >> $GITHUB_OUTPUT
+          
+          if [ "$total_urls" -gt 0 ]; then
+            echo "URLs to check:"
+            cat github-http-urls.txt
+          fi
+
       - name: Check GitHub links (very low concurrency to avoid 503 rate limiting)
         id: lychee_github
+        if: steps.extract_github_http.outputs.github_http_count != '0'
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
@@ -263,9 +310,8 @@ jobs:
             --timeout 30
             --max-retries 5
             --retry-wait-time 20
-            --max-concurrency 10
-            --include "^https://github\\.com/[^/]+/[^/]+/(issues|compare|commit|commits|discussions)/"
-            --files-from urls.txt
+            --max-concurrency 2
+            github-http-urls.txt
           output: ./lychee-raw-github.md
           format: markdown
           fail: false

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -50,9 +50,10 @@ jobs:
             "^https://www\\.npmjs\\.com",
             "^https://cdn\\.simpleicons\\.org",
             
-            # fern-api org GitHub file/tree links - verified locally instead of via HTTP
-            # This avoids 503 errors from GitHub rate limiting automated requests
-            "^https://github\\.com/fern-api/[^/]+/(blob|tree)/",
+            # All fern-api org GitHub links - skip HTTP checks to avoid 503 rate limiting
+            # blob/tree links are verified locally; PR/issue/compare links are not checked
+            # (they rarely break and checking them triggers GitHub rate limiting)
+            "^https://github\\.com/fern-api/",
             
             # Non-HTTP links
             "^mailto:",

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -72,24 +72,30 @@ jobs:
       - name: Extract and verify fern-api GitHub URLs locally
         id: verify_fern_api
         run: |
-          # Extract all fern-api GitHub blob/tree URLs from the documentation pages
-          # These are excluded from lychee and verified locally instead to avoid 503 errors
+          # Extract all fern-api GitHub blob/tree URLs from the repo source files
+          # This is much faster than fetching all published pages via HTTP (~11 min -> seconds)
+          # These URLs are excluded from lychee and verified locally instead to avoid 503 errors
           
-          echo "Fetching documentation pages to extract fern-api GitHub URLs..."
+          echo "Scanning repo for fern-api GitHub URLs..."
+          start_time=$(date +%s)
           > fern-api-urls.txt
           
-          # Fetch each page and extract fern-api GitHub blob/tree URLs
-          while IFS= read -r page_url; do
-            [ -z "$page_url" ] && continue
-            curl -s "$page_url" | grep -oE 'https://github\.com/fern-api/[^/]+/(blob|tree)/[^"<>[:space:]]+' >> fern-api-urls.txt 2>/dev/null || true
-          done < urls.txt
+          # Search the content directories for fern-api blob/tree URLs
+          # Include fern/ (main docs) and README.md (root)
+          # Exclude .git and any cloned repos
+          grep -RhoE 'https://github\.com/fern-api/[^/]+/(blob|tree)/[^"'"'"')<>[:space:]]+' \
+            fern/ \
+            README.md \
+            --exclude-dir=.git \
+            --exclude-dir=.fern-api-repos \
+            >> fern-api-urls.txt 2>/dev/null || true
           
           # Deduplicate URLs
-          sort -u fern-api-urls.txt > fern-api-urls-unique.txt
-          mv fern-api-urls-unique.txt fern-api-urls.txt
+          sort -u fern-api-urls.txt -o fern-api-urls.txt
           
           total_urls=$(wc -l < fern-api-urls.txt | tr -d ' ')
-          echo "Found $total_urls unique fern-api GitHub URLs to verify locally"
+          end_time=$(date +%s)
+          echo "Found $total_urls unique fern-api GitHub URLs to verify locally (took $((end_time - start_time))s)"
           
           if [ "$total_urls" -eq 0 ]; then
             echo "No fern-api GitHub URLs to verify"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -247,8 +247,8 @@ jobs:
           # Cleanup cloned repos
           rm -rf .github-repos
 
-      - name: Check Fern Docs Links (first pass)
-        id: lychee
+      - name: Check non-GitHub links (high concurrency)
+        id: lychee_main
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
@@ -258,11 +258,38 @@ jobs:
             --max-retries 3
             --retry-wait-time 10
             --max-concurrency 10
+            --exclude "^https://github\\.com/"
             --files-from urls.txt
-          output: ./lychee-raw.md
+          output: ./lychee-raw-main.md
           format: markdown
           fail: false
           jobSummary: false
+
+      - name: Check GitHub links (low concurrency to avoid 503 rate limiting)
+        id: lychee_github
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config lychee.toml
+            --no-progress
+            --timeout 30
+            --max-retries 5
+            --retry-wait-time 15
+            --max-concurrency 2
+            --include "^https://github\\.com/"
+            --files-from urls.txt
+          output: ./lychee-raw-github.md
+          format: markdown
+          fail: false
+          jobSummary: false
+
+      - name: Combine lychee outputs
+        run: |
+          # Combine both lychee runs into a single raw file for downstream processing
+          : > lychee-raw.md
+          [ -f lychee-raw-main.md ] && cat lychee-raw-main.md >> lychee-raw.md
+          [ -f lychee-raw-github.md ] && cat lychee-raw-github.md >> lychee-raw.md
+          echo "Combined lychee outputs into lychee-raw.md"
 
       - name: Extract 429 URLs and retry with exponential backoff
         id: retry429

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -350,6 +350,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
+            --config lychee.toml
             --no-progress
             --timeout 30
             --max-retries 3
@@ -518,6 +519,10 @@ jobs:
               echo "$line" >> broken-links.txt
             fi
           done < broken-links-raw.txt
+          
+          # Deduplicate error files (same URL may appear multiple times if linked from multiple pages)
+          sort -u broken-links.txt -o broken-links.txt
+          sort -u external-5xx-links.txt -o external-5xx-links.txt
           
           echo "Repo-internal GitHub URLs with 5xx verified locally: $verified_5xx"
           echo "External GitHub URLs with 5xx (likely rate limiting): $external_5xx"


### PR DESCRIPTION
## Summary

Updates the link scanning workflow to verify **all GitHub blob/tree/tag URLs** by cloning repos locally instead of making HTTP requests. This addresses 503 errors from GitHub rate limiting automated requests.

The workflow now:
1. **Excludes ALL GitHub blob/tree and releases/tag URLs from lychee's HTTP checks** (for any org, not just fern-api)
2. Scans local repo source files with grep to extract GitHub URLs (~1 second vs ~11 min for HTTP)
3. Clones the relevant repos (shallow clone with sparse checkout for efficiency)
4. Uses `git ls-tree` to verify blob/tree paths exist, and `git tag -l` to verify release tags
5. Fetches specific commit SHAs when URLs reference them
6. Reports missing paths/tags as broken links in the summary and PR scaffold
7. **Separates 5xx errors from external GitHub repos as "soft failures"** - these are likely rate limiting, not broken links
8. **Excludes 403s from broken links report** - bot-blocking sites (npmjs, simpleicons) return 403 but are not actually broken
9. **Updates DEVIN_PROMPT** to not auto-remove links when the only signal is a transient error (5xx/503)

**Trade-off**: Issues/PRs/compare links are still checked via HTTP (they rarely break and are less likely to trigger rate limiting than code links).

## Updates since last revision

- **403s excluded from broken links but NOT retried**: Bot-blocking sites (npmjs.com, simpleicons.org) consistently return 403 regardless of retries, so there's no point retrying them. They're excluded from the broken links report via `FAILURE_PATTERN` but not included in the exponential backoff retry step.
- **Uses `grep -qxF` for literal string matching**: The previous `grep -q "^${rel_path}$"` treated `[` and `]` as regex character classes, causing paths like `src/app/[host]/[domain]/...` to never match. Now uses `-F` (fixed string) and `-x` (exact line match) for correct literal matching.
- **URL-decodes paths before git ls-tree verification**: GitHub URLs encode special characters like `[` and `]` as `%5B` and `%5D`. The local verification now decodes these before checking.
- **Wires up lychee.toml config to non-GitHub lychee run**: The config file with exclusions was created but not actually used. Now `--config lychee.toml` is passed.
- **Deduplicates error files**: Same URL appearing on multiple pages would show up multiple times. Now `sort -u` is applied.
- **Excludes `your-org` placeholder URLs from local verification**: Both HTTP checking AND local verification now skip `github.com/your-org/...` documentation example URLs.

## Review & Testing Checklist for Human

- [ ] **403 handling**: Confirm 403 URLs are NOT in the retry step (`grep '\[429\]'` only, not `grep -E '\[403\]|\[429\]'`) but ARE excluded from broken links via `FAILURE_PATTERN`
- [ ] **grep -qxF literal matching**: Verify that paths with `[` and `]` (like `src/app/[host]/[domain]/...`) are now correctly verified instead of being marked as MISSING
- [ ] **FAILURE_PATTERN regex**: Verify `\[400\]|\[401\]|\[402\]|\[40[4-9]\]|...` correctly excludes 403 but includes 400-402 and 404-409
- [ ] **URL decoding logic**: Verify `python3 -c "import sys, urllib.parse; print(urllib.parse.unquote(sys.argv[1]))"` correctly decodes `%5Bhost%5D` → `[host]`

**Recommended test plan**: Trigger the workflow manually via `workflow_dispatch` and verify:
1. No 503 errors from GitHub (the main goal)
2. URLs with `[` and `]` in paths (like the fern-platform route.ts file) are verified correctly - should NOT appear in LOCAL_MISSING
3. npmjs.com and simpleicons.org URLs do NOT appear in the broken links section (excluded via FAILURE_PATTERN)
4. `github.com/your-org/...` URLs do NOT appear in any error output
5. No duplicate URLs in the error report

### Notes
- This cannot be fully tested locally since it's a GitHub Actions workflow
- The "Check links" workflow only runs on schedule (M/W/F) or via workflow_dispatch, not on PR pushes
- Python3 is assumed to be available on the GitHub Actions runner (standard for ubuntu-latest)
- Recent CI failure was due to lychee binary download issue (exit code 22), not code changes - the local verification step completed successfully

Link to Devin run: https://app.devin.ai/sessions/ae05565e070a4f65b35d074823e99f93
Requested by: David Konigsberg (@davidkonigsberg)