### PR TITLE
docs: fix incorrect claim about Schema component type discovery

### DIFF
--- a/fern/products/docs/pages/component-library/default-components/schema.mdx
+++ b/fern/products/docs/pages/component-library/default-components/schema.mdx
@@ -8,7 +8,7 @@ The `<Schema>` component displays type definitions from your API Reference anywh
 Similar to [`<EndpointSchemaSnippet>`](/learn/docs/writing-content/components/endpoint-schema-snippet), but accepts any type name rather than being limited to endpoint-specific schemas. Pair with [`<SchemaSnippet>`](/learn/docs/writing-content/components/schema-snippet) to display the JSON representation alongside the field breakdown.
 
 <Note>
-  The component only discovers types referenced by endpoints. Types exclusively used by websockets or webhooks won't be available. If multiple APIs have the same type name, the component returns the first match.
+  The component discovers types from your API definition, including those referenced by endpoints, webhooks, and websockets. Types must be defined as named schemas in your OpenAPI spec (under `components/schemas`) to be discoverable. Inline schemas that aren't extracted as named types won't be available. If multiple APIs have the same type name, the component returns the first match.
 </Note>
 
 ## Usage
@@ -28,7 +28,7 @@ The component works with [API references already configured in your `docs.yml`](
 ## Properties
 
 <ParamField path="type" type="string" required={true}>
-  The name of the type to display. The component will search for this type across all endpoints in your API definition.
+  The name of the type to display. The component searches for this type across all named schemas in your API definition.
 </ParamField>
 
 <ParamField path="className" type="string" required={false}>


### PR DESCRIPTION
## Summary

Updates the Schema component documentation to correct an inaccurate claim about type discovery. The previous documentation stated that "types exclusively used by websockets or webhooks won't be available," but after investigating the fern-platform codebase, I found that the `IrGraph.build()` method does include types from webhooks and websocket channels.

The actual limitation is that types must be defined as named schemas in the OpenAPI spec (under `components/schemas`) to be discoverable - inline schemas that aren't extracted as named types won't be available.

## Review & Testing Checklist for Human

- [ ] **Verify the technical accuracy**: Confirm that types from webhooks/websockets ARE actually discoverable by the Schema component. My investigation was code-based (looking at `IrGraph.build()` in fern-platform), not empirically tested.
- [ ] **Test with a real webhook type**: Try using `<Schema type="SomeWebhookType" />` with a type that's only referenced by a webhook to confirm it works.
- [ ] **Check if this addresses the original issue**: The original issue was about Square's `ACHDetails` type not being found. The new docs suggest this is because it might be an inline schema - verify this is the actual root cause.

### Notes

- The user also requested "webhook examples" support, but my investigation showed webhook examples are already implemented in the codebase (`WebhookExamplesClient.tsx`, `generateWebhookExample.ts`). If webhook examples aren't appearing for Square, it may be a separate issue with their specific OpenAPI spec.
- Link to Devin run: https://app.devin.ai/sessions/a6fc306d37b04ecd971cdc6505c302b5
- Requested by: @Ryan-Amirthan