### PR TITLE
docs: add SearchableTable and StickySearchableTable wrapper documentation

### DIFF
--- a/fern/products/docs/pages/changelog/2026-01-30.mdx
+++ b/fern/products/docs/pages/changelog/2026-01-30.mdx
@@ -1,6 +1,17 @@
 ## Searchable tables
 
-Add the `searchable` attribute to HTML tables to enable client-side filtering for large tables. A search input appears above the table that filters rows in real-time using case-insensitive substring matching.
+The `<SearchableTable>` component enables client-side filtering for large tables. A search input appears above the table that filters rows in real-time using case-insensitive substring matching. Wrap any markdown table with `<SearchableTable>` to add search functionality:
+
+```jsx Markdown
+<SearchableTable>
+| Plant | Light Requirements | Water |
+|-------|-------------------|-------|
+| Fern | Partial shade | Weekly |
+| Snake Plant | Low to bright indirect | Bi-weekly |
+</SearchableTable>
+```
+
+Alternatively, add the `searchable` attribute to HTML tables:
 
 ```jsx Markdown
 <table searchable className="fern-table">

--- a/fern/products/docs/pages/changelog/2026-01-30.mdx
+++ b/fern/products/docs/pages/changelog/2026-01-30.mdx
@@ -11,6 +11,17 @@ The `<SearchableTable>` component enables client-side filtering for large tables
 </SearchableTable>
 ```
 
+Use `<StickySearchableTable>` to combine both sticky headers and search:
+
+```jsx Markdown
+<StickySearchableTable>
+| Plant | Light Requirements | Water |
+|-------|-------------------|-------|
+| Fern | Partial shade | Weekly |
+| Snake Plant | Low to bright indirect | Bi-weekly |
+</StickySearchableTable>
+```
+
 Alternatively, add the `searchable` attribute to HTML tables:
 
 ```jsx Markdown

--- a/fern/products/docs/pages/component-library/default-components/tables.mdx
+++ b/fern/products/docs/pages/component-library/default-components/tables.mdx
@@ -81,7 +81,57 @@ The `<StickyTable>` component adds a fixed header that remains visible while scr
 
 ### Searchable tables
 
-Add the `searchable` attribute to enable client-side filtering for large tables. A search input appears above the table that filters rows in real-time using case-insensitive substring matching.
+The `<SearchableTable>` component enables client-side filtering for large tables. A search input appears above the table that filters rows in real-time using case-insensitive substring matching.
+
+<div className="highlight-frame">
+  <div className="highlight-frame-content-sticky">
+  <SearchableTable>
+  | Plant | Light Requirements | Water |
+  |-------|-------------------|-------|
+  | Fern | Partial shade | Weekly |
+  | Snake Plant | Low to bright indirect | Bi-weekly |
+  | Monstera | Bright indirect | Weekly |
+  | Pothos | Low to bright indirect | Weekly |
+  | Fiddle Leaf Fig | Bright indirect | Weekly |
+  | Peace Lily | Low to medium indirect | Weekly |
+  | Rubber Plant | Bright indirect | Weekly |
+  | ZZ Plant | Low to bright indirect | Bi-weekly |
+  | Philodendron | Medium to bright indirect | Weekly |
+  | Aloe Vera | Bright direct | Bi-weekly |
+  | Boston Fern | Partial shade | 2-3x weekly |
+  | Spider Plant | Medium to bright indirect | Weekly |
+  | Dracaena | Medium indirect | Weekly |
+  | Bird of Paradise | Bright indirect to direct | Weekly |
+  | Calathea | Medium indirect | Weekly |
+  </SearchableTable>
+  </div>
+</div>
+
+```jsx Markdown maxLines=10
+<SearchableTable>
+| Plant | Light Requirements | Water |
+|-------|-------------------|-------|
+| Fern | Partial shade | Weekly |
+| Snake Plant | Low to bright indirect | Bi-weekly |
+| Monstera | Bright indirect | Weekly |
+| Pothos | Low to bright indirect | Weekly |
+| Fiddle Leaf Fig | Bright indirect | Weekly |
+| Peace Lily | Low to medium indirect | Weekly |
+| Rubber Plant | Bright indirect | Weekly |
+| ZZ Plant | Low to bright indirect | Bi-weekly |
+| Philodendron | Medium to bright indirect | Weekly |
+| Aloe Vera | Bright direct | Bi-weekly |
+| Boston Fern | Partial shade | 2-3x weekly |
+| Spider Plant | Medium to bright indirect | Weekly |
+| Dracaena | Medium indirect | Weekly |
+| Bird of Paradise | Bright indirect to direct | Weekly |
+| Calathea | Medium indirect | Weekly |
+</SearchableTable>
+```
+
+### HTML searchable tables
+
+Alternatively, add the `searchable` attribute to an HTML table element:
 
 <div className="highlight-frame">
   <div className="highlight-frame-content-sticky">
@@ -402,6 +452,12 @@ Sticky tables can be styled independently from regular tables. To add custom sty
 
 <ParamField path="children" type="markdown table" required={true}>
   The markdown table to display with sticky headers. The table must be formatted using standard markdown table syntax.
+</ParamField>
+
+### `<SearchableTable>` properties
+
+<ParamField path="children" type="markdown table" required={true}>
+  The markdown table to display with search functionality. The table must be formatted using standard markdown table syntax.
 </ParamField>
 
 ### HTML `<table>` attributes

--- a/fern/products/docs/pages/component-library/default-components/tables.mdx
+++ b/fern/products/docs/pages/component-library/default-components/tables.mdx
@@ -129,6 +129,56 @@ The `<SearchableTable>` component enables client-side filtering for large tables
 </SearchableTable>
 ```
 
