### PR TITLE
docs: document Schema component `description`, `api`, `exclude`, `excludeDeprecated` props

### DIFF
--- a/fern/products/docs/pages/component-library/default-components/schema.mdx
+++ b/fern/products/docs/pages/component-library/default-components/schema.mdx
@@ -31,6 +31,22 @@ The component works with [API references already configured in your `docs.yml`](
   The name of the type to display. The component will search for this type across all endpoints in your API definition.
 </ParamField>
 
+<ParamField path="api" type="string" required={false}>
+  The name of the API to fetch the type from. If not specified, the type will be fetched from the first API that contains it.
+</ParamField>
+
+<ParamField path="description" type="boolean" required={false}>
+  If `true`, includes the type definition's description above the schema fields. This is useful for displaying comments associated with the type, such as Protobuf message comments.
+</ParamField>
+
+<ParamField path="exclude" type="string[]" required={false}>
+  A list of field names to exclude from the rendered schema.
+</ParamField>
+
+<ParamField path="excludeDeprecated" type="boolean" required={false}>
+  If `true`, hides deprecated fields from the rendered schema.
+</ParamField>
+
 <ParamField path="className" type="string" required={false}>
   Optional CSS class name for custom styling.
 </ParamField>


### PR DESCRIPTION
## Summary

Adds documentation for 4 previously undocumented props on the `<Schema>` component:

- **`api`** – select which API to fetch the type from (existing prop, was undocumented)
- **`description`** – render the type's description above the fields, e.g. Protobuf message comments (new prop from [fern-platform#7029](https://github.com/fern-api/fern-platform/pull/7029))
- **`exclude`** – hide specific fields by name (existing prop, was undocumented)
- **`excludeDeprecated`** – hide deprecated fields (existing prop, was undocumented)

## Review & Testing Checklist for Human

- [ ] Verify the `description` prop documentation is accurate against the implementation in [fern-platform#7029](https://github.com/fern-api/fern-platform/pull/7029) — that PR must be merged for this prop to work
- [ ] Confirm `exclude` accepts `string[]` (array of field names) — matches the `SchemaProps` type in `Schema.tsx`
- [ ] Consider whether a live usage example for the `description` prop should be added to the page (currently only the Properties table is updated, no example block)

### Notes

The `description` prop is the main new feature; the other three props (`api`, `exclude`, `excludeDeprecated`) already existed in the component but were never documented.

[Link to Devin run](https://app.devin.ai/sessions/b78693a1dc7b4885a882925a9a9bc375) | Requested by: @thesandlord