### PR TITLE
docs: add build-time generation, --only-deps flag, and gRPC air-gapped guidance

### DIFF
--- a/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
@@ -47,9 +47,17 @@ In the directory containing your `fern/` folder, create a new `Dockerfile` with 
 FROM fernapi/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
+
+RUN fern-generate
 ```
 
 Replace `<latest-tag>` with the actual tag used in the previous step.
+
+The `fern-generate` command processes your documentation at build time, which provides several advantages:
+
+- **Faster container startup**: Documentation is pre-generated, so the container starts quickly
+- **Air-gapped runtime**: No network access required when the container runs
+- **Smaller attack surface**: The running container doesn't need to fetch external dependencies
 
 </Step>
 <Step title="Build Your Custom Docker Image">
@@ -93,5 +101,103 @@ instances:
 You can now deploy the image to your own infrastructure, allowing you to host the documentation on your own domain.
 
 </Step>
-</Steps>  
+</Steps>
+
+## Runtime documentation generation
+
+By default, the `fern-generate` command processes your documentation at Docker build time. However, you can defer documentation generation to runtime using the `--only-deps` flag.
+
+### Using the `--only-deps` flag
+
+The `--only-deps` flag starts all required services (PostgreSQL, MinIO, FDR) at build time but skips the actual documentation generation:
+
+```dockerfile
+FROM fernapi/fern-self-hosted:<latest-tag>
+
+COPY fern/ /fern/
+
+RUN fern-generate --only-deps
+```
+
+When the container starts, it will automatically detect that documentation hasn't been generated and run `fern generate --docs` at runtime.
+
+### When to use runtime generation
+
+Runtime generation is useful when:
+
+- **Dynamic configuration**: You want to pass documentation configuration (like environment variables or secrets) at runtime rather than baking them into the image
+- **Faster builds**: You want to reduce Docker build time during development
+- **Shared base images**: You want to build a single image that can serve different documentation configurations
+
+<Warning>
+Runtime generation requires network access when the container starts. If you're deploying to an air-gapped environment, use the default build-time generation instead.
+</Warning>
+
+## gRPC APIs and air-gapped environments
+
+If your API uses gRPC/Protocol Buffers with dependencies from the [Buf Schema Registry](https://buf.build) (BSR), special consideration is needed for air-gapped deployments.
+
+### Understanding the challenge
+
+When Fern generates documentation for gRPC APIs, it uses the `buf` CLI to resolve protobuf dependencies. By default, `buf` fetches modules from `buf.build` at generation time. In air-gapped environments where external network access is blocked, this will fail.
+
+### Solution 1: Build-time generation (recommended)
+
+The simplest solution is to run `fern-generate` at build time when network access is available:
+
+```dockerfile
+FROM fernapi/fern-self-hosted:<latest-tag>
+
+COPY fern/ /fern/
+
+RUN fern-generate
+```
+
+This approach downloads all BSR dependencies during the Docker build (when network access is typically available) and bakes the generated documentation into the image. At runtime, no network access is required.
+
+### Solution 2: Vendor buf dependencies
+
+If you need runtime generation in an air-gapped environment, you can vendor your buf dependencies locally in your repository. This eliminates the need for network access entirely.
+
+Add a step in your Dockerfile to export buf dependencies before copying your fern folder:
+
+```dockerfile
+FROM fernapi/fern-self-hosted:<latest-tag>
+
+COPY fern/ /fern/
+
+# Export buf dependencies to vendor them locally
+RUN cd /fern && buf export . --output ./vendor
+
+RUN fern-generate --only-deps
+```
+
+Then update your `buf.yaml` to reference the vendored dependencies instead of BSR modules:
+
+```yaml
+# Before (requires network access)
+deps:
+  - buf.build/googleapis/googleapis
+
+# After (uses local vendored files)
+deps:
+  - ./vendor/googleapis
+```
+
+<Info>
+For more information on vendoring buf dependencies, see the [Buf documentation on dependency management](https://buf.build/docs/bsr/module/dependency-management).
+</Info>
+
+### Checking for BSR dependencies
+
+To determine if your project uses BSR dependencies, check your `buf.yaml` file for a `deps` section:
+
+```yaml
+version: v2
+deps:
+  - buf.build/googleapis/googleapis
+  - buf.build/grpc-ecosystem/grpc-gateway
+```
+
+If your `buf.yaml` has no `deps` section or only references local paths, your project doesn't require BSR access and will work in air-gapped environments without additional configuration.      
 

--- a/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
@@ -12,6 +12,8 @@ Before setting up self-hosted documentation, ensure you have:
 - Access to your Fern project's `fern/` directory
 - A Docker Hub account (for accessing the private image)
 
+## Setup instructions
+
 <Steps>
 <Step title="Request Access to the Docker Image">
 
@@ -53,11 +55,7 @@ RUN fern-generate
 
 Replace `<latest-tag>` with the actual tag used in the previous step.
 
-The `fern-generate` command processes your documentation at build time, which provides several advantages:
-
-- **Faster container startup**: Documentation is pre-generated, so the container starts quickly
-- **Air-gapped runtime**: No network access required when the container runs
-- **Smaller attack surface**: The running container doesn't need to fetch external dependencies
+`fern-generate` processes your documentation at build time, enabling faster container startup, air-gapped deployment, and a smaller attack surface.
 
 </Step>
 <Step title="Build Your Custom Docker Image">
@@ -103,13 +101,18 @@ You can now deploy the image to your own infrastructure, allowing you to host th
 </Step>
 </Steps>
 
-## Runtime documentation generation
+## Additional configuration
 
-By default, the `fern-generate` command processes your documentation at Docker build time. However, you can defer documentation generation to runtime using the `--only-deps` flag.
+The following sections cover optional configurations for specific deployment scenarios.
 
-### Using the `--only-deps` flag
+### Runtime generation
 
-The `--only-deps` flag starts all required services (PostgreSQL, MinIO, FDR) at build time but skips the actual documentation generation:
+By default, `fern-generate` runs at Docker build time. Defer generation to runtime if you need to:
+- Pass configuration (environment variables, secrets) at runtime
+- Speed up Docker builds during development
+- Share a single image across multiple documentation configurations
+
+Use the `--only-deps` flag to defer generation to runtime:
 
 ```dockerfile
 FROM fernapi/fern-self-hosted:<latest-tag>
