### PR TITLE
docs: document noindex frontmatter excludes pages from llms.txt

### DIFF
--- a/fern/products/docs/pages/ai/llms-txt.mdx
+++ b/fern/products/docs/pages/ai/llms-txt.mdx
@@ -54,6 +54,19 @@ Filter `llms.txt` and `llms-full.txt` output with the `lang` and `excludeSpec` q
 </ParamField>
 
 
+## Exclude pages from LLM endpoints
+
+To exclude an entire page from `llms.txt` and `llms-full.txt`, add `noindex: true` to the page's [frontmatter](/learn/docs/content/frontmatter):
+
+```mdx docs/internal-notes.mdx
+---
+title: Internal notes
+noindex: true
+---
+```
+
+Pages with `noindex: true` are excluded from LLM endpoints and search engine indexing.
+
 ## Control visibility for AI vs humans
 
 Use `<llms-only>` and `<llms-ignore>` tags to provide additional context for AI assistants while keeping your documentation site clean and focused.

--- a/fern/products/docs/pages/ai/llms-txt.mdx
+++ b/fern/products/docs/pages/ai/llms-txt.mdx
@@ -56,7 +56,7 @@ Filter `llms.txt` and `llms-full.txt` output with the `lang` and `excludeSpec` q
 
 ## Control visibility for AI vs humans
 
