### PR TITLE
Add all availability tags to pages and API routes for smoke testing

### DIFF
--- a/fern/products/api-def/api-def.yml
+++ b/fern/products/api-def/api-def.yml
@@ -1,15 +1,19 @@
 navigation:
   - section: Overview
+    availability: stable
     contents:
       - page: What is an API definition?
         path: ./pages/what-is-an-api-definition.mdx       
       - page: Project structure
         path: ./pages/project-structure.mdx
+        availability: generally-available
       - page: Overrides
         path: ./pages/overrides.mdx
+        availability: beta
   - section: OpenAPI
     collapsed: true
     slug: openapi
+    availability: generally-available
     contents:
       - page: Overview
         path: ./openapi-pages/overview.mdx
@@ -85,6 +89,7 @@ navigation:
   - section: AsyncAPI
     collapsed: true
     slug: asyncapi
+    availability: pre-release
     contents:
       - page: Overview
         path: ./asyncapi-pages/overview.mdx
@@ -135,6 +140,7 @@ navigation:
   - section: OpenRPC
     collapsed: true
     slug: openrpc
+    availability: deprecated
     contents:
       - page: Overview
         path: ./openrpc-pages/overview.mdx
@@ -194,6 +200,7 @@ navigation:
   - section: gRPC
     collapsed: true
     slug: grpc
+    availability: in-development
     contents:
       - page: Overview
         path: ./grpc-pages/overview.mdx

--- a/fern/products/ask-fern/ask-fern.yml
+++ b/fern/products/ask-fern/ask-fern.yml
@@ -1,28 +1,35 @@
 navigation:
   - section: Getting started
+    availability: stable
     contents:
       - page: What is Ask Fern?
         path: ./pages/getting-started/what-is-ask-fern.mdx
       - page: How it works
         path: ./pages/getting-started/how-it-works.mdx
+        availability: generally-available
       - link: Customer showcase
         href: https://buildwithfern.com/showcase#ask-fern-customers
   - section: Configuration
+    availability: beta
     contents:
       - page: Setup
         path: ./pages/configuration/setup.mdx
         slug: setup
       - page: Guidance
         path: ./pages/features/guidance.mdx
+        availability: in-development
       - page: Additional content sources
         path: ./pages/features/content-sources.mdx
         slug: content-sources
+        availability: pre-release
   - section: Features
+    availability: generally-available
     contents:
       - page: Analytics
         path: ./pages/features/analytics.mdx
       - page: Citations
         path: ./pages/features/citations.mdx
+        availability: deprecated
       - page: Insights
         path: ./pages/features/insights.mdx
       - page: Evaluation
@@ -34,6 +41,7 @@ navigation:
   - api: API reference
     api-name: fai
     paginated: true
+    availability: stable
     audiences:
       - customers
     layout:

--- a/fern/products/cli-api-reference/cli-api-reference.yml
+++ b/fern/products/cli-api-reference/cli-api-reference.yml
@@ -1,5 +1,6 @@
 navigation:
   - section: CLI reference
+    availability: stable
     contents:
       - page: Get started with Fern CLI
         path: ./pages/cli-get-started.mdx
@@ -7,6 +8,8 @@ navigation:
       - page: Global options
         path: ./pages/global-options.mdx
         slug: options
+        availability: generally-available
       - page: Commands
         path: ./pages/commands.mdx
+        availability: beta
       - changelog: ./cli-changelog

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -1,10 +1,12 @@
 navigation:
   - section: Getting started
+    availability: stable
     contents:
       - page: Overview
         path: ./pages/getting-started/overview.mdx
       - page: How it works
         path: ./pages/getting-started/how-it-works.mdx
+        availability: generally-available
       - page: Quickstart
         path: ./pages/getting-started/quickstart.mdx
       - page: Project structure
@@ -14,6 +16,7 @@ navigation:
   - changelog: ./pages/changelog
     icon: fa-regular fa-clock-rotate-left
   - section: Configuration
+    availability: generally-available
     contents:
       - page: Site-level settings
         path: ./pages/customization/site-level-settings.mdx
