### PR TITLE
docs: add missing OpenAPI extensions to overview page

### DIFF
--- a/fern/products/api-def/openapi-pages/extensions/overview.md
+++ b/fern/products/api-def/openapi-pages/extensions/overview.md
@@ -26,15 +26,20 @@ The table below shows all available extensions and links to detailed documentati
 | [`x-fern-explorer`](./api-explorer-control) | Control API Explorer (playground) availability globally or per endpoint |
 | [`x-fern-global-headers`](./global-headers) | Configure headers used across all endpoints |
 | [`x-fern-header`](/api-definitions/openapi/authentication#apikey-security-scheme) | Customize API key header authentication parameter names and environment variables |
+| [`x-fern-idempotent`](/sdks/guides/configure-idempotency) | Mark an endpoint as idempotent |
+| [`x-fern-idempotency-headers`](/sdks/guides/configure-idempotency) | Configure idempotency headers for safe request retries |
 | [`x-fern-ignore`](./ignoring-elements) | Skip reading specific endpoints or schemas |
+| [`x-fern-pagination`](/sdks/guides/configure-auto-pagination) | Configure auto-pagination for list endpoints |
 | [`x-fern-sdk-method-name`](./method-names) | Customize SDK method names |
 | [`x-fern-sdk-group-name`](./method-names) | Organize methods into SDK groups |
 | [`x-fern-sdk-variables`](./sdk-variables) | Set common path parameters across all requests |
 | [`x-fern-parameter-name`](./parameter-names) | Customize parameter variable names |
 | [`x-fern-property-name`](./property-names) | Customize object property variable names |
 | [`x-fern-retries`](./retry-behavior) | Configure retry behavior for endpoints |
+| [`x-fern-streaming`](/api-definitions/openapi/endpoints/sse) | Configure streaming endpoints (JSON or SSE) |
 | [`x-fern-type-name`](./schema-names) | Override auto-generated names for inline schemas |
 | [`x-fern-server-name`](./server-names) | Name your servers |
+| [`x-fern-webhook`](/api-definitions/openapi/webhooks) | Define webhooks in OpenAPI 3.0 specifications |
 
 <Note title="Request a new extension">
     If there's an extension you want that doesn't already exist, file an [issue](https://github.com/fern-api/fern/issues/new) to start a discussion about it.

--- a/fern/products/api-def/openapi-pages/extensions/overview.md
+++ b/fern/products/api-def/openapi-pages/extensions/overview.md
@@ -26,10 +26,10 @@ The table below shows all available extensions and links to detailed documentati
 | [`x-fern-explorer`](./api-explorer-control) | Control API Explorer (playground) availability globally or per endpoint |
 | [`x-fern-global-headers`](./global-headers) | Configure headers used across all endpoints |
 | [`x-fern-header`](/api-definitions/openapi/authentication#apikey-security-scheme) | Customize API key header authentication parameter names and environment variables |
-| [`x-fern-idempotent`](/sdks/guides/configure-idempotency) | Mark an endpoint as idempotent |
-| [`x-fern-idempotency-headers`](/sdks/guides/configure-idempotency) | Configure idempotency headers for safe request retries |
+| [`x-fern-idempotent`](/sdks/deep-dives/idempotency) | Mark an endpoint as idempotent |
+| [`x-fern-idempotency-headers`](/sdks/deep-dives/idempotency) | Configure idempotency headers for safe request retries |
 | [`x-fern-ignore`](./ignoring-elements) | Skip reading specific endpoints or schemas |
-| [`x-fern-pagination`](/sdks/guides/configure-auto-pagination) | Configure auto-pagination for list endpoints |
+| [`x-fern-pagination`](/sdks/deep-dives/auto-pagination) | Configure auto-pagination for list endpoints |
 | [`x-fern-sdk-method-name`](./method-names) | Customize SDK method names |
 | [`x-fern-sdk-group-name`](./method-names) | Organize methods into SDK groups |
 | [`x-fern-sdk-variables`](./sdk-variables) | Set common path parameters across all requests |
@@ -39,7 +39,7 @@ The table below shows all available extensions and links to detailed documentati
 | [`x-fern-streaming`](/api-definitions/openapi/endpoints/sse) | Configure streaming endpoints (JSON or SSE) |
 | [`x-fern-type-name`](./schema-names) | Override auto-generated names for inline schemas |
 | [`x-fern-server-name`](./server-names) | Name your servers |
-| [`x-fern-webhook`](/api-definitions/openapi/webhooks) | Define webhooks in OpenAPI 3.0 specifications |
+| [`x-fern-webhook`](/api-definitions/openapi/endpoints/webhooks) | Define webhooks in OpenAPI 3.0 specifications |
 
 <Note title="Request a new extension">
     If there's an extension you want that doesn't already exist, file an [issue](https://github.com/fern-api/fern/issues/new) to start a discussion about it.


### PR DESCRIPTION
## Summary

Adds 5 missing OpenAPI extensions to the extensions overview page at `/learn/api-definitions/openapi/extensions/overview`. The user noticed that `x-fern-pagination` was missing from the list, and upon investigation, several other supported extensions were also not documented in the overview table.

**Extensions added:**
- `x-fern-idempotent` - Mark endpoints as idempotent
- `x-fern-idempotency-headers` - Configure idempotency headers
- `x-fern-pagination` - Configure auto-pagination for list endpoints
- `x-fern-streaming` - Configure streaming endpoints (JSON or SSE)
- `x-fern-webhook` - Define webhooks in OpenAPI 3.0 specs

All extensions link to their existing dedicated documentation pages.

## Updates since last revision

Fixed broken links reported in review:
- Changed idempotency links from `/sdks/guides/configure-idempotency` to `/sdks/deep-dives/idempotency`
- Changed pagination link from `/sdks/guides/configure-auto-pagination` to `/sdks/deep-dives/auto-pagination`
- Changed webhook link from `/api-definitions/openapi/webhooks` to `/api-definitions/openapi/endpoints/webhooks`

## Review & Testing Checklist for Human

- [ ] Verify all 5 new links resolve correctly on the preview deployment:
  - `/sdks/deep-dives/idempotency` (for x-fern-idempotent and x-fern-idempotency-headers)
  - `/sdks/deep-dives/auto-pagination` (for x-fern-pagination)
  - `/api-definitions/openapi/endpoints/sse` (for x-fern-streaming)
  - `/api-definitions/openapi/endpoints/webhooks` (for x-fern-webhook)
- [ ] Confirm the descriptions accurately reflect what each extension does
- [ ] Check that the table maintains alphabetical ordering

**Test plan:** Navigate to the preview URL and click each of the 5 new extension links to verify they resolve to the correct documentation pages.

### Notes

Requested by Chris McDonnell (@cdonel707)

[Link to Devin run](https://app.devin.ai/sessions/00816c708d1d46f9b79dbd6325eff947)