### PR TITLE
docs: add POST support for self-hosted JWT callback endpoint

### DIFF
--- a/fern/products/docs/pages/changelog/2026-02-12.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-12.mdx
@@ -1,5 +1,5 @@
-## POST support for self-hosted JWT callback
+## POST support for JWT callback
 
-The self-hosted JWT callback endpoint (`/api/fern-docs/auth/jwt/callback`) now accepts `POST` requests with `application/x-www-form-urlencoded` body in addition to `GET` requests with query parameters. POST avoids exposing JWT tokens in URLs and server logs.
+The JWT callback endpoint (`/api/fern-docs/auth/jwt/callback`) now accepts `POST` requests with `application/x-www-form-urlencoded` body in addition to `GET` requests with query parameters. POST avoids exposing JWT tokens in URLs and server logs.
 
 Learn more about [self-hosted authentication](/learn/docs/self-hosted/authentication#basic-token-verification).

--- a/fern/products/docs/pages/changelog/2026-02-12.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-12.mdx
@@ -2,4 +2,4 @@
 
 The JWT callback endpoint (`/api/fern-docs/auth/jwt/callback`) now accepts `POST` requests with `application/x-www-form-urlencoded` body in addition to `GET` requests with query parameters. POST avoids exposing JWT tokens in URLs and server logs.
 
-Learn more about [self-hosted authentication](/learn/docs/self-hosted/authentication#basic-token-verification).
+Learn more about [authentication](/learn/docs/authentication/overview).

--- a/fern/products/docs/pages/changelog/2026-02-12.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-12.mdx
@@ -1,0 +1,5 @@
+## POST support for self-hosted JWT callback
+
+The self-hosted JWT callback endpoint (`/api/fern-docs/auth/jwt/callback`) now accepts `POST` requests with `application/x-www-form-urlencoded` body in addition to `GET` requests with query parameters. POST avoids exposing JWT tokens in URLs and server logs.
+
+Learn more about [self-hosted authentication](/learn/docs/self-hosted/authentication#basic-token-verification).

--- a/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
@@ -42,7 +42,7 @@ Basic token verification uses JWTs (JSON Web Tokens) to authenticate users. This
 1. An unauthenticated user visits the docs and is redirected to your login page (`FERN_AUTH_REDIRECT`).
 2. Your login page authenticates the user (e.g., checking credentials against your database).
 3. After successful authentication, your server creates a signed JWT using the shared secret.
-4. Your server redirects the user to the Fern callback endpoint (`/api/fern-docs/auth/jwt/callback`) with the JWT as a query parameter.
+4. Your server sends the user to the Fern callback endpoint (`/api/fern-docs/auth/jwt/callback`) with the JWT. This can be done via a **GET** redirect with the token as a query parameter, or via a **POST** request with the token in a `application/x-www-form-urlencoded` body.
 5. The Fern docs container verifies the JWT signature and issuer, sets a session cookie, and redirects the user to the docs.
 
 ### Configuration
@@ -82,7 +82,9 @@ Your server must:
 
 1. Authenticate the user.
 2. Create a JWT signed with the same `FERN_AUTH_SECRET` using the HS256 algorithm.
-3. Redirect the user to the `redirect_uri` with the JWT as the `fern_token` query parameter and the original `state` as the return-to URL.
+3. Send the user to the `redirect_uri` with the JWT as `fern_token` and the original `state` as the return-to path. You can use either method:
+   - **GET redirect**: Append `fern_token` and `state` as query parameters.
+   - **POST form submission**: Submit `fern_token` and `state` as `application/x-www-form-urlencoded` fields. POST avoids exposing the token in URLs and server logs.
 
 The JWT payload must include the following claims:
 
@@ -95,6 +97,8 @@ The JWT payload must include the following claims:
 
 Here is an example Node.js (Express) server that signs a JWT and redirects to the callback:
 
+<Tabs>
+<Tab title="GET (query parameters)">
 ```javascript
 const express = require("express");
 const crypto = require("crypto");
@@ -149,6 +153,70 @@ app.listen(3001, () => {
   console.log("Login server running on http://localhost:3001");
 });
 ```
+</Tab>
+<Tab title="POST (form body)">
+```javascript
+const express = require("express");
+const crypto = require("crypto");
+
+const app = express();
+
+const SECRET = "my-test-secret-at-least-32-chars-long";
+const ISSUER = "https://my-test-issuer";
+
+function base64url(input) {
+  const buf = Buffer.isBuffer(input) ? input : Buffer.from(input, "utf8");
+  return buf.toString("base64").replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function createFernJWT(secret, issuer) {
+  const header = { alg: "HS256", typ: "JWT" };
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    fern: {},
+    iat: now,
+    exp: now + 30 * 24 * 60 * 60, // 30 days
+    iss: issuer,
+  };
+
+  const headerB64 = base64url(JSON.stringify(header));
+  const payloadB64 = base64url(JSON.stringify(payload));
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(`${headerB64}.${payloadB64}`)
+    .digest();
+
+  return `${headerB64}.${payloadB64}.${base64url(signature)}`;
+}
+
+app.get("/login", (req, res) => {
+  const redirectUri = req.query.redirect_uri;
+  const state = req.query.state || "/";
+
+  // TODO: Add your own authentication logic here
+  // (e.g., check session, verify credentials, show a login form, etc.)
+
+  const token = createFernJWT(SECRET, ISSUER);
+
+  res.send(`
+    <html>
+      <body>
+        <form method="POST" action="${redirectUri}">
+          <input type="hidden" name="fern_token" value="${token}" />
+          <input type="hidden" name="state" value="${state}" />
+        </form>
+        <script>document.forms[0].submit();</script>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(3001, () => {
+  console.log("Login server running on http://localhost:3001");
+});
+```
+</Tab>
+</Tabs>
 
 <Warning>
 The `FERN_AUTH_SECRET` in your login server must exactly match the secret set in the Dockerfile. If they differ, JWT verification will fail and users will not be able to log in.

--- a/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
@@ -42,7 +42,7 @@ Basic token verification uses JWTs (JSON Web Tokens) to authenticate users. This
 1. An unauthenticated user visits the docs and is redirected to your login page (`FERN_AUTH_REDIRECT`).
 2. Your login page authenticates the user (e.g., checking credentials against your database).
 3. After successful authentication, your server creates a signed JWT using the shared secret.
-4. Your server sends the user to the Fern callback endpoint (`/api/fern-docs/auth/jwt/callback`) with the JWT. This can be done via a **GET** redirect with the token as a query parameter, or via a **POST** request with the token in a `application/x-www-form-urlencoded` body.
+4. Your server sends the user to the Fern callback endpoint (`/api/fern-docs/auth/jwt/callback`) with the JWT. This can be done via a **GET** redirect with the token as a query parameter, or via a **POST** request with the token in an `application/x-www-form-urlencoded` body.
 5. The Fern docs container verifies the JWT signature and issuer, sets a session cookie, and redirects the user to the docs.
 
 ### Configuration


### PR DESCRIPTION
# docs: add POST support for self-hosted JWT callback endpoint

## Summary

Updates the self-hosted authentication docs to reflect that the JWT callback endpoint (`/api/fern-docs/auth/jwt/callback`) now supports `POST` with `application/x-www-form-urlencoded` body, in addition to the existing `GET` query parameter flow. This documents the feature added in [fern-platform#7059](https://github.com/fern-api/fern-platform/pull/7059).

Changes:
- Updated the "How it works" and "Building your login server" sections to describe both GET and POST methods
- Wrapped the existing Node.js example in `<Tabs>` with a new POST tab showing an auto-submitting HTML form pattern
- Added a changelog entry for 2026-02-12

## Updates since last revision
- Fixed grammar: "in a `application/x-www-form-urlencoded`" → "in an `application/x-www-form-urlencoded`" (line 45 of auth doc)

## Review & Testing Checklist for Human

- [ ] **Verify the changelog link** `/learn/docs/self-hosted/authentication#basic-token-verification` resolves to the correct page and anchor in the preview
- [ ] **Check `<Tabs>` rendering** in the preview — confirm both GET and POST tabs display and switch correctly
- [ ] **XSS in POST example**: The template literal injects `redirectUri` and `token` directly into HTML without escaping. Acceptable for a documentation example, but worth a conscious decision since users may copy-paste this into production code

**Suggested test plan**: Open the preview link, navigate to the self-hosted authentication page, and verify the tabbed code examples render correctly. Check the changelog page for the new entry.

### Notes
- Vale CI check passed
- The POST tab duplicates the `base64url`/`createFernJWT` helper code from the GET tab to keep each example self-contained
- Local testing confirmed all sections render correctly (tabs, changelog entry, formatting)

[Link to Devin run](https://app.devin.ai/sessions/0af91a96e6b94eb8921a58b615004ef8) | Requested by @thesandlord