-You can exclude whole pages from LLM endpoints (`llms.txt` and `llms-full.txt`) by [adding `noindex: true`](learn/docs/seo/setting-seo-metadata#noindex) to the page's frontmatter. Pages marked `noindex` are hidden from your documentation site’s navigation and not indexed by search engines but can still be accessed directly by URL.
+You can exclude whole pages from LLM endpoints (`llms.txt` and `llms-full.txt`) by [adding `noindex: true`](/learn/docs/seo/setting-seo-metadata#noindex) to the page's frontmatter. Pages marked `noindex` are hidden from your documentation site’s navigation and not indexed by search engines but can still be accessed directly by URL.
 
 ```mdx docs/pages/internal-notes.mdx
 ---

--- a/fern/products/docs/pages/ai/llms-txt.mdx
+++ b/fern/products/docs/pages/ai/llms-txt.mdx
@@ -54,26 +54,22 @@ Filter `llms.txt` and `llms-full.txt` output with the `lang` and `excludeSpec` q
 </ParamField>
 
 
-## Exclude pages from LLM endpoints
+## Control visibility for AI vs humans
 
-To exclude an entire page from `llms.txt` and `llms-full.txt`, add `noindex: true` to the page's [frontmatter](/learn/docs/content/frontmatter):
+You can exclude whole pages from LLM endpoints (`llms.txt` and `llms-full.txt`) by [adding `noindex: true`](learn/docs/seo/setting-seo-metadata#noindex) to the page's frontmatter. Pages marked `noindex` are hidden from your documentation site’s navigation and not indexed by search engines but can still be accessed directly by URL.
 
-```mdx docs/internal-notes.mdx
+```mdx docs/pages/internal-notes.mdx
 ---
 title: Internal notes
 noindex: true
 ---
 ```
 
-Pages with `noindex: true` are excluded from LLM endpoints and search engine indexing.
-
-## Control visibility for AI vs humans
-
-Use `<llms-only>` and `<llms-ignore>` tags to provide additional context for AI assistants while keeping your documentation site clean and focused.
+Within pages, use `<llms-only>` and `<llms-ignore>` tags to control what content is exposed to LLM endpoints versus human readers.
 
 ### Content for AI only
 
-The `<llms-only>` tag is included in LLM endpoints (e.g., `/llms.txt`, `/llms-full.txt`) but hidden on your documentation site. Use it for:
+Use the `<llms-only>` tag to show content to LLM endpoints but hide it on your documentation site. This is useful for:
 - Technical context that's verbose but helpful for AI, like implementation details or architecture notes
 - Code-related metadata that would clutter the human UI
 - Cross-references that help AI understand relationships between pages
@@ -86,7 +82,7 @@ The `<llms-only>` tag is included in LLM endpoints (e.g., `/llms.txt`, `/llms-fu
 
 ### Content for humans only
 
-The `<llms-ignore>` tag is shown on your documentation site but excluded from LLM endpoints. Use it for:
+Use the `<llms-ignore>` tag to show content to human readers on your documentation site while excluding it from LLM endpoints. This is useful for:
 - Marketing CTAs or promotional content
 - Navigation hints meant only for human readers
 

--- a/fern/products/docs/pages/ai/llms-txt.mdx
+++ b/fern/products/docs/pages/ai/llms-txt.mdx
@@ -56,7 +56,7 @@ Filter `llms.txt` and `llms-full.txt` output with the `lang` and `excludeSpec` q
 
 ## Exclude pages from LLM endpoints
 
-To exclude an entire page from `llms.txt` and `llms-full.txt`, add `noindex: true` to the page's [frontmatter](/learn/docs/content/frontmatter):
+To exclude an entire page from `llms.txt` and `llms-full.txt`, add `noindex: true` to the page's [frontmatter](/learn/docs/customization/frontmatter):
 
 ```mdx docs/internal-notes.mdx
 ---

--- a/fern/products/docs/pages/seo/metadata.mdx
+++ b/fern/products/docs/pages/seo/metadata.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure SEO metadata
 description: Configure SEO metadata in Fern docs with page-level frontmatter and site-wide settings. Control titles, descriptions, and social media previews.
+max-toc-depth: 2
 ---
 
 Fern automatically generates all SEO metadata for every page in your documentation site. Search engines and social media previews work out of the box with no configuration required.

--- a/fern/snippets/seo-metadata-page.mdx
+++ b/fern/snippets/seo-metadata-page.mdx
@@ -112,7 +112,7 @@ nofollow: false
 </Accordion>
 <Accordion title="Indexing properties">
 <ParamField path="noindex" type="boolean" required={false} default={false}>
-  If set to `true`, the page will not be indexed by search engines.
+  If set to `true`, the page will not be indexed by search engines and will be excluded from [llms.txt](/learn/docs/ai-features/llms-txt) endpoints.
 </ParamField>
 
 <ParamField path="nofollow" type="boolean" required={false} default={false}>

--- a/fern/snippets/seo-metadata-page.mdx
+++ b/fern/snippets/seo-metadata-page.mdx
@@ -111,11 +111,11 @@ nofollow: false
 </ParamField>
 </Accordion>
 <Accordion title="Indexing properties">
-<ParamField path="noindex" type="boolean" required={false} default={false}>
+<ParamField path="noindex" type="boolean" required={false} default={false} toc={true}>
   If set to `true`, the page will not be indexed by search engines and will be excluded from [llms.txt](/learn/docs/ai-features/llms-txt) endpoints.
 </ParamField>
 
-<ParamField path="nofollow" type="boolean" required={false} default={false}>
+<ParamField path="nofollow" type="boolean" required={false} default={false} toc={true}>
   If set to `true`, a search engine will not follow any links present on the page.
 </ParamField>
 </Accordion>


### PR DESCRIPTION
## Summary

Documents that the `noindex: true` frontmatter property excludes pages from `llms.txt` and `llms-full.txt` endpoints, in addition to preventing search engine indexing.

Changes:
- Added new "Exclude pages from LLM endpoints" section to the llms.txt documentation page with a code example
- Updated the `noindex` property description in the SEO metadata reference to mention llms.txt exclusion

This addresses a documentation gap where page-level exclusion from llms.txt was only mentioned in the CLI changelog (v0.53.3) but not in the main documentation.

## Updates since last revision

- Fixed the frontmatter link path from `/learn/docs/content/frontmatter` to `/learn/docs/customization/frontmatter`

## Review & Testing Checklist for Human

- [ ] Verify the link `/learn/docs/customization/frontmatter` in llms-txt.mdx resolves correctly
- [ ] Verify the link `/learn/docs/ai-features/llms-txt` in seo-metadata-page.mdx resolves correctly
- [ ] Confirm the documented behavior is accurate (that `noindex: true` actually excludes pages from llms.txt endpoints)

### Notes

Requested by @jon-fern

Link to Devin run: https://app.devin.ai/sessions/38838429aac248f59d011470f0a02d84