### PR TITLE
Add logging documentation for Python SDK generator

### DIFF
--- a/fern/products/sdks/overview/python/logging.mdx
+++ b/fern/products/sdks/overview/python/logging.mdx
@@ -78,7 +78,7 @@ The SDK logs HTTP request and response metadata at appropriate levels:
 | Error response (4xx/5xx) | `error` | Method, URL, status code, redacted response headers |
 
 <Note>
-Sensitive headers such as `Authorization`, `Cookie`, `X-API-Key`, and `X-CSRF-Token` are automatically replaced with `[REDACTED]` in all log output. This prevents accidental leakage of credentials in logs.
+Sensitive headers such as `Authorization`, `Cookie`, `X-API-Key`, and `X-CSRF-Token` (Cross-Site Request Forgery) are automatically replaced with `[REDACTED]` in all log output. This prevents accidental leakage of credentials in logs.
 </Note>
 
 ## Configuration reference

--- a/fern/products/sdks/overview/python/logging.mdx
+++ b/fern/products/sdks/overview/python/logging.mdx
@@ -1,0 +1,96 @@
+---
+title: Logging
+description: Configure logging in your generated Python SDK to debug HTTP requests and responses.
+---
+
+Generated Python SDKs include a built-in configurable logging system. Logging is **silent by default** and can be enabled by passing a `logging` parameter to the client constructor.
+
+## Basic usage
+
+```python
+from my_sdk import MyClient
+from my_sdk.core import LogConfig
+
+client = MyClient(
+    token="YOUR_TOKEN",
+    logging=LogConfig(
+        level="debug",   # "debug" | "info" | "warn" | "error"
+        silent=False,     # must be False to enable output
+    ),
+)
+```
+
+## Using a pre-configured Logger instance
+
+You can create a `Logger` instance and reuse it across multiple clients:
+
+```python
+from my_sdk import MyClient
+from my_sdk.core import Logger, ConsoleLogger
+
+logger = Logger(level="debug", logger=ConsoleLogger(), silent=False)
+
+client = MyClient(
+    token="YOUR_TOKEN",
+    logging=logger,
+)
+```
+
+## Custom logger implementation
+
+Supply your own logger by implementing the `ILogger` protocol. Any class that defines `debug`, `info`, `warn`, and `error` methods is compatible:
+
+```python
+from my_sdk import MyClient
+from my_sdk.core import LogConfig
+
+class MyCustomLogger:
+    def debug(self, message: str, **kwargs) -> None:
+        print(f"[DEBUG] {message}", kwargs)
+
+    def info(self, message: str, **kwargs) -> None:
+        print(f"[INFO] {message}", kwargs)
+
+    def warn(self, message: str, **kwargs) -> None:
+        print(f"[WARN] {message}", kwargs)
+
+    def error(self, message: str, **kwargs) -> None:
+        print(f"[ERROR] {message}", kwargs)
+
+client = MyClient(
+    token="YOUR_TOKEN",
+    logging=LogConfig(
+        logger=MyCustomLogger(),
+        silent=False,
+    ),
+)
+```
+
+## What gets logged
+
+The SDK logs HTTP request and response metadata at appropriate levels:
+
+| Event | Level | Details |
+|---|---|---|
+| Outgoing HTTP request | `debug` | Method, URL, redacted headers |
+| Outgoing streaming request | `debug` | Method, URL, redacted headers |
+| Successful response (2xx/3xx) | `debug` | Method, URL, status code, redacted response headers |
+| Error response (4xx/5xx) | `error` | Method, URL, status code, redacted response headers |
+
+<Note>
+Sensitive headers such as `Authorization`, `Cookie`, `X-API-Key`, and `X-CSRF-Token` are automatically replaced with `[REDACTED]` in all log output. This prevents accidental leakage of credentials in logs.
+</Note>
+
+## Configuration reference
+
+<ParamField path="level" type="'debug' | 'info' | 'warn' | 'error'" default="info">
+  The minimum log level. Messages below this level are suppressed.
+</ParamField>
+
+<ParamField path="logger" type="ILogger" default="ConsoleLogger()">
+  The logger implementation to use. The default `ConsoleLogger` uses Python's built-in `logging` module with a `"fern"` logger name.
+</ParamField>
+
+<ParamField path="silent" type="bool" default="true">
+  When `True`, suppresses all log output regardless of the configured level. Set to `False` to enable logging.
+</ParamField>

--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -78,6 +78,9 @@ navigation:
           - page: Dynamic authentication
             path: ./overview/python/dynamic-authentication.mdx
             slug: dynamic-authentication
+          - page: Logging
+            path: ./overview/python/logging.mdx
+            slug: logging
           - changelog: ./overview/python/changelog
             slug: changelog
           - link: Customer showcase


### PR DESCRIPTION
# Add logging documentation for Python SDK generator

## Summary

Adds a new docs page documenting the configurable logging system introduced in the Python SDK generator (via [fern-api/fern#12219](https://github.com/fern-api/fern/pull/12219)). The page covers basic `LogConfig` usage, pre-configured `Logger` instances, custom `ILogger` implementations, a table of what gets logged, and a configuration reference using `<ParamField>` components.

The page is registered in the Python section of the SDK sidebar navigation, between "Dynamic authentication" and the changelog.

## Review & Testing Checklist for Human

- [ ] **Verify `ConsoleLogger` and `ILogger` are actually exported from generated SDKs.** The code examples import these from `my_sdk.core`, but the implementation PR ([#12219](https://github.com/fern-api/fern/pull/12219)) may have only added `LogConfig`, `LogLevel`, `Logger`, and `create_logger` to the generated `core/__init__.py` dynamic imports. If these symbols aren't exported, the "pre-configured Logger instance" example will mislead users. This is the highest priority item.
- [ ] **Preview the rendered page** in the Fern docs site to confirm the MDX renders correctly — particularly the `<ParamField>` components, `<Note>` callout, and the markdown table.
- [ ] **Check that the page URL** (`/learn/sdks/generators/python/logging`) doesn't conflict with any existing redirects in `docs.yml`.

### Notes

- The code examples use `token="YOUR_TOKEN"` as a generic auth placeholder. Actual generated SDKs may use different parameter names depending on auth configuration.
- This PR does **not** add logging docs for TypeScript or other generators — only Python, which is the language that just received the logging feature.

Link to Devin run: https://app.devin.ai/sessions/416c0ce2bffb4596aa37a8563fd7076b
Requested by: @iamnamananand996