### PR TITLE
Add switcher-placement documentation and changelog entry

### DIFF
--- a/fern/products/docs/pages/changelog/2026-01-30.mdx
+++ b/fern/products/docs/pages/changelog/2026-01-30.mdx
@@ -1,0 +1,10 @@
+## Switcher placement configuration
+
+Control where the product and version switchers appear in your documentation site using the `switcher-placement` option in your `docs.yml` layout configuration. Choose between `header` (default) to display switchers in the top navigation bar, or `sidebar` to place them in the sidebar navigation.
+
+```yaml docs.yml
+layout:
+  switcher-placement: sidebar
+```
+
+Learn more about [layout configuration](/learn/docs/configuration/site-level-settings#layout-configuration).

--- a/fern/products/docs/pages/customization/site-level-settings.mdx
+++ b/fern/products/docs/pages/customization/site-level-settings.mdx
@@ -535,6 +535,7 @@ layout:
   sidebar-width: 336px
   searchbar-placement: header
   tabs-placement: header
+  switcher-placement: sidebar
   content-alignment: left
   hide-nav-links: true
   hide-feedback: true
@@ -566,6 +567,12 @@ layout:
 
 <ParamField path="layout.tabs-placement" type="string" required={false} default="sidebar" toc={true}>
   Set the placement of the tabs. Can be one of `header` or `sidebar`. 
+
+  <Note>This setting is ignored when `disable-header` is set to true.</Note>
+</ParamField>
+
+<ParamField path="layout.switcher-placement" type="string" required={false} default="header" toc={true}>
+  Set the placement of the product and version switchers. Can be one of `header` or `sidebar`. 
 
   <Note>This setting is ignored when `disable-header` is set to true.</Note>
 </ParamField>


### PR DESCRIPTION
## Summary

Adds documentation for the new `switcher-placement` layout configuration option that allows users to control where product and version switchers appear in their documentation site.

Changes:
- New changelog entry for 2026-01-30 announcing the feature
- Updated the layout configuration section in site-level-settings.mdx with the new `switcher-placement` option

## Review & Testing Checklist for Human

- [ ] Verify the link `/learn/docs/configuration/site-level-settings#layout-configuration` in the changelog resolves correctly
- [ ] Confirm the documented options (`header`, `sidebar`) and default value (`header`) match the actual implementation in fern-api/fern

### Test Plan
1. Deploy preview and navigate to the changelog page to verify the new entry renders correctly
2. Navigate to the layout configuration section and verify the new `switcher-placement` ParamField appears in the correct location (after `tabs-placement`)

### Notes
- Link to Devin run: https://app.devin.ai/sessions/08eb7b00d9ff41cca979f0111f753332
- Requested by: @sbawabe