### PR TITLE
Fix typo in tab title markdown-media.mdx

### DIFF
--- a/fern/products/docs/pages/component-library/writing-content/markdown-media.mdx
+++ b/fern/products/docs/pages/component-library/writing-content/markdown-media.mdx
@@ -53,7 +53,7 @@ For more details about the HTML image element and its attributes, see the [MDN d
 Embed PDFs using the `<iframe>` element. Don't use the `<embed>` element, as it has inconsistent browser support.
 
 <Tabs>
-<Tab title="Rendered video">
+<Tab title="Rendered PDF">
 <iframe src="../default-components/all-about-ferns.pdf" width="100%" height="500px" style={{ border: 'none', borderRadius: '0.5rem' }} />
 </Tab>
 <Tab title="HTML">


### PR DESCRIPTION
Simple change. The title of this tab currently reads "Rendered video", but the tab actually contains a PDF.