### PR TITLE
chore: fix fern docs dev warnings

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -22,7 +22,6 @@ products:
   - display-name: Home
     path: ./products/home/home.yml
     image: ./images/product-switcher/product-switcher-home-light.png
-    slug: 
     subtitle: Products that elevate your developer experience 
   
   - display-name: SDKs

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -377,8 +377,6 @@ navigation:
         contents: []
       - sources:
           hidden: true
-      - upstash:
-          hidden: true
       - website:
           hidden: true
     # must be included to use the schema component


### PR DESCRIPTION
original warnings:
`Failed to locate API section upstash. Did you mean sdks?`
`docs.yml contained null/undefined sections that were ignored: products.0.slug`
       