@@ -22,16 +25,20 @@ navigation:
       - page: Tabs and tab variants
         path: ./pages/navigation/tabs.mdx
         slug: tabs
+        availability: beta
       - page: Versions
         path: ./pages/navigation/versions.mdx
       - page: Products
         path: ./pages/navigation/products.mdx
+        availability: deprecated
       - page: Changelog pages
         path: ./pages/navigation/changelogs.mdx
         slug: changelogs
       - page: Page-level settings
         path: ./pages/customization/frontmatter.mdx
+        availability: in-development
   - section: Writing content
+    availability: pre-release
     contents:
       - page: Markdown basics
         path: ./pages/component-library/writing-content/markdown-basics.mdx
@@ -335,8 +342,10 @@ navigation:
     paginated: false
     api-name: mcp-tools
     slug: fern-api-reference
+    availability: stable
   - api: Scribe API
     api-name: fai
+    availability: beta
     audiences:
       - customers
     flattened: true
@@ -386,4 +395,5 @@ navigation:
     # must be included to use the schema component
   - api: API reference
     api-name: docs-yml
+    availability: generally-available
 

--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -1,11 +1,13 @@
 navigation:
   - section: Overview
+    availability: stable
     contents:
       - page: Introduction
         path: ./introduction.mdx
         slug: introduction
       - page: How it works
         path: ./how-it-works.mdx
+        availability: generally-available
       - page: Quickstart
         path: ./fern-folder.mdx
         slug: quickstart
@@ -15,18 +17,22 @@ navigation:
       - page: Adding custom code
         path: ./custom-code.mdx
         slug: custom-code
+        availability: beta
       - page: Capabilities
         path: ./capabilities.mdx
         slug: capabilities
       - page: Fern Autorelease
         path: ./autorelease.mdx
         slug: autorelease
+        availability: pre-release
       - link: Customer showcase
         href: https://buildwithfern.com/showcase
   - section: Generators
+    availability: generally-available
     contents:
       - section: TypeScript
         slug: typescript
+        availability: stable
         contents:
           - page: Quickstart
             path: ./overview/typescript/quickstart.mdx
@@ -55,6 +61,7 @@ navigation:
           - link: Customer showcase
             href: https://buildwithfern.com/showcase#sdk-customers.typescript
       - section: Python
+        availability: deprecated
         contents:
           - page: Quickstart
             path: ./overview/python/quickstart.mdx
@@ -80,6 +87,7 @@ navigation:
           - link: Customer showcase
             href: https://buildwithfern.com/showcase#sdk-customers.python
       - section: Go
+        availability: in-development
         contents:
           - page: Quickstart
             path: ./overview/go/quickstart.mdx


### PR DESCRIPTION
## Summary

Adds all 6 availability tag options to pages, sections, and API routes across multiple products to test how they render in the documentation. This is a smoke test to verify the visual rendering of availability badges.

**Availability tags added:**
- `stable`
- `generally-available`
- `beta`
- `pre-release`
- `in-development`
- `deprecated`

**Products updated:**
- Docs product (docs.yml) - pages, sections, and API routes
- SDKs product (sdks.yml) - sections and pages
- Ask Fern product (ask-fern.yml) - sections, pages, and API reference
- CLI Reference product (cli-api-reference.yml) - section and pages
- API Definitions product (api-def.yml) - sections and pages

## Review & Testing Checklist for Human

- [ ] Verify in the preview that all 6 availability tag types render correctly with appropriate visual styling
- [ ] Confirm this is intended for smoke testing only - some tags (e.g., "deprecated" on Python SDK, "in-development" on Go SDK) are placed for testing purposes, not accuracy
- [ ] Check that availability tags appear correctly on both pages and API routes in the sidebar navigation

**Recommended test plan:** Navigate through the preview site and check each product's navigation to see the availability badges rendering on sections, pages, and API routes.

### Notes

Link to Devin run: https://app.devin.ai/sessions/a2b95e61848242778ae9ba03cf36e9a0
Requested by: Sandeep Dinesh (@thesandlord)