### PR TITLE
docs: document custom terminator field for SSE streaming

### DIFF
--- a/fern/products/api-def/openapi-pages/endpoints/sse.mdx
+++ b/fern/products/api-def/openapi-pages/endpoints/sse.mdx
@@ -75,7 +75,7 @@ components:
 ## Custom terminator
 
 Some SSE APIs send a standalone terminator message to signal that the stream is complete. For example, 
-OpenAI's API sends `[DONE]` as a final message. This terminator is not parsed as JSON — it is a raw 
+OpenAI's API sends `[DONE]` as a final message. This terminator isn't parsed as JSON — it's a raw 
 string that indicates the end of the stream.
 
 You can specify a custom terminator using the `terminator` field:

--- a/fern/products/api-def/openapi-pages/endpoints/sse.mdx
+++ b/fern/products/api-def/openapi-pages/endpoints/sse.mdx
@@ -41,7 +41,7 @@ components:
 
 <Markdown src="/snippets/pro-plan.mdx"/>
 
-If your API returns server-sent-events, with the `data` and `event` keys as seen below
+If your API returns server-sent-events (SSE), with the `data` and `event` keys as seen below
 
 ```json
 data: { "text": "Hi, I am a" }
@@ -72,10 +72,10 @@ components:
           type: string
 ```
 
-### Custom terminator
+### Terminator message
 
 Some SSE APIs send a standalone terminator message to signal that the stream is complete. For example, 
-OpenAI's API sends `[DONE]` as a final message. You can specify a custom terminator using the `terminator` field:
+OpenAI's API sends `[DONE]` as a final message. You can specify this with the `terminator` field:
 
 ```yaml title="openapi.yml" {4-6}
 paths:

--- a/fern/products/api-def/openapi-pages/endpoints/sse.mdx
+++ b/fern/products/api-def/openapi-pages/endpoints/sse.mdx
@@ -72,6 +72,36 @@ components:
           type: string
 ```
 
+## Custom terminator
+
+Some SSE APIs send a standalone terminator message to signal that the stream is complete. For example, 
+OpenAI's API sends `[DONE]` as a final message. This terminator is not parsed as JSON — it is a raw 
+string that indicates the end of the stream.
+
+You can specify a custom terminator using the `terminator` field:
+
+```yaml title="openapi.yml" {4-6}
+paths:
+  /logs:
+    post:
+      x-fern-streaming: 
+        format: sse
+        terminator: "[DONE]"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Chat"
+components:
+  schemas:
+    Chat:
+      type: object
+      properties:
+        text:
+          type: string
+```
+
 ## `Stream` parameter
 
 It has become common practice for endpoints to have a `stream` parameter that 
@@ -80,12 +110,13 @@ class way.
 
 Simply specify the `stream-condition` as well as the ordinary response and the streaming response: 
 
-```yaml title="openapi.yml" {4-10}
+```yaml title="openapi.yml" {4-11}
 paths:
   /logs:
     post:
       x-fern-streaming: 
         format: sse
+        terminator: "[DONE]"
         stream-condition: $request.stream
         response: 
           $ref: '#/components/schemas/Chat'

--- a/fern/products/api-def/openapi-pages/endpoints/sse.mdx
+++ b/fern/products/api-def/openapi-pages/endpoints/sse.mdx
@@ -72,13 +72,10 @@ components:
           type: string
 ```
 
-## Custom terminator
+### Custom terminator
 
 Some SSE APIs send a standalone terminator message to signal that the stream is complete. For example, 
-OpenAI's API sends `[DONE]` as a final message. This terminator isn't parsed as JSON — it's a raw 
-string that indicates the end of the stream.
-
-You can specify a custom terminator using the `terminator` field:
+OpenAI's API sends `[DONE]` as a final message. You can specify a custom terminator using the `terminator` field:
 
 ```yaml title="openapi.yml" {4-6}
 paths:
@@ -87,19 +84,6 @@ paths:
       x-fern-streaming: 
         format: sse
         terminator: "[DONE]"
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Chat"
-components:
-  schemas:
-    Chat:
-      type: object
-      properties:
-        text:
-          type: string
 ```
 
 ## `Stream` parameter

--- a/fern/products/api-def/openapi-pages/endpoints/sse.mdx
+++ b/fern/products/api-def/openapi-pages/endpoints/sse.mdx
@@ -81,9 +81,10 @@ OpenAI's API sends `[DONE]` as a final message. You can specify this with the `t
 paths:
   /logs:
     post:
-      x-fern-streaming: 
+      x-fern-streaming:
         format: sse
         terminator: "[DONE]"
+# ... responses and schemas
 ```
 
 ## `Stream` parameter


### PR DESCRIPTION
## Summary

Adds documentation for the `terminator` field in the `x-fern-streaming` SSE configuration. This field allows users to specify a custom standalone message (e.g., `[DONE]`) that signals the end of a stream, which isn't parsed as JSON.

Changes:
- New **Custom terminator** section added between "Server-sent events" and "Stream parameter" sections with a standalone example
- Updated the **Stream parameter** example to also show `terminator` used alongside `stream-condition`

## Updates since last revision
- Fixed vale lint warnings (contractions: "is not" → "isn't", "it is" → "it's")
- Note: the vale warning about "SSE has no definition" is pre-existing on this page and not introduced by this PR

## Review & Testing Checklist for Human
- [ ] Verify the description of `terminator` behavior is accurate (standalone message, not parsed as JSON, signals stream end)
- [ ] Confirm the YAML examples render correctly on the [preview deployment](https://fern-preview-07074266-5b85-49c5-af8f-1ea40d4b52ba.docs.buildwithfern.com/learn/api-definitions/openapi/endpoints/sse) — check highlight ranges (`{4-6}` and `{4-11}`) are correct
- [ ] Check that `terminator` is indeed optional and doesn't require additional fields beyond `format: sse`

### Notes
- Requested by: @aditya-arolkar-swe
- [Link to Devin run](https://app.devin.ai/sessions/4db7d3cf23d449cfaf19caf4abfe59ac)