@@ -119,31 +122,37 @@ COPY fern/ /fern/
 RUN fern-generate --only-deps
 ```
 
-When the container starts, it will automatically detect that documentation hasn't been generated and run `fern generate --docs` at runtime.
-
-### When to use runtime generation
-
-Runtime generation is useful when:
-
-- **Dynamic configuration**: You want to pass documentation configuration (like environment variables or secrets) at runtime rather than baking them into the image
-- **Faster builds**: You want to reduce Docker build time during development
-- **Shared base images**: You want to build a single image that can serve different documentation configurations
+This starts required services (PostgreSQL, MinIO, FDR) at build time but skips documentation generation. When the container starts, it automatically runs `fern generate --docs`.
 
 <Warning>
-Runtime generation requires network access when the container starts. If you're deploying to an air-gapped environment, use the default build-time generation instead.
+Runtime generation requires network access at container startup. For air-gapped deployments, use the default build-time generation.
 </Warning>
 
-## gRPC APIs and air-gapped environments
+### Air-gapped deployments with gRPC
 
-If your API uses gRPC/Protocol Buffers with dependencies from the [Buf Schema Registry](https://buf.build) (BSR), special consideration is needed for air-gapped deployments.
+If your API uses gRPC with dependencies from the [Buf Schema Registry](https://buf.build) (BSR), the `buf` CLI fetches modules from `buf.build` during generation. This fails in air-gapped environments without network access.
 
-### Understanding the challenge
+<Steps>
+<Step title="Check for BSR dependencies">
 
-When Fern generates documentation for gRPC APIs, it uses the `buf` CLI to resolve protobuf dependencies. By default, `buf` fetches modules from `buf.build` at generation time. In air-gapped environments where external network access is blocked, this will fail.
+Look for a `deps` section in your `buf.yaml` file:
 
-### Solution 1: Build-time generation (recommended)
+```yaml
+version: v2
+deps:
+  - buf.build/googleapis/googleapis
+  - buf.build/grpc-ecosystem/grpc-gateway
+```
 
-The simplest solution is to run `fern-generate` at build time when network access is available:
+If there's no `deps` section or only local paths, you can skip the rest of this section.
+
+</Step>
+<Step title="Choose a solution">
+
+<AccordionGroup>
+<Accordion title="Option 1: Build-time generation (recommended)" defaultOpen>
+
+Run `fern-generate` at build time when network access is available:
 
 ```dockerfile
 FROM fernapi/fern-self-hosted:<latest-tag>
@@ -153,51 +162,39 @@ COPY fern/ /fern/
 RUN fern-generate
 ```
 
-This approach downloads all BSR dependencies during the Docker build (when network access is typically available) and bakes the generated documentation into the image. At runtime, no network access is required.
+This downloads BSR dependencies during the Docker build and bakes them into the image. No network access required at runtime.
+</Accordion>
+<Accordion title="Option 2: Vendor dependencies for runtime generation">
 
-### Solution 2: Vendor buf dependencies
-
-If you need runtime generation in an air-gapped environment, you can vendor your buf dependencies locally in your repository. This eliminates the need for network access entirely.
-
-Add a step in your Dockerfile to export buf dependencies before copying your fern folder:
+To generate at runtime in an air-gapped environment, vendor buf dependencies locally:
 
 ```dockerfile
 FROM fernapi/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 
-# Export buf dependencies to vendor them locally
 RUN cd /fern && buf export . --output ./vendor
 
 RUN fern-generate --only-deps
 ```
 
-Then update your `buf.yaml` to reference the vendored dependencies instead of BSR modules:
+Update `buf.yaml` to reference vendored dependencies:
 
 ```yaml
-# Before (requires network access)
+# Before
 deps:
   - buf.build/googleapis/googleapis
 
-# After (uses local vendored files)
+# After
 deps:
   - ./vendor/googleapis
 ```
 
 <Info>
-For more information on vendoring buf dependencies, see the [Buf documentation on dependency management](https://buf.build/docs/bsr/module/dependency-management).
+See the [Buf documentation on dependency management](https://buf.build/docs/bsr/module/dependency-management) for more details.
 </Info>
+</Accordion>
+</AccordionGroup>
 
-### Checking for BSR dependencies
-
-To determine if your project uses BSR dependencies, check your `buf.yaml` file for a `deps` section:
-
-```yaml
-version: v2
-deps:
-  - buf.build/googleapis/googleapis
-  - buf.build/grpc-ecosystem/grpc-gateway
-```
-
-If your `buf.yaml` has no `deps` section or only references local paths, your project doesn't require BSR access and will work in air-gapped environments without additional configuration.      
-
+</Step>
+</Steps>

--- a/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
@@ -55,7 +55,9 @@ RUN fern-generate
 
 Replace `<latest-tag>` with the actual tag used in the previous step.
 
-`fern-generate` processes your documentation at build time, enabling faster container startup, air-gapped deployment, and a smaller attack surface.
+<Info>
+  `fern-generate` processes your documentation at build time, enabling faster container startup, air-gapped deployment, and a smaller attack surface. You can alternatively [defer generation to runtime](#runtime-generation).
+  </Info>
 
 </Step>
 <Step title="Build Your Custom Docker Image">


### PR DESCRIPTION
# docs: add self-hosted build options and gRPC air-gapped guidance

## Summary

Updates the self-hosted documentation to explain the different documentation generation options and provide guidance for gRPC APIs in air-gapped environments.

Key additions:
- **Default behavior**: Added `RUN fern-generate` to the Dockerfile example and explained its advantages (faster startup, air-gapped runtime, smaller attack surface)
- **`--only-deps` flag**: Documents the new flag that starts services at build time but defers docs generation to runtime, useful for dynamic configuration or faster builds
- **gRPC/air-gapped section**: Explains the challenge with BSR dependencies and provides two solutions:
  1. Build-time generation (recommended) - downloads deps during build when network is available
  2. Vendoring buf dependencies - for runtime generation in air-gapped environments

## Review & Testing Checklist for Human

- [ ] **Verify `--only-deps` flag exists**: This documents a feature from PR fern-platform#6097 - confirm that PR is merged or will be merged before this docs PR
- [ ] **Test buf vendoring workflow**: The Solution 2 instructions (`buf export . --output ./vendor` and updating `buf.yaml`) should be validated with an actual gRPC project
- [ ] **Check Buf documentation link**: Verify https://buf.build/docs/bsr/module/dependency-management is a valid URL
- [ ] **Review Dockerfile syntax**: Ensure all Dockerfile examples are syntactically correct

**Recommended test plan**: Follow the documented steps with a real self-hosted deployment to verify the instructions work end-to-end, particularly the `--only-deps` flag behavior.

### Notes

- This PR accompanies fern-platform#6097 which implements the `--only-deps` flag
- Requested by: Sandeep Dinesh (@thesandlord)
- Devin session: https://app.devin.ai/sessions/e46cfc8376e14f1792acc170603ecb7b