### PR TITLE
update Rust SDK configuration documentation

### DIFF
--- a/fern/products/sdks/overview/rust/configuration.mdx
+++ b/fern/products/sdks/overview/rust/configuration.mdx
@@ -36,11 +36,27 @@ The name of the generated environment enum. This allows you to customize the enu
 </ParamField>
 
 <ParamField path="enableWireTests" type="boolean" default="false" required={false} toc={true}>
-When enabled, generates [mock server (wire) tests](/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends the correct HTTP requests and correctly handles responses per the API spec.
+When enabled, generates [mock server (wire) tests](/learn/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends the correct HTTP requests and correctly handles responses per the API spec.
 </ParamField>
 
 <ParamField path="generateExamples" type="boolean" default="true" required={false} toc={true}>
 When enabled, generates code examples in the README and reference documentation.
+</ParamField>
+
+### DateTime configuration
+
+Configure how datetime values are handled in the generated SDK:
+
+```yaml title="generators.yml"
+config:
+  dateTimeType: "utc"
+```
+
+<ParamField path="dateTimeType" type="'offset' | 'utc'" default="offset" required={false} toc={true}>
+The DateTime type to use for datetime primitives:
+
+- `offset`: Uses `DateTime<FixedOffset>` which preserves the original timezone from the API response. Accepts any datetime format and assumes UTC when no timezone is specified.
+- `utc`: Uses `DateTime<Utc>` which converts all datetimes to UTC. Accepts any datetime format and assumes UTC when no timezone is specified.
 </ParamField>
 
 ### Package metadata
@@ -85,9 +101,65 @@ config:
 ```
 
 <ParamField path="extraDependencies" type="object" required={false} toc={true}>
-Additional dependencies to include in the generated `Cargo.toml`. Specify as a map of crate names to version requirements.
+Additional dependencies to include in the generated `Cargo.toml`. Specify as a map of crate names to version requirements. You can also specify full dependency specifications with features, git sources, and more:
+
+```yaml title="generators.yml"
+config:
+  extraDependencies:
+    tokio: "1.0"
+    my-crate:
+      version: "1.0"
+      features:
+        - "feature-a"
+        - "feature-b"
+      optional: true
+```
 </ParamField>
 
 <ParamField path="extraDevDependencies" type="object" required={false} toc={true}>
 Additional dev dependencies to include in the generated `Cargo.toml`. These are only used during development and testing.
+</ParamField>
+
+### Cargo features
+
+Configure custom Cargo features for your generated SDK:
+
+```yaml title="generators.yml"
+config:
+  features:
+    experimental:
+      - "dep-a"
+      - "dep-b"
+    advanced:
+      - "sse"
+  defaultFeatures:
+    - "sse"
+```
+
+<ParamField path="features" type="object" required={false} toc={true}>
+Custom Cargo features to add to the generated crate. Maps feature names to lists of dependencies or other features they enable. This allows users to opt-in to specific functionality.
+</ParamField>
+
+<ParamField path="defaultFeatures" type="array of strings" required={false} toc={true}>
+Override which features are included in the default feature set. By default, the generator automatically detects and enables features based on your API (such as `multipart` for file uploads and `sse` for streaming endpoints). Use this option to customize the default features.
+</ParamField>
+
+### README customization
+
+Add custom sections to the generated README:
+
+```yaml title="generators.yml"
+config:
+  customReadmeSections:
+    - title: "Rate limiting"
+      content: |
+        This API implements rate limiting. Please refer to the
+        [rate limiting documentation](https://docs.example.com/rate-limits)
+        for more information.
+    - title: "Support"
+      content: "For support, please contact support@example.com"
+```
+
+<ParamField path="customReadmeSections" type="array of objects" required={false} toc={true}>
+Additional sections to include in the generated README file. Each section requires a `title` and `content` field. The content supports Markdown formatting.
 </ParamField>

--- a/fern/products/sdks/overview/rust/configuration.mdx
+++ b/fern/products/sdks/overview/rust/configuration.mdx
@@ -5,7 +5,7 @@ description: Configuration options for the Fern Rust SDK.
 
 You can customize the behavior of the Rust SDK generator in `generators.yml`:
 
-```yaml {6-14} title="generators.yml"
+```yaml {6-15} title="generators.yml"
 groups:
   rust-sdk:
     generators:
@@ -15,6 +15,7 @@ groups:
           clientClassName: YourClientName
           crateName: your-crate-name
           crateVersion: "1.0.0"
+          dateTimeType: "offset"
           environmentEnumName: YourEnvironment
           enableWireTests: true
 ```
@@ -31,6 +32,15 @@ The name of the generated Rust crate. This is used in `Cargo.toml` and determine
 The version of the generated crate. This is used in `Cargo.toml` for publishing to crates.io.
 </ParamField>
 
+<ParamField path="dateTimeType" type="'offset' | 'utc'" default="offset" required={false} toc={true}>
+Determines how timezone information is handled:
+
+- `offset`: Uses `DateTime<FixedOffset>` to preserve the original timezone from API responses
+- `utc`: Uses `DateTime<Utc>` to normalize all datetimes to UTC regardless of their original timezone
+
+Both options accept any datetime format and assume UTC if no timezone is provided in the datetime string.
+</ParamField>
+
 <ParamField path="environmentEnumName" type="string" required={false} toc={true}>
 The name of the generated environment enum. This allows you to customize the enum name that defines your API environments (such as production, staging, development).
 </ParamField>
@@ -41,22 +51,6 @@ When enabled, generates [mock server (wire) tests](/learn/sdks/deep-dives/testin
 
 <ParamField path="generateExamples" type="boolean" default="true" required={false} toc={true}>
 When enabled, generates code examples in the README and reference documentation.
-</ParamField>
-
-### Datetime configuration
-
-Configure how datetime values are handled in the generated SDK:
-
-```yaml title="generators.yml"
-config:
-  dateTimeType: "utc"
-```
-
-<ParamField path="dateTimeType" type="'offset' | 'utc'" default="offset" required={false} toc={true}>
-The DateTime type to use for datetime primitives:
-
-- `offset`: Uses `DateTime<FixedOffset>` which preserves the original timezone from the API response. Accepts any datetime format and assumes Coordinated Universal Time (UTC) when no timezone is specified.
-- `utc`: Uses `DateTime<Utc>` which converts all datetimes to UTC. Accepts any datetime format and assumes UTC when no timezone is specified.
 </ParamField>
 
 ### Package metadata

--- a/fern/products/sdks/overview/rust/configuration.mdx
+++ b/fern/products/sdks/overview/rust/configuration.mdx
@@ -43,7 +43,7 @@ When enabled, generates [mock server (wire) tests](/learn/sdks/deep-dives/testin
 When enabled, generates code examples in the README and reference documentation.
 </ParamField>
 
-### DateTime configuration
+### Datetime configuration
 
 Configure how datetime values are handled in the generated SDK:
 
@@ -55,7 +55,7 @@ config:
 <ParamField path="dateTimeType" type="'offset' | 'utc'" default="offset" required={false} toc={true}>
 The DateTime type to use for datetime primitives:
 
-- `offset`: Uses `DateTime<FixedOffset>` which preserves the original timezone from the API response. Accepts any datetime format and assumes UTC when no timezone is specified.
+- `offset`: Uses `DateTime<FixedOffset>` which preserves the original timezone from the API response. Accepts any datetime format and assumes Coordinated Universal Time (UTC) when no timezone is specified.
 - `utc`: Uses `DateTime<Utc>` which converts all datetimes to UTC. Accepts any datetime format and assumes UTC when no timezone is specified.
 </ParamField>
 

--- a/fern/products/sdks/overview/rust/configuration.mdx
+++ b/fern/products/sdks/overview/rust/configuration.mdx
@@ -101,65 +101,25 @@ config:
 ```
 
 <ParamField path="extraDependencies" type="object" required={false} toc={true}>
-Additional dependencies to include in the generated `Cargo.toml`. Specify as a map of crate names to version requirements. You can also specify full dependency specifications with features, git sources, and more:
+Additional dependencies to include in the generated `Cargo.toml`. Specify as a map of crate names to version requirements. You can also specify full dependency specifications with features and default features:
 
 ```yaml title="generators.yml"
 config:
   extraDependencies:
-    tokio: "1.0"
-    my-crate:
-      version: "1.0"
-      features:
-        - "feature-a"
-        - "feature-b"
-      optional: true
+    reqwest:
+      version: "0.12"
+      defaultFeatures: true
+```
+
+```yaml title="generators.yml"
+config:
+  extraDependencies:
+    reqwest:
+      version: "0.12"
+      features: ["rustls-tls"]
 ```
 </ParamField>
 
 <ParamField path="extraDevDependencies" type="object" required={false} toc={true}>
 Additional dev dependencies to include in the generated `Cargo.toml`. These are only used during development and testing.
-</ParamField>
-
-### Cargo features
-
-Configure custom Cargo features for your generated SDK:
-
-```yaml title="generators.yml"
-config:
-  features:
-    experimental:
-      - "dep-a"
-      - "dep-b"
-    advanced:
-      - "sse"
-  defaultFeatures:
-    - "sse"
-```
-
-<ParamField path="features" type="object" required={false} toc={true}>
-Custom Cargo features to add to the generated crate. Maps feature names to lists of dependencies or other features they enable. This allows users to opt-in to specific functionality.
-</ParamField>
-
-<ParamField path="defaultFeatures" type="array of strings" required={false} toc={true}>
-Override which features are included in the default feature set. By default, the generator automatically detects and enables features based on your API (such as `multipart` for file uploads and `sse` for streaming endpoints). Use this option to customize the default features.
-</ParamField>
-
-### README customization
-
-Add custom sections to the generated README:
-
-```yaml title="generators.yml"
-config:
-  customReadmeSections:
-    - title: "Rate limiting"
-      content: |
-        This API implements rate limiting. Please refer to the
-        [rate limiting documentation](https://docs.example.com/rate-limits)
-        for more information.
-    - title: "Support"
-      content: "For support, please contact support@example.com"
-```
-
-<ParamField path="customReadmeSections" type="array of objects" required={false} toc={true}>
-Additional sections to include in the generated README file. Each section requires a `title` and `content` field. The content supports Markdown formatting.
 </ParamField>


### PR DESCRIPTION
## Summary

Updates the Rust SDK configuration documentation to add missing configuration options and improve existing documentation.

**New documented options:**
- `dateTimeType`: Configure DateTime handling (`offset` vs `utc`)

**Other changes:**
- Enhanced `extraDependencies` documentation with examples showing `defaultFeatures` and `features` array syntax using `reqwest`
- Fixed broken link to testing documentation (`/sdks/...` → `/learn/sdks/...`)

### Updates since last revision
- Fixed Vale style suggestions: changed heading to sentence case ("Datetime configuration") and defined UTC acronym on first use
- Updated `extraDependencies` examples to use `reqwest` with `defaultFeatures: true` and `features: ["rustls-tls"]` syntax per user feedback
- Removed Cargo features and README customization sections per user request

## Review & Testing Checklist for Human

- [ ] Verify the `dateTimeType` option (`offset` vs `utc`) matches the actual generator behavior in `generators/rust/codegen/src/custom-config/BaseRustConfigSchema.ts`
- [ ] Confirm the `extraDependencies` YAML syntax (especially `defaultFeatures` casing) matches what the generator actually accepts
- [ ] Verify the link `/learn/sdks/deep-dives/testing#mock-server-tests` resolves correctly in the preview deployment

**Recommended test plan:** Open the preview deployment and navigate to the Rust configuration page. Verify the datetime and dependencies sections render correctly with the new examples.

### Notes

Requested by @iamnamananand996

[Link to Devin run](https://app.devin.ai/sessions/3aa345da4cc345abbacd2fec5f3be0ae)