### PR TITLE
docs: add EndpointSnippet component documentation

### DIFF
--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -90,6 +90,9 @@ navigation:
           - page: Endpoint schema snippet
             path: ./pages/component-library/default-components/endpoint-schema-snippet.mdx
             icon: fa-duotone fa-sitemap
+          - page: Endpoint snippet
+            path: ./pages/component-library/default-components/endpoint-snippet.mdx
+            icon: fa-duotone fa-terminal
           - page: Webhook payload snippet
             path: ./pages/component-library/default-components/webhook-payload-snippet.mdx
             icon: fa-duotone fa-webhook

--- a/fern/products/docs/pages/changelog/2026-01-15.mdx
+++ b/fern/products/docs/pages/changelog/2026-01-15.mdx
@@ -1,0 +1,17 @@
+## EndpointSnippet component
+
+The new `<EndpointSnippet>` component displays an API endpoint with its HTTP method, path, a code example, and an optional "Try it" button that links to your API reference.
+
+```jsx Markdown
+<EndpointSnippet 
+  method="GET" 
+  path="/v2/plants" 
+  code={`curl https://api.plantstore.dev/v2/plants \\
+  -H "Authorization: Bearer <token>"`}
+  href="/api-reference/plants/list"
+/>
+```
+
+This component is useful for highlighting specific API endpoints in your documentation with a quick code example and a link to the full API reference.
+
+Learn more about the [EndpointSnippet](/learn/docs/writing-content/components/endpoint-snippet) component.

--- a/fern/products/docs/pages/component-library/default-components/endpoint-snippet.mdx
+++ b/fern/products/docs/pages/component-library/default-components/endpoint-snippet.mdx
@@ -1,0 +1,149 @@
+---
+title: Endpoint snippet
+description: Learn how to use the EndpointSnippet component to display API endpoints with code examples and a "Try it" button.
+---
+
+Use the `<EndpointSnippet>` component to display an API endpoint with its HTTP method, path, a code example (typically a curl command), and an optional "Try it" button that links to your API reference.
+
+## Usage
+
+<div className="highlight-frame">
+<EndpointSnippet 
+  method="GET" 
+  path="/v2/plants" 
+  code={`curl https://api.plantstore.dev/v2/plants \\
+  -H "Authorization: Bearer <token>"`}
+  href="/api-reference/plants/list"
+/>
+</div>
+
+```jsx Markdown
+<EndpointSnippet 
+  method="GET" 
+  path="/v2/plants" 
+  code={`curl https://api.plantstore.dev/v2/plants \\
+  -H "Authorization: Bearer <token>"`}
+  href="/api-reference/plants/list"
+/>
+```
+
+## Variants
+
+### Without "Try it" button
+
+Omit the `href` prop to display the endpoint without a "Try it" button.
+
+<div className="highlight-frame">
+<EndpointSnippet 
+  method="POST" 
+  path="/v2/plants" 
+  code={`curl -X POST https://api.plantstore.dev/v2/plants \\
+  -H "Authorization: Bearer <token>" \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "Monstera", "species": "Monstera deliciosa"}'`}
+/>
+</div>
+
+```jsx Markdown
+<EndpointSnippet 
+  method="POST" 
+  path="/v2/plants" 
+  code={`curl -X POST https://api.plantstore.dev/v2/plants \\
+  -H "Authorization: Bearer <token>" \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "Monstera", "species": "Monstera deliciosa"}'`}
+/>
+```
+
+### Different HTTP methods
+
+The component supports all standard HTTP methods with color-coded badges.
+
+<div className="highlight-frame">
+<EndpointSnippet 
+  method="GET" 
+  path="/v2/plants/{plantId}" 
+  code={`curl https://api.plantstore.dev/v2/plants/123 \\
+  -H "Authorization: Bearer <token>"`}
+/>
+</div>
+
+<div className="highlight-frame">
+<EndpointSnippet 
+  method="PUT" 
+  path="/v2/plants/{plantId}" 
+  code={`curl -X PUT https://api.plantstore.dev/v2/plants/123 \\
+  -H "Authorization: Bearer <token>" \\
+  -H "Content-Type: application/json" \\
+  -d '{"name": "Updated Plant"}'`}
+/>
+</div>
+
+<div className="highlight-frame">
+<EndpointSnippet 
+  method="DELETE" 
+  path="/v2/plants/{plantId}" 
+  code={`curl -X DELETE https://api.plantstore.dev/v2/plants/123 \\
+  -H "Authorization: Bearer <token>"`}
+/>
+</div>
+
+### Custom language
+
+By default, the code snippet uses `bash` syntax highlighting. Use the `language` prop to specify a different language.
+
+<div className="highlight-frame">
+<EndpointSnippet 
+  method="GET" 
+  path="/v2/plants" 
+  language="python"
+  code={`import requests
+
+response = requests.get(
+    "https://api.plantstore.dev/v2/plants",
+    headers={"Authorization": "Bearer <token>"}
+)
+print(response.json())`}
+/>
+</div>
+
+```jsx Markdown
+<EndpointSnippet 
+  method="GET" 
+  path="/v2/plants" 
+  language="python"
+  code={`import requests
+
+response = requests.get(
+    "https://api.plantstore.dev/v2/plants",
+    headers={"Authorization": "Bearer <token>"}
+)
+print(response.json())`}
+/>
+```
+
+## Properties
+
+<ParamField path="method" type="string" required={true}>
+  The HTTP method for the endpoint. Supported values: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`, `CONNECT`, `TRACE`.
+</ParamField>
+
+<ParamField path="path" type="string" required={true}>
+  The endpoint path (e.g., `/v2/plants` or `/api/plants/{plantId}`).
+</ParamField>
+
+<ParamField path="code" type="string" required={true}>
+  The code snippet to display, typically a curl command or SDK example.
+</ParamField>
+
+<ParamField path="language" type="string" required={false}>
+  The programming language for syntax highlighting. Defaults to `bash`.
+</ParamField>
+
+<ParamField path="href" type="string" required={false}>
+  The URL to link to when clicking the "Try it" button. If not provided, the button is not displayed.
+</ParamField>
+
+<ParamField path="className" type="string" required={false}>
+  Optional CSS class name for custom styling.
+</ParamField>