+### Sticky searchable tables
+
+The `<StickySearchableTable>` component combines both sticky headers and search functionality:
+
+<div className="highlight-frame">
+  <div className="highlight-frame-content-sticky">
+  <StickySearchableTable>
+  | Plant | Light Requirements | Water |
+  |-------|-------------------|-------|
+  | Fern | Partial shade | Weekly |
+  | Snake Plant | Low to bright indirect | Bi-weekly |
+  | Monstera | Bright indirect | Weekly |
+  | Pothos | Low to bright indirect | Weekly |
+  | Fiddle Leaf Fig | Bright indirect | Weekly |
+  | Peace Lily | Low to medium indirect | Weekly |
+  | Rubber Plant | Bright indirect | Weekly |
+  | ZZ Plant | Low to bright indirect | Bi-weekly |
+  | Philodendron | Medium to bright indirect | Weekly |
+  | Aloe Vera | Bright direct | Bi-weekly |
+  | Boston Fern | Partial shade | 2-3x weekly |
+  | Spider Plant | Medium to bright indirect | Weekly |
+  | Dracaena | Medium indirect | Weekly |
+  | Bird of Paradise | Bright indirect to direct | Weekly |
+  | Calathea | Medium indirect | Weekly |
+  </StickySearchableTable>
+  </div>
+</div>
+
+```jsx Markdown maxLines=10
+<StickySearchableTable>
+| Plant | Light Requirements | Water |
+|-------|-------------------|-------|
+| Fern | Partial shade | Weekly |
+| Snake Plant | Low to bright indirect | Bi-weekly |
+| Monstera | Bright indirect | Weekly |
+| Pothos | Low to bright indirect | Weekly |
+| Fiddle Leaf Fig | Bright indirect | Weekly |
+| Peace Lily | Low to medium indirect | Weekly |
+| Rubber Plant | Bright indirect | Weekly |
+| ZZ Plant | Low to bright indirect | Bi-weekly |
+| Philodendron | Medium to bright indirect | Weekly |
+| Aloe Vera | Bright direct | Bi-weekly |
+| Boston Fern | Partial shade | 2-3x weekly |
+| Spider Plant | Medium to bright indirect | Weekly |
+| Dracaena | Medium indirect | Weekly |
+| Bird of Paradise | Bright indirect to direct | Weekly |
+| Calathea | Medium indirect | Weekly |
+</StickySearchableTable>
+```
+
 ### HTML searchable tables
 
 Alternatively, add the `searchable` attribute to an HTML table element:
@@ -458,6 +508,12 @@ Sticky tables can be styled independently from regular tables. To add custom sty
 
 <ParamField path="children" type="markdown table" required={true}>
   The markdown table to display with search functionality. The table must be formatted using standard markdown table syntax.
+</ParamField>
+
+### `<StickySearchableTable>` properties
+
+<ParamField path="children" type="markdown table" required={true}>
+  The markdown table to display with both sticky headers and search functionality. The table must be formatted using standard markdown table syntax.
 </ParamField>
 
 ### HTML `<table>` attributes


### PR DESCRIPTION
## Summary

Adds documentation for the new `<SearchableTable>` and `<StickySearchableTable>` components that allow wrapping markdown tables with search functionality, similar to how `<StickyTable>` works. This provides a simpler alternative to converting markdown tables to HTML when adding search.

Changes:
- Updated changelog entry to document the `<SearchableTable>` and `<StickySearchableTable>` wrapper syntax
- Added new section in tables.mdx showing `<SearchableTable>` usage with markdown tables
- Added new section for `<StickySearchableTable>` that combines sticky headers and search
- Renamed existing searchable section to "HTML searchable tables" for clarity
- Added `<SearchableTable>` and `<StickySearchableTable>` properties documentation

## Review & Testing Checklist for Human

- [ ] **Verify the fern-platform PR (https://github.com/fern-api/fern-platform/pull/6775) is merged first** - this docs PR depends on the platform implementation
- [ ] Test that `<SearchableTable>` renders with search functionality in the preview deployment
- [ ] Test that `<StickySearchableTable>` renders with both sticky headers AND search functionality
- [ ] Verify the live examples in the tables.mdx page work correctly (search filters rows, headers stay sticky when scrolling)

### Notes

This PR is part of a two-PR change:
1. fern-platform PR: Implements `<SearchableTable>` and `<StickySearchableTable>` in the rehype-table.ts plugin
2. This PR: Documents the new components

Requested by: @thesandlord
Link to Devin run: https://app.devin.ai/sessions/0ada0f0218204c528d4a32c3375a10fe