### PR TITLE
docs(python): add positional_single_property_constructors config option

### DIFF
--- a/fern/products/sdks/overview/python/configuration.mdx
+++ b/fern/products/sdks/overview/python/configuration.mdx
@@ -228,6 +228,7 @@ config:
     include_union_utils: false
     include_validators: true
     orm_mode: false
+    positional_single_property_constructors: false
     require_optional_fields: false
     skip_formatting: false
     skip_validation: true
@@ -286,6 +287,22 @@ config:
 
 <ParamField path="orm_mode" type="bool" default="false" toc={true}>
   Enable ORM mode for Pydantic models to work with ORMs like SQLAlchemy.
+</ParamField>
+
+<ParamField path="positional_single_property_constructors" type="bool" default="false" toc={true}>
+  When enabled, generates a custom `__init__` method for models with a single required field, allowing positional argument construction instead of requiring keyword arguments.
+
+  ```python
+  # Without positional_single_property_constructors (default)
+  wrapper = Wrapper(value="my_value")
+
+  # With positional_single_property_constructors enabled
+  wrapper = Wrapper("my_value")
+  ```
+
+  <Warning>
+  Enabling this option can cause backwards compatibility issues. If a model later adds another required field, the positional `__init__` will no longer be generated, causing runtime failures for existing code that uses positional arguments. Use keyword arguments for long-term stability.
+  </Warning>
 </ParamField>
 
 <ParamField path="package_name" type="string" required={false} toc={true}>


### PR DESCRIPTION
## Summary

Adds documentation for the new `pydantic_config.positional_single_property_constructors` option introduced in [fern-api/fern#11334](https://github.com/fern-api/fern/pull/11334). This option allows models with a single required field to be initialized with positional arguments instead of keyword arguments.

Changes:
- Added the option to the `pydantic_config` example YAML block
- Added a `ParamField` entry with description, code example, and backwards compatibility warning

## Review & Testing Checklist for Human

- [ ] Verify the documentation accurately describes the feature behavior (compare with PR #11334)
- [ ] Check that the backwards compatibility warning is clear and appropriately prominent
- [ ] Preview the page to ensure it renders correctly

### Notes

Link to Devin run: https://app.devin.ai/sessions/1aadc790e6dc418daf0329178441114b
Requested by: @aditya-arolkar-swe