--- a/fern/products/docs/pages/component-library/default-components/endpoint-snippet.mdx
+++ b/fern/products/docs/pages/component-library/default-components/endpoint-snippet.mdx
@@ -7,6 +7,20 @@ Use the `<EndpointSnippet>` component to display an API endpoint with its HTTP m
 
 ## Usage
 
+### Auto-populated from API definition
+
+The simplest way to use `EndpointSnippet` is with the `endpoint` parameter, which automatically populates the method, path, and code from your API definition:
+
+```jsx Markdown
+<EndpointSnippet endpoint="GET /plants" />
+```
+
+The component will look up the endpoint in your API definition and display the curl snippet from the first example.
+
+### Manual configuration
+
+You can also manually specify all properties:
+
 <div className="highlight-frame">
 <EndpointSnippet 
   method="GET" 
@@ -26,6 +40,19 @@ Use the `<EndpointSnippet>` component to display an API endpoint with its HTTP m
   href="/api-reference/plants/list"
 />
 ```
+
+### Hybrid: auto-populate with overrides
+
+When using the `endpoint` parameter, you can override any auto-populated value by explicitly providing it:
+
+```jsx Markdown
+<EndpointSnippet 
+  endpoint="GET /plants" 
+  code={`curl https://api.example.com/plants -H "X-Custom-Header: value"`}
+/>
+```
+
+In this example, the method and path come from the API definition, but the code snippet is overridden with a custom value.
 
 ## Variants
 
@@ -124,16 +151,20 @@ print(response.json())`}
 
 ## Properties
 
-<ParamField path="method" type="string" required={true}>
-  The HTTP method for the endpoint. Supported values: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`, `CONNECT`, `TRACE`.
+<ParamField path="endpoint" type="string" required={false}>
+  The endpoint locator (e.g., `GET /plants` or `POST /plants/{plantId}`). When provided, the component auto-populates `method`, `path`, and `code` from your API definition. Explicit props override auto-populated values.
 </ParamField>
 
-<ParamField path="path" type="string" required={true}>
-  The endpoint path (e.g., `/v2/plants` or `/api/plants/{plantId}`).
+<ParamField path="method" type="string" required={false}>
+  The HTTP method for the endpoint. Supported values: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`, `CONNECT`, `TRACE`. Required if `endpoint` is not provided.
 </ParamField>
 
-<ParamField path="code" type="string" required={true}>
-  The code snippet to display, typically a curl command or SDK example.
+<ParamField path="path" type="string" required={false}>
+  The endpoint path (e.g., `/v2/plants` or `/api/plants/{plantId}`). Required if `endpoint` is not provided.
+</ParamField>
+
+<ParamField path="code" type="string" required={false}>
+  The code snippet to display, typically a curl command or SDK example. Required if `endpoint` is not provided.
 </ParamField>
 
 <ParamField path="language" type="string" required={false}>


### PR DESCRIPTION
## Summary

Adds documentation for the new `<EndpointSnippet>` MDX component, which displays an API endpoint with its HTTP method badge, path, code example, and optional "Try it" button.

This documentation PR accompanies the component implementation in https://github.com/fern-api/fern-platform/pull/6408.

**Changes:**
- New documentation page at `component-library/default-components/endpoint-snippet.mdx`
- Changelog entry for 2026-01-15
- Navigation entry in docs.yml (placed after "Endpoint schema snippet")

### Updates since last revision

Documentation now includes the new `endpoint` parameter feature for auto-population from API definitions:
- Added "Auto-populated from API definition" section showing `<EndpointSnippet endpoint="GET /plants" />` usage
- Added "Hybrid: auto-populate with overrides" section explaining how explicit props override auto-populated values
- Updated Properties section to document the `endpoint` parameter

## Review & Testing Checklist for Human

- [ ] **Merge fern-platform#6408 first** - This documentation references a component that doesn't exist yet. The examples will fail to render until the component PR is merged.
- [ ] **Verify manual configuration examples render correctly** - The GET/POST/PUT/DELETE examples with explicit props should work once the component is available
- [ ] **Note: Auto-population examples may not render in preview** - The `<EndpointSnippet endpoint="GET /plants" />` syntax requires the rehype plugin to look up endpoints from an actual API definition at build time. These examples demonstrate the syntax but may not render actual content without a matching API definition.
- [ ] **Verify changelog link works** - The changelog links to `/learn/docs/writing-content/components/endpoint-snippet` - confirm this resolves correctly

**Test plan:**
1. Merge fern-platform#6408 first
2. Deploy this docs PR to preview
3. Navigate to the new EndpointSnippet documentation page
4. Verify manual configuration examples render with proper HTTP method badges and code highlighting
5. Check the changelog entry displays correctly

### Notes

This is documentation for a component inspired by [Webflow's ApiEndpoint component](https://developers.webflow.com/data/reference/rest-introduction#make-your-first-api-call).

---

Link to Devin run: https://app.devin.ai/sessions/00416794cab647788a045fc6ca343c3f
Requested by: Sarah Bawabe (@sbawabe)