### PR TITLE
docs: rewrite API key injection page and update self-hosted auth docs

### DIFF
--- a/fern/products/docs/pages/api-references/autopopulate-api-key.mdx
+++ b/fern/products/docs/pages/api-references/autopopulate-api-key.mdx
@@ -1,37 +1,43 @@
 ---
 title: Autopopulate API keys
-subtitle: Set up API key injection with JWT or OAuth authentication. Allow users to login and automatically populate their API keys in your API Explorer.
+subtitle: Allow users to log in and automatically populate their API keys in the API Explorer.
 ---
 
 <Markdown src="/snippets/pro-plan.mdx"/>
 
-Fern can integrate with your authentication flow, allowing users to login and have their API key automatically populated with the click of a button.
+Fern can integrate with your authentication flow, allowing users to log in and have their API key automatically populated with the click of a button.
 
 <div style="position: relative; padding-bottom: 66.38846737481032%; height: 0;"><iframe src="https://www.loom.com/embed/790eb5849f1c4622aae09527908fdc7a?sid=d77062f8-35c3-41ab-8669-4c28b62e233b?hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 
-With this feature, you can **create new users of your API** directly from within your documentation.
-
 <Note>
 User credentials are stored only in browser cookies and never transmitted to Fern's servers. Learn more in the [Security overview](/learn/docs/security/overview).
-</Note> 
+</Note>
 
-## Integrating with your auth flow
+## The `fern` payload
 
-API key injection can work in two different ways depending on your company's authentication setup:
+API key injection works by reading a `fern` claim from a JWT stored in the user's browser. The `fern` claim contains a `playground` object that tells the API Explorer what values to pre-fill.
 
-* **JWT:** You handle the entire auth flow and just give Fern a JWT cookie
-* **OAuth:** You give Fern access, and Fern directly initiates the OAuth handshake process
+The top-level structure is:
 
-<Tabs>
-<Tab title="JWT">
+```json
+{
+  "fern": {
+    "playground": {
+      "initial_state": { ... },
+      "env_state": { ... }
+    }
+  }
+}
+```
 
-Configure JWT authentication so that Fern can securely retrieve API keys for your users. The process works as follows:
+| Field | Description |
+|---|---|
+| `initial_state` | Default values applied to all API Explorer requests. |
+| `env_state` | Per-environment overrides that are merged on top of `initial_state` when the user selects a matching environment. |
 
-1. When a user clicks the "Login" button in the API Explorer, they're redirected to your authentication page.
-2. After successful authentication, your system must set a cookie called `fern_token` in the user's browser.
-3. This token should be a [JWT](https://jwt.io) encrypted with a secret key from Fern. The JWT should contain the user's API key.
+### Auth types
 
-The JWT should have a structure similar to:
+The `initial_state.auth` object supports bearer token and basic authentication.
 
 <CodeBlocks>
 ```json Bearer
@@ -54,27 +60,35 @@ The JWT should have a structure similar to:
     "playground": {
       "initial_state": {
         "auth": {
-            "basic": {
-              "username": "your_username",
-              "password": "your_password"
-            }
+          "basic": {
+            "username": "your_username",
+            "password": "your_password"
+          }
         }
       }
     }
   }
 }
 ```
+</CodeBlocks>
 
-```json Custom
+### Custom headers and parameters
+
+You can pre-fill headers, path parameters, and query parameters in addition to (or instead of) auth credentials. Values are applied to any matching fields in the API Explorer.
+
+```json
 {
   "fern": {
     "playground": {
       "initial_state": {
+        "auth": {
+          "bearer_token": "eyJhbGciOiJIUzI1c"
+        },
         "headers": {
           "API-Version": "2024-02-02"
         },
         "path_parameters": {
-          "id": "1234f"
+          "plantId": "plant_1234"
         },
         "query_parameters": {
           "sort": "DESCENDING"
@@ -85,18 +99,105 @@ The JWT should have a structure similar to:
 }
 ```
 
-</CodeBlocks>
+### Multiple API keys
+
+To provide multiple API keys (for example, one per application), set `bearer_token` to a JSON-encoded array of key-value objects. Each object maps an application name to its key.
+
+```json
+{
+  "fern": {
+    "playground": {
+      "initial_state": {
+        "auth": {
+          "bearer_token": "[{\"Greenhouse app\": \"sk-greenhouse-abc123\"}, {\"Garden app\": \"sk-garden-def456\"}]"
+        }
+      }
+    }
+  }
+}
+```
+
+The API Explorer displays a dropdown so the user can choose which application key to use for requests.
+
+### Per-environment keys
+
+Use `env_state` to provide different credentials for each environment (for example, production vs. staging). Each key in `env_state` is matched against the currently selected environment URL using substring matching.
+
+```json
+{
+  "fern": {
+    "playground": {
+      "initial_state": {
+        "auth": {
+          "bearer_token": "default-token"
+        }
+      },
+      "env_state": {
+        "prod": {
+          "auth": {
+            "bearer_token": "prod-token-abc123"
+          }
+        },
+        "staging": {
+          "auth": {
+            "bearer_token": "staging-token-def456"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+When the user selects an environment containing `prod` (such as `https://api.prod.example.com`), the API Explorer uses `prod-token-abc123`. The `env_state` values are merged on top of `initial_state`: auth is replaced entirely, while headers, path parameters, and query parameters are shallow-merged.
+
+You can combine multiple API keys with per-environment keys:
+
+```json
+{
+  "fern": {
+    "playground": {
+      "env_state": {
+        "prod": {
+          "auth": {
+            "bearer_token": "[{\"Greenhouse app\": \"sk-prod-abc\"}, {\"Garden app\": \"sk-prod-def\"}]"
+          }
+        },
+        "dev": {
+          "auth": {
+            "bearer_token": "[{\"Greenhouse app\": \"sk-dev-abc\"}, {\"Garden app\": \"sk-dev-def\"}]"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Integrating with your auth flow
+
+API key injection requires a JWT containing the `fern` payload described above to be stored in the user's browser as a cookie called `fern_token`. There are two ways to set this up:
+
+* **JWT:** You handle the entire auth flow and set the `fern_token` cookie yourself.
+* **OAuth:** You give Fern access, and Fern initiates the OAuth handshake process directly.
+
+<Tabs>
+<Tab title="JWT">
+
+1. When a user clicks the **Login** button in the API Explorer, they are redirected to your authentication page.
+2. After successful authentication, your system sets a cookie called `fern_token` in the user's browser.
+3. This token is a [JWT](https://jwt.io) signed with a secret key from Fern. The JWT payload contains the `fern` claim with the user's API key.
 
 <Accordion title="Architecture diagram">
 <Markdown src="/snippets/jwt-auth-diagram.mdx"/>
 </Accordion>
 
-#### Set up autopopulated API keys
+#### Set up
 
-To enable API key injection:
-1. Reach out to Fern to get your secret key
-1. Send Fern the URL of your authentication page. This is where users will be redirected to after clicking the "Login" button in the API Explorer.
-1. Add logic to your service to set the `fern_token` cookie when a user logs in
+To enable API key injection with JWT:
+1. Reach out to Fern to get your secret key.
+1. Send Fern the URL of your authentication page. This is where users are redirected after clicking the **Login** button in the API Explorer.
+1. Add logic to your service to set the `fern_token` cookie when a user logs in.
 
 <Accordion title="Example: Complete callback endpoint">
 This Next.js endpoint handles the callback from your authentication page. It reads the `state` parameter to determine where to redirect the user, mints a `fern_token` JWT using [jose](https://github.com/panva/jose), sets it as a cookie, and redirects the user back to the docs.
@@ -182,9 +283,7 @@ async function mintFernToken({
 </Tab>
 <Tab title="OAuth">
 
-Configure OAuth authentication so that Fern can securely retrieve API keys for your users through your OAuth provider. Here's how the process works:
-
-1. When a user clicks the "Login" button in the API Explorer, Fern initiates an OAuth flow by making a request to your authorization endpoint.
+1. When a user clicks the **Login** button in the API Explorer, Fern initiates an OAuth flow by making a request to your authorization endpoint.
 1. The user is redirected to your OAuth provider's login page where they authenticate using your existing auth system.
 1. After successful authentication, your OAuth provider redirects back to Fern with an authorization code, which Fern exchanges for an access token at your token endpoint.
 1. Fern sets a `fern_token` cookie containing the user's authentication credentials and automatically populates their API key in the API Explorer.
@@ -193,15 +292,15 @@ Configure OAuth authentication so that Fern can securely retrieve API keys for y
 <Markdown src="/snippets/oauth-diagram.mdx"/>
 </Accordion>
 
-#### Set up autopopulated API keys
+#### Set up
 
-To enable API key injection:
+To enable API key injection with OAuth:
 1. Set up an authenticated account for Fern so Fern can authorize users on your behalf.
-1. Configure your OAuth application to return user API keys when Fern requests them
+1. Configure your OAuth application to return user API keys when Fern requests them.
 
 Then, send Fern the following items:
 - The client ID and client secret for Fern's authenticated account
-- The URL of your authentication endpoint. This is where users will be redirected to after clicking the "Login" button in the API Explorer.
+- The URL of your authentication endpoint. This is where users are redirected after clicking the **Login** button in the API Explorer.
 - The URL of your token endpoint. This is where Fern exchanges codes for tokens.
 
 </Tab>

--- a/fern/products/docs/pages/changelog/2026-02-11.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-11.mdx
@@ -1,0 +1,9 @@
+## API key injection for self-hosted docs
+
+Self-hosted deployments now support [API key injection](/learn/docs/authentication/api-key-injection) via environment variables. Enable `FERN_API_KEY_INJECTION_ENABLED` to show a **Login** button in the API Explorer without requiring login for the entire site. Use `FERN_AUTH_ALLOWLIST` and `FERN_AUTH_DENYLIST` to control page-level access.
+
+Learn more about [self-hosted authentication](/learn/docs/self-hosted/authentication#api-key-injection).
+
+## Multiple API keys and per-environment keys
+
+API key injection now supports [multiple API keys](/learn/docs/authentication/api-key-injection#multiple-api-keys) and [per-environment credentials](/learn/docs/authentication/api-key-injection#per-environment-keys). Provide multiple keys as a JSON-encoded array in `bearer_token`, and use `env_state` to set different credentials per environment with substring matching.

--- a/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
@@ -179,3 +179,47 @@ Setting `FERN_AUTH_TEST_LOGIN="true"` enables the `/__test-login` endpoint on th
 <Warning>
 The test login page is intended for development and testing only. Do not enable `FERN_AUTH_TEST_LOGIN` in production environments.
 </Warning>
+
+## Page-level access control
+
+By default, all pages require authentication when auth is enabled. Use `FERN_AUTH_ALLOWLIST` and `FERN_AUTH_DENYLIST` to control which pages require login. Both accept comma-separated regex patterns matched against page paths.
+
+| Variable | Description |
+|---|---|
+| `FERN_AUTH_ALLOWLIST` | Pages matching these patterns are publicly accessible without login. |
+| `FERN_AUTH_DENYLIST` | Pages matching these patterns require login. Takes precedence over the allowlist. |
+
+For example, to make all pages publicly accessible:
+
+```dockerfile
+ENV FERN_AUTH_ALLOWLIST="/(.*)"
+```
+
+To make only API reference pages require login:
+
+```dockerfile
+ENV FERN_AUTH_DENYLIST="/api-reference/(.*)"
+```
+
+## API key injection
+
+You can enable [API key injection](/learn/docs/authentication/api-key-injection) in the API Explorer for self-hosted deployments. This shows a **Login** button in the API Explorer so users can authenticate and have their API keys auto-populated, without requiring login for the entire documentation site.
+
+Add `FERN_API_KEY_INJECTION_ENABLED` to your Dockerfile alongside the basic token verification variables:
+
+```dockerfile
+FROM fernapi/fern-self-hosted:<latest-tag>
+
+COPY fern/ /fern/
+
+ENV FERN_AUTH_TYPE="basic_token_verification"
+ENV FERN_AUTH_SECRET="my-test-secret-at-least-32-chars-long"
+ENV FERN_AUTH_ISSUER="https://my-test-issuer"
+ENV FERN_AUTH_REDIRECT="https://your-login-page.com/login"
+ENV FERN_API_KEY_INJECTION_ENABLED="true"
+ENV FERN_AUTH_ALLOWLIST="/(.*)"
+
+RUN fern-generate
+```
+
+With `FERN_AUTH_ALLOWLIST="/(.*)"`, all doc pages are publicly accessible (no login wall), but the API Explorer still shows the **Login** button. When a user logs in, their JWT's `fern` payload is read and the API key is injected into the API Explorer. See [Autopopulate API keys](/learn/docs/authentication/api-key-injection) for the full `fern` payload reference.

--- a/fern/products/docs/pages/enterprise/self-hosted.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted.mdx
@@ -21,7 +21,7 @@ Unless you have specific requirements that prevent using Fern's default hosting,
 
 Self-hosted deployments include core Fern documentation website features like auto-generated API references, interactive documentation, SDK code snippets, search, and customizable branding. 
 
-However, features requiring external connections aren't supported, including [Ask Fern](/learn/docs/ai-features/ask-fern/overview) (AI chat), [analytics](/learn/docs/integrations/overview), [live API key population](/learn/docs/authentication/api-key-injection), and [SSO integrations](/learn/docs/authentication/sso).
+However, features requiring external connections aren't supported, including [Ask Fern](/learn/docs/ai-features/ask-fern/overview) (AI chat), [analytics](/learn/docs/integrations/overview), and [SSO integrations](/learn/docs/authentication/sso). [API key injection](/learn/docs/authentication/api-key-injection) is supported via environment variables; see [Self-hosted authentication](/learn/docs/self-hosted/authentication) for details.
 
 <Info title="Extended feature support">
 **PDF export** and **offline AI chat functionality** are not yet available on any plan but are in development for enterprise self-hosted deployments. [Email us](mailto:support@buildwithfern.com) if you're interested in these features.
@@ -57,7 +57,7 @@ sequenceDiagram
 
 ## Monitoring and health checks
 
-The self-hosted container includes [health check endpoints](./health-check-endpoints) on port 8081 for Kubernetes and Helm deployments.  
+The self-hosted container includes [health check endpoints](./health-check-endpoints) on port 8081 for Kubernetes and Helm deployments.    
 
 
 

--- a/fern/products/docs/pages/enterprise/self-hosted.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted.mdx
@@ -21,7 +21,7 @@ Unless you have specific requirements that prevent using Fern's default hosting,
 
 Self-hosted deployments include core Fern documentation website features like auto-generated API references, interactive documentation, SDK code snippets, search, and customizable branding. 
 
-However, features requiring external connections aren't supported, including [Ask Fern](/learn/docs/ai-features/ask-fern/overview) (AI chat), [analytics](/learn/docs/integrations/overview), and [SSO integrations](/learn/docs/authentication/sso). [API key injection](/learn/docs/authentication/api-key-injection) is supported via environment variables; see [Self-hosted authentication](/learn/docs/self-hosted/authentication) for details.
+However, features requiring external connections aren't supported, including [Ask Fern](/learn/docs/ai-features/ask-fern/overview) (AI chat), [analytics](/learn/docs/integrations/overview), and [SSO integrations](/learn/docs/authentication/sso).
 
 <Info title="Extended feature support">
 **PDF export** and **offline AI chat functionality** are not yet available on any plan but are in development for enterprise self-hosted deployments. [Email us](mailto:support@buildwithfern.com) if you're interested in these features.
@@ -57,7 +57,7 @@ sequenceDiagram
 
 ## Monitoring and health checks
 
-The self-hosted container includes [health check endpoints](./health-check-endpoints) on port 8081 for Kubernetes and Helm deployments.    
+The self-hosted container includes [health check endpoints](./health-check-endpoints) on port 8081 for Kubernetes and Helm deployments.        
 
 
 


### PR DESCRIPTION
# docs: rewrite API key injection page and update self-hosted auth docs

## Summary

Based on [fern-platform PR #6995](https://github.com/fern-api/fern-platform/pull/6995) (self-hosted API key injection support), this PR makes the following documentation changes:

1. **Rewrites the API key injection page** (`autopopulate-api-key.mdx`) to lead with the `fern` JWT payload structure instead of the auth integration flow. Adds new sections for:
   - Multiple API keys (JSON-encoded array of `{appName: key}` objects in `bearer_token`)
   - Per-environment keys via `env_state` with substring matching
   - Combined multi-key + multi-environment example

2. **Updates self-hosted authentication page** with two new sections:
   - `FERN_AUTH_ALLOWLIST` / `FERN_AUTH_DENYLIST` for page-level access control
   - `FERN_API_KEY_INJECTION_ENABLED` env var with a full Dockerfile example and link to the main API key injection page

3. **Updates self-hosted overview** — removes "live API key population" from the unsupported features list (it is now supported via env vars).

4. **Adds changelog entry** (`2026-02-11.mdx`) for API key injection on self-hosted and multiple API keys / per-environment keys.

### Local testing

Pages were tested locally via `fern docs dev`. Code blocks, tables, links, and tabs all render correctly.

![API key injection page - payload section](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOiJlbWFpbHw2OTE0OTBlNjAyNWJlOGY4YTEyOTY3NGIiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfc2JkaXJzeHp5eHRjdHphai9jZTJmYjNmZi00MGM4LTQ0ZjctYWE4OC0xNjFjZDRlYWI3MTgiLCJpYXQiOjE3NzA3NzA2MzAsImV4cCI6MTc3MTM3NTQzMH0.kVPtzdOyUiVe_5T_xvzt-fme5puCeY-U4tx9yuP9smU)
![Self-hosted auth page - new sections](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOiJlbWFpbHw2OTE0OTBlNjAyNWJlOGY4YTEyOTY3NGIiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfc2JkaXJzeHp5eHRjdHphai9mYzI1NGFkMC1mOGExLTRiMDctOGJlYS04ZmZiMzlmNGFkMmMiLCJpYXQiOjE3NzA3NzA2MzAsImV4cCI6MTc3MTM3NTQzMH0.7usAppuAR3JhkAhZs2lejeWY_MdIzNb-kgzD3KqxE-A)

## Review & Testing Checklist for Human

- [ ] **Verify multiple API keys format**: The documented format `"[{\"App\": \"key\"}, ...]"` is based on the `cache-proxy.js` code in PR #6995. Confirm the frontend API Explorer actually parses this JSON-encoded string and renders a dropdown.
- [ ] **Verify `env_state` merge semantics**: The page states "auth is replaced entirely, while headers/params are shallow-merged." This matches the `resolveEndpointEnvironmentState` function — confirm this is accurate for the user-facing behavior.
- [ ] **Check rendered links**: Verify that anchor links in the changelog entry (`#multiple-api-keys`, `#per-environment-keys`, `#api-key-injection`) resolve correctly on the preview. Also confirm the cross-page links from self-hosted auth → API key injection page work.
- [ ] **Preview the pages**: Check that the new JSON code blocks, tables, and CodeBlocks render correctly — especially the escaped JSON strings in the multiple-keys examples.

### Notes
- The existing JWT/OAuth integration tabs and code examples are preserved and moved below the new payload-focused content.
- The removed line "With this feature, you can **create new users of your API** directly from within your documentation" was intentional — it was marketing copy not relevant to the payload-focused rewrite.
- The self-hosted overview no longer mentions API key injection at all (per reviewer request) — it just removes it from the unsupported list.

[Link to Devin run](https://app.devin.ai/sessions/76769bd284554cbf870a26a619027f85)
Requested by: @thesandlord