### PR TITLE
docs: improve tag display names documentation with complete example

### DIFF
--- a/fern/products/api-def/openapi-pages/extensions/tag-display-name.mdx
+++ b/fern/products/api-def/openapi-pages/extensions/tag-display-name.mdx
@@ -6,16 +6,42 @@ description: Customize how tag names appear in your API Reference using the `x-d
 
 By default, tag names from your OpenAPI specification become section names in your API Reference. Use the `x-displayName` extension to control how these section names display in your generated documentation. This is helpful for controlling capitalization and creating user-friendly names. 
 
-You can set display names directly in your spec or in an overrides file.
+Define tags with display names at the root level of your OpenAPI specification, then reference them by name in your operations:
 
 ```yaml title="openapi.yml"
+openapi: 3.0.0
+info:
+  title: Plant Care API
+  version: 1.0.0
+
 tags:
-  - name: task
-    x-displayName: Tasks
-  - name: billing-and-payments
-    x-displayName: Billing and Payments
+  - name: plant
+    x-displayName: Plants
+    description: Operations for managing plants
+  - name: watering-schedule
+    x-displayName: Watering Schedules
+    description: Handle watering schedule operations
+
+paths:
+  /plants:
+    get:
+      tags:
+        - plant
+      summary: List all plants
+  /plants/{plantId}:
+    get:
+      tags:
+        - plant
+      summary: Get a plant by ID
+  /watering-schedules:
+    get:
+      tags:
+        - watering-schedule
+      summary: List watering schedules
 ```
 
+You can also set display names in an [overrides file](/learn/api-definitions/openapi/overrides).
+
 <Note>
-  Alternatively, you can rename sections directly in your [`docs.yml` file](/docs/api-references/customize-api-reference-layout).
+  Alternatively, you can rename sections directly in your [`docs.yml` file](/learn/docs/api-references/customize-api-reference-layout).
 </Note>


### PR DESCRIPTION
## Summary

Improves the tag display names documentation to prevent customer confusion about where `x-displayName` should be placed in OpenAPI specs. A customer incorrectly placed `name` and `x-displayName` inside an operation's `tags` array instead of at the root level, causing a CLI error.

The previous documentation showed only a snippet without context. This PR adds a complete OpenAPI spec example that clearly demonstrates:
- Tags with `x-displayName` are defined at the **root level** of the spec
- Operations reference tags by name only (as strings, not objects)

Also fixes the link path from `/docs/api-references/...` to `/learn/docs/api-references/...`.

## Review & Testing Checklist for Human

- [ ] Verify the two links work correctly in the preview:
  - `/learn/api-definitions/openapi/overrides`
  - `/learn/docs/api-references/customize-api-reference-layout`
- [ ] Confirm the example is clear enough to prevent the original confusion
- [ ] Check the page renders correctly in the preview deployment

### Notes

Requested by: @thesandlord (Sandeep Dinesh)
Devin session: https://app.devin.ai/sessions/534d266e5c6d47eb8fa6b3385e1c9b78