### PR TITLE
docs: add changelog entry for If component products and versions props

### DIFF
--- a/fern/products/docs/pages/changelog/2026-01-17.mdx
+++ b/fern/products/docs/pages/changelog/2026-01-17.mdx
@@ -1,0 +1,21 @@
+## Products and versions props for If component
+
+The `<If>` component now supports `products` and `versions` props, allowing you to conditionally show content based on where a page is located within the navigation structure.
+
+```jsx Markdown
+<If products={["api-reference"]}>
+  This content only shows in the api-reference product
+</If>
+
+<If versions={["v2", "v3"]}>
+  This content only shows in v2 or v3
+</If>
+
+<If products={["docs"]} versions={["v2"]}>
+  All conditions must match (AND logic)
+</If>
+```
+
+You can also use the `not` prop to invert the condition, showing content when the current product or version does not match.
+
+Learn more about the [If component](/learn/docs/authentication/rbac#access-control-within-mdx-pages).


### PR DESCRIPTION
## Summary

Adds a changelog entry documenting the new `products` and `versions` props for the `<If>` component. This feature allows documentation authors to conditionally show content based on where a page is located within the navigation structure (which product or version the user is viewing).

This changelog entry accompanies the implementation PR: https://github.com/fern-api/fern-platform/pull/6456

## Review & Testing Checklist for Human

- [ ] **Merge order**: This changelog should be merged after the fern-platform implementation PR (#6456) is merged, otherwise users will see documentation for a feature that doesn't exist yet
- [ ] **Link validity**: Verify the link `/learn/docs/authentication/rbac#access-control-within-mdx-pages` works correctly (note: the RBAC page currently only documents the `roles` prop, not the new `products`/`versions` props)
- [ ] **Preview the changelog**: Check that the changelog entry renders correctly in the docs preview

### Notes

**Link to Devin run:** https://app.devin.ai/sessions/eea1536f18554cde8cebf3db3898a470
**Requested by:** Sarah Bawabe (@sbawabe)