### PR TITLE
docs: add hideTryItButton prop to EndpointRequestSnippet

### DIFF
--- a/fern/products/docs/pages/changelog/2026-02-03.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-03.mdx
@@ -1,3 +1,16 @@
+## Try It button in EndpointRequestSnippet
+
+The `<EndpointRequestSnippet>` component includes a Try It button, allowing users to test API endpoints directly from code snippets. Use the `hideTryItButton` prop to hide the button when needed.
+
+```jsx Markdown
+<EndpointRequestSnippet 
+  endpoint="POST /plants/{plantId}" 
+  hideTryItButton={true}
+/>
+```
+
+Learn more about [EndpointRequestSnippet](/learn/docs/writing-content/components/endpoint-request-snippet#hide-try-it-button).
+
 ## Frontmatter availability
 
 Set page availability directly in frontmatter using the `availability` field. This displays an availability badge on the page and overrides any availability defined in the navigation (`docs.yml`).

--- a/fern/products/docs/pages/changelog/2026-02-03.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-03.mdx
@@ -2,7 +2,7 @@
 
 The `<EndpointRequestSnippet>` component now includes a Try It button, allowing users to access the endpoint explorer and test API endpoints directly from code snippets.
 
-Learn more about [EndpointRequestSnippet](/learn/docs/writing-content/components/endpoint-request-snippet).
+Learn more about [EndpointRequestSnippet](/learn/docs/writing-content/components/request-snippet).
 
 ## Frontmatter availability
 

--- a/fern/products/docs/pages/changelog/2026-02-03.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-03.mdx
@@ -1,15 +1,8 @@
 ## Try It button in EndpointRequestSnippet
 
-The `<EndpointRequestSnippet>` component includes a Try It button, allowing users to test API endpoints directly from code snippets. Use the `hideTryItButton` prop to hide the button when needed.
+The `<EndpointRequestSnippet>` component now includes a Try It button, allowing users to access the endpoint explorer and test API endpoints directly from code snippets.
 
-```jsx Markdown
-<EndpointRequestSnippet 
-  endpoint="POST /plants/{plantId}" 
-  hideTryItButton={true}
-/>
-```
-
-Learn more about [EndpointRequestSnippet](/learn/docs/writing-content/components/endpoint-request-snippet#hide-try-it-button).
+Learn more about [EndpointRequestSnippet](/learn/docs/writing-content/components/endpoint-request-snippet).
 
 ## Frontmatter availability
 

--- a/fern/products/docs/pages/component-library/default-components/endpoint-request-snippet.mdx
+++ b/fern/products/docs/pages/component-library/default-components/endpoint-request-snippet.mdx
@@ -140,6 +140,6 @@ The `EndpointRequestSnippet` component includes a Try It button by default. Use 
   Specifies which languages to show in the dropdown and in what order. Supported values include `curl`, `python`, `typescript`, `javascript`, `go`, `ruby`, `java`, `kotlin`, `csharp`, `php`, `swift`, `rust`, and `payload`. When not specified, all available languages are shown.
 </ParamField>
 
-<ParamField path="hideTryItButton" type="boolean" required={false}>
-  When set to `true`, hides the Try It button from the snippet. Defaults to `false`.
+<ParamField path="hideTryItButton" type="boolean" required={false} default={false}>
+  When set to `true`, hides the Try It button from the snippet.
 </ParamField>

--- a/fern/products/docs/pages/component-library/default-components/endpoint-request-snippet.mdx
+++ b/fern/products/docs/pages/component-library/default-components/endpoint-request-snippet.mdx
@@ -115,6 +115,12 @@ The `payload` option displays the raw JSON request body for POST/PUT/PATCH reque
 
 The `EndpointRequestSnippet` component includes a Try It button by default. Use the `hideTryItButton` prop to hide it.
 
+<div className="highlight-frame">
+  <div className="highlight-frame-content">
+  <EndpointRequestSnippet endpoint="POST /chat/{domain}" hideTryItButton={true} />
+  </div>
+</div>
+
 ```jsx Markdown
 <EndpointRequestSnippet 
   endpoint="POST /chat/{domain}" 
@@ -140,6 +146,6 @@ The `EndpointRequestSnippet` component includes a Try It button by default. Use 
   Specifies which languages to show in the dropdown and in what order. Supported values include `curl`, `python`, `typescript`, `javascript`, `go`, `ruby`, `java`, `kotlin`, `csharp`, `php`, `swift`, `rust`, and `payload`. When not specified, all available languages are shown.
 </ParamField>
 
-<ParamField path="hideTryItButton" type="boolean" required={false}>
-  When set to `true`, hides the Try It button from the snippet. Defaults to `false`.
+<ParamField path="hideTryItButton" type="boolean" required={false} default={false}>
+  When set to `true`, hides the Try It button from the snippet.
 </ParamField>

--- a/fern/products/docs/pages/component-library/default-components/endpoint-request-snippet.mdx
+++ b/fern/products/docs/pages/component-library/default-components/endpoint-request-snippet.mdx
@@ -111,6 +111,17 @@ The `payload` option displays the raw JSON request body for POST/PUT/PATCH reque
 />
 ```
 
+### Hide the Try It button
+
+The `EndpointRequestSnippet` component includes a Try It button by default. Use the `hideTryItButton` prop to hide it.
+
+```jsx Markdown
+<EndpointRequestSnippet 
+  endpoint="POST /chat/{domain}" 
+  hideTryItButton={true}
+/>
+```
+
 ## Properties
 
 <ParamField path="endpoint" type="string" required={true}>
@@ -127,4 +138,8 @@ The `payload` option displays the raw JSON request body for POST/PUT/PATCH reque
 
 <ParamField path="languages" type="string[]" required={false}>
   Specifies which languages to show in the dropdown and in what order. Supported values include `curl`, `python`, `typescript`, `javascript`, `go`, `ruby`, `java`, `kotlin`, `csharp`, `php`, `swift`, `rust`, and `payload`. When not specified, all available languages are shown.
+</ParamField>
+
+<ParamField path="hideTryItButton" type="boolean" required={false}>
+  When set to `true`, hides the Try It button from the snippet. Defaults to `false`.
 </ParamField>


### PR DESCRIPTION
## Summary

Documents the new `hideTryItButton` prop for the `EndpointRequestSnippet` component and adds a changelog entry for the Try It button feature.

Changes:
- Added "Hide the Try It button" section to the EndpointRequestSnippet component documentation with usage example
- Added `hideTryItButton` property to the Properties section
- Added changelog entry for February 3, 2026 documenting the new Try It button feature

## Review & Testing Checklist for Human

- [x] Verify the prop name `hideTryItButton` matches the actual implementation
- [x] Confirm the Try It button behavior description is accurate (shown by default, hidden when prop is true)

### Notes

Requested by: Sarah Bawabe (@sbawabe)

Link to Devin run: https://app.devin.ai/sessions/f0f2a6cdd7f44c02af14140ae4f189b9