### PR TITLE
docs: add self-hosted setup page to navigation and link from overview

### DIFF
--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -281,7 +281,6 @@ navigation:
       - page: Set up self-hosted documentation
         path: ./pages/enterprise/self-hosted-set-up.mdx
         slug: set-up
-        hidden: true
       - page: Health check endpoints
         path: ./pages/enterprise/health-check-endpoints.mdx
   - section: Analytics & integrations

--- a/fern/products/docs/pages/enterprise/self-hosted.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted.mdx
@@ -29,7 +29,7 @@ However, features requiring external connections aren't supported, including [As
 
 ## Setup process
 
-Fern provides your documentation site as a ready-to-run Docker container that you can deploy on your own infrastructure. For detailed instructions, see [Set up self-hosted documentation](./self-hosted-set-up).
+Fern provides your documentation site as a ready-to-run Docker container that you can deploy on your own infrastructure. For detailed instructions, see [Set up self-hosted documentation](/learn/docs/self-hosted/set-up).
 
 1. **Download the Docker image** - Fern provides the location of the most up-to-date Docker image containing the documentation frontend
 1. **Upload your fern folder** - Add your documentation source files to the container

--- a/fern/products/docs/pages/enterprise/self-hosted.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted.mdx
@@ -29,7 +29,7 @@ However, features requiring external connections aren't supported, including [As
 
 ## Setup process
 
-Fern provides your documentation site as a ready-to-run Docker container that you can deploy on your own infrastructure.
+Fern provides your documentation site as a ready-to-run Docker container that you can deploy on your own infrastructure. For detailed instructions, see [Set up self-hosted documentation](./self-hosted-set-up).
 
 1. **Download the Docker image** - Fern provides the location of the most up-to-date Docker image containing the documentation frontend
 1. **Upload your fern folder** - Add your documentation source files to the container


### PR DESCRIPTION
## Summary

Makes the self-hosted setup documentation page visible in the navigation and adds a link to it from the overview page. This follows up on PR #2930 which added the setup content but left the page hidden.

Changes:
- Removed `hidden: true` from the "Set up self-hosted documentation" page in `docs.yml`
- Added a link to the setup page from the "Setup process" section in the self-hosted overview page

## Review & Testing Checklist for Human

- [ ] Verify the setup page appears in the Self-hosted section of the navigation sidebar
- [ ] Verify the link in the overview page works and navigates to the setup page

**Recommended test plan**: Use the preview deployment to navigate to the Self-hosted section and confirm both the navigation entry and the inline link work correctly.

### Notes

- Tested locally: Navigation sidebar shows the setup page, and the inline link navigates correctly
- Requested by: Sandeep Dinesh (@thesandlord)
- Devin session: https://app.devin.ai/sessions/9b543131c5a44066a8d51a418819d524