### PR TITLE
docs: fix Vale style warnings from API key injection docs

### DIFF
--- a/fern/products/docs/pages/api-references/autopopulate-api-key.mdx
+++ b/fern/products/docs/pages/api-references/autopopulate-api-key.mdx
@@ -74,7 +74,7 @@ The `initial_state.auth` object supports bearer token and basic authentication.
 
 ### Custom headers and parameters
 
-You can pre-fill headers, path parameters, and query parameters in addition to (or instead of) auth credentials. Values are applied to any matching fields in the API Explorer.
+You can also pre-fill headers, path parameters, and query parameters instead of (or along with) auth credentials. Values are applied to any matching fields in the API Explorer.
 
 ```json
 {
@@ -121,7 +121,7 @@ The API Explorer displays a dropdown so the user can choose which application ke
 
 ### Per-environment keys
 
-Use `env_state` to provide different credentials for each environment (for example, production vs. staging). Each key in `env_state` is matched against the currently selected environment URL using substring matching.
+Use `env_state` to provide different credentials for each environment (for example, production vs. staging). Each key in `env_state` is matched against the selected environment URL using substring matching.
 
 ```json
 {
@@ -184,7 +184,7 @@ API key injection requires a JWT containing the `fern` payload described above t
 <Tabs>
 <Tab title="JWT">
 
-1. When a user clicks the **Login** button in the API Explorer, they are redirected to your authentication page.
+1. When a user clicks the **Login** button in the API Explorer, they're redirected to your authentication page.
 2. After successful authentication, your system sets a cookie called `fern_token` in the user's browser.
 3. This token is a [JWT](https://jwt.io) signed with a secret key from Fern. The JWT payload contains the `fern` claim with the user's API key.
 

--- a/fern/products/docs/pages/changelog/2026-02-11.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-11.mdx
@@ -1,9 +1,9 @@
 ## API key injection for self-hosted docs
 
-Self-hosted deployments now support [API key injection](/learn/docs/authentication/api-key-injection) via environment variables. Enable `FERN_API_KEY_INJECTION_ENABLED` to show a **Login** button in the API Explorer without requiring login for the entire site. Use `FERN_AUTH_ALLOWLIST` and `FERN_AUTH_DENYLIST` to control page-level access.
+Self-hosted deployments support [API key injection](/learn/docs/authentication/api-key-injection) via environment variables. Enable `FERN_API_KEY_INJECTION_ENABLED` to show a **Login** button in the API Explorer without requiring login for the entire site. Use `FERN_AUTH_ALLOWLIST` and `FERN_AUTH_DENYLIST` to control page-level access.
 
 Learn more about [self-hosted authentication](/learn/docs/self-hosted/authentication#api-key-injection).
 
 ## Multiple API keys and per-environment keys
 
-API key injection now supports [multiple API keys](/learn/docs/authentication/api-key-injection#multiple-api-keys) and [per-environment credentials](/learn/docs/authentication/api-key-injection#per-environment-keys). Provide multiple keys as a JSON-encoded array in `bearer_token`, and use `env_state` to set different credentials per environment with substring matching.
+API key injection supports [multiple API keys](/learn/docs/authentication/api-key-injection#multiple-api-keys) and [per-environment credentials](/learn/docs/authentication/api-key-injection#per-environment-keys). Provide multiple keys as a JSON-encoded array in `bearer_token`, and use `env_state` to set different credentials per environment with substring matching.

--- a/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
@@ -195,7 +195,7 @@ For example, to make all pages publicly accessible:
 ENV FERN_AUTH_ALLOWLIST="/(.*)"
 ```
 
-To make only API reference pages require login:
+To make only API Reference pages require login:
 
 ```dockerfile
 ENV FERN_AUTH_DENYLIST="/api-reference/(.*)"


### PR DESCRIPTION
# docs: fix Vale style warnings from API key injection docs

## Summary

Fixes Vale style warnings left over from #3579. All changes are minor wording tweaks across three files:

- **autopopulate-api-key.mdx**: "in addition to" → "also" (Microsoft.Wordiness), "currently selected" → "selected" (FernStyles.Current), "they are" → "they're" (Microsoft.Contractions)
- **self-hosted-authentication.mdx**: "API reference" → "API Reference" (FernStyles.Reject)
- **changelog/2026-02-11.mdx**: Remove "now" x2 (FernStyles.Current)

## Review & Testing Checklist for Human

- [ ] Verify the reworded sentence on line 77 of `autopopulate-api-key.mdx` ("You can also pre-fill ... instead of (or along with) auth credentials") reads naturally — the original was "in addition to (or instead of)" and the meaning shifted slightly during the Vale fix

### Notes

- These warnings were reported by Vale on PR #3579 but that PR was merged before they were addressed.
- No structural or functional changes; prose-only edits.

[Link to Devin run](https://app.devin.ai/sessions/76769bd284554cbf870a26a619027f85)
Requested by: @thesandlord