### PR TITLE
Add `import_paths` config documentation for Python SDK generator

### DIFF
--- a/fern/products/sdks/overview/python/configuration.mdx
+++ b/fern/products/sdks/overview/python/configuration.mdx
@@ -109,7 +109,7 @@ When enabled, generates a flatter package structure by reducing nested directori
 
 <ParamField path="import_paths" type="array of strings" default="null" required={false} toc={true}>
 Paths to files that are automatically imported when the SDK package is loaded. This is useful for running custom
-setup code — such as Sentry integration, logging configuration, or telemetry hooks — without modifying generated code.
+setup code, such as Sentry integration, logging configuration, or telemetry hooks without modifying generated code.
 
 Each entry is a module name relative to the package root (omit the `.py` extension). The SDK will attempt to import each
 module at package initialization time; missing files are skipped.
@@ -119,16 +119,6 @@ config:
   import_paths:
     - sentry_integration
     - custom_logging
-```
-
-The generated root `__init__.py` will include:
-
-```python
-for _path in ["sentry_integration", "custom_logging"]:
-    try:
-        import_module(f".{_path}", "<package_name>")
-    except ImportError:
-        pass
 ```
 
 <Note>

--- a/fern/products/sdks/overview/python/configuration.mdx
+++ b/fern/products/sdks/overview/python/configuration.mdx
@@ -107,6 +107,35 @@ When enabled, generates a flatter package structure by reducing nested directori
   Feature flag that improves imports in the Python SDK by removing nested `resources` directory
 </ParamField>
 
+<ParamField path="import_paths" type="array of strings" default="null" required={false} toc={true}>
+Paths to files that are automatically imported when the SDK package is loaded. This is useful for running custom
+setup code — such as Sentry integration, logging configuration, or telemetry hooks — without modifying generated code.
+
+Each entry is a module name relative to the package root (omit the `.py` extension). The SDK will attempt to import each
+module at package initialization time; missing files are silently skipped.
+
+```yaml
+config:
+  import_paths:
+    - sentry_integration
+    - custom_logging
+```
+
+The generated root `__init__.py` will include:
+
+```python
+for _path in ["sentry_integration", "custom_logging"]:
+    try:
+        import_module(f".{_path}", "<package_name>")
+    except ImportError:
+        pass
+```
+
+<Note>
+  Files listed in `import_paths` must also be added to `.fernignore` so they are not overwritten during generation.
+</Note>
+</ParamField>
+
 <ParamField path="include_legacy_wire_tests" type="bool" default="false" required={false} toc={true}>
   Whether or not to include legacy wire tests in the generated SDK
 </ParamField>

--- a/fern/products/sdks/overview/python/configuration.mdx
+++ b/fern/products/sdks/overview/python/configuration.mdx
@@ -112,7 +112,7 @@ Paths to files that are automatically imported when the SDK package is loaded. T
 setup code — such as Sentry integration, logging configuration, or telemetry hooks — without modifying generated code.
 
 Each entry is a module name relative to the package root (omit the `.py` extension). The SDK will attempt to import each
-module at package initialization time; missing files are silently skipped.
+module at package initialization time; missing files are skipped.
 
 ```yaml
 config:
@@ -132,7 +132,7 @@ for _path in ["sentry_integration", "custom_logging"]:
 ```
 
 <Note>
-  Files listed in `import_paths` must also be added to `.fernignore` so they are not overwritten during generation.
+  Files listed in `import_paths` must also be added to `.fernignore` so they're not overwritten during generation.
 </Note>
 </ParamField>
 


### PR DESCRIPTION
## Summary

Adds documentation for the `import_paths` configuration option on the Python SDK configuration page. This feature (introduced in Python SDK generator v4.53.0) allows users to specify files that are automatically imported when the SDK package is loaded, enabling custom setup code (e.g., Sentry integration, logging) without modifying generated code.

The new `ParamField` entry is inserted in alphabetical order between `improved_imports` and `include_legacy_wire_tests`, consistent with the existing page structure.

Only the Python SDK generator supports `import_paths` — confirmed by searching across all specified repos (`fern`, `fern-platform`, `docs`, `fern-autopilot`, `venus`, `fiddle`, `workspace`, `twilio-core-fern-config`, `twilio-core-python-sdk`, `docs-starter`, `scribe-editing-environment`, `SEO`, `olimar`).

### Updates since last revision
- Fixed vale lint warnings: removed adverb ("silently skipped" → "skipped") and used contraction ("they are" → "they're").

### Local testing
Verified the page renders correctly via `fern docs dev`:

![Local docs preview showing import_paths section](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOiJlbWFpbHw2OGYxMzJkZDE0YzE2ODY1NTc1OTBmMDQiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfc2JkaXJzeHp5eHRjdHphai9kYTE3OGVlZC02NWM1LTQxMjYtYWZjZi04NDk5ZmQwNzVlOWMiLCJpYXQiOjE3NzEzMzg3MzQsImV4cCI6MTc3MTk0MzUzNH0.msbHc-6Cb25SCy3Cr_NeJ_cZrqOTZZHnIw5X4YzumRo)

## Review & Testing Checklist for Human

- [ ] Verify the generated Python code snippet in the docs matches what the generator actually produces (compare against [`seed/python-sdk/exhaustive/import-paths/src/seed/__init__.py`](https://github.com/fern-api/fern/blob/main/seed/python-sdk/exhaustive/import-paths/src/seed/__init__.py) in `fern-api/fern`)
- [ ] Check the [rendered preview](https://fern-preview-4dbe865c-75f0-4df5-8992-bf7a589cbb18.docs.buildwithfern.com/learn/sdks/generators/python/configuration) to confirm the `ParamField`, YAML/Python code blocks, and `<Note>` render correctly
- [ ] Confirm the `.fernignore` guidance in the `<Note>` is appropriate advice for this feature

### Notes
- Link to Devin run: https://app.devin.ai/sessions/f59fbb17efd44f40b612474c9c9a10d1
- Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/3651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
