### PR TITLE
docs: document password protection dashboard feature

### DIFF
--- a/fern/products/dashboard/dashboard.yml
+++ b/fern/products/dashboard/dashboard.yml
@@ -14,6 +14,8 @@ navigation:
       - page: Set up SSO
         path: ./pages/sso.mdx
         slug: sso
+      - page: Password protection
+        path: ./pages/password-protection.mdx
       - page: Custom domains
         path: ./pages/domains.mdx
       - page: PDF export

--- a/fern/products/dashboard/pages/changelog/2026-02-23.mdx
+++ b/fern/products/dashboard/pages/changelog/2026-02-23.mdx
@@ -1,0 +1,7 @@
+## Password protection
+
+You can now enable password protection for your documentation site directly from the Fern Dashboard.
+
+Once enabled, visitors must enter a shared password before viewing any content. You can also reset or remove the password at any time from your site's **Settings** page.
+
+[Learn more](/learn/dashboard/configuration/password-protection) about password protection. To get started, go to **Settings** > **Password** in the [Dashboard](https://dashboard.buildwithfern.com/).

--- a/fern/products/dashboard/pages/overview.mdx
+++ b/fern/products/dashboard/pages/overview.mdx
@@ -32,13 +32,6 @@ Visit your team's [Dashboard](https://dashboard.buildwithfern.com/) and complete
     Connect your GitHub repository to your project.
   </Card>
   <Card
-    title="Password protection"
-    icon="regular lock"
-    href="/learn/dashboard/configuration/password-protection"
-  >
-    Restrict access to your docs site with a shared password.
-  </Card>
-  <Card
     title="Enable Ask Fern"
     icon="regular message-bot"
   >
@@ -141,6 +134,13 @@ Manage your documentation site and team collaboration:
     <img src="https://files.buildwithfern.com/fern.docs.buildwithfern.com/learn/2025-09-30T17:39:54.370Z/products/home/pages/images/arrow-right-white.svg" alt="Arrow right light" className="arrow-right hidden dark:block m-0 h-4 w-4" noZoom />
   </p>
 
+  </Card>
+    <Card
+    title="Password protection"
+    icon="regular lock"
+    href="/learn/dashboard/configuration/password-protection"
+  >
+    Restrict access to your docs site with a shared password.
   </Card>
 </CardGroup>
 

--- a/fern/products/dashboard/pages/overview.mdx
+++ b/fern/products/dashboard/pages/overview.mdx
@@ -32,6 +32,13 @@ Visit your team's [Dashboard](https://dashboard.buildwithfern.com/) and complete
     Connect your GitHub repository to your project.
   </Card>
   <Card
+    title="Password protection"
+    icon="regular lock"
+    href="/learn/dashboard/configuration/password-protection"
+  >
+    Restrict access to your docs site with a shared password.
+  </Card>
+  <Card
     title="Enable Ask Fern"
     icon="regular message-bot"
   >

--- a/fern/products/dashboard/pages/password-protection.mdx
+++ b/fern/products/dashboard/pages/password-protection.mdx
@@ -11,7 +11,7 @@ Protect your published documentation site with a shared password directly from t
   Password-protected sites aren't indexed by search engines.
 </Note>
 
-For more details on how password protection works and how it compares to other authentication options, see [Password protection](/learn/docs/authentication/setup/password-protection).
+You can alternatively authenticate users using SSO, JWT, or OAuth. See [Authentication overview](/learn/docs/authentication/overview) for details. 
 
 ## Enable password protection
 
@@ -29,51 +29,15 @@ Open the **Settings** page for your docs site. You'll see a **Password** card at
 <Step title="Set a password">
 
 Enter a password and click **Save**. A confirmation dialog will appear — select **Enable** to activate password protection.
-</Step>
-</Steps>
 
 Once enabled, the card displays the current password along with when and by whom it was last updated.
-
-## Reset the password
-
-<Steps>
-<Step title="Open the Password card">
-
-From your site's **Settings** page, locate the **Password** card.
-</Step>
-
-<Step title="Click Reset">
-
-Click **Reset** below the current password field.
-</Step>
-
-<Step title="Enter a new password">
-
-Type your new password and click **Save**. Confirm the change in the dialog that appears.
 </Step>
 </Steps>
 
-<Warning>
-  Existing visitors will need to re-enter the new password.
-</Warning>
+## Manage password protection
 
-## Remove password protection
+In the same dialog, you can **Reset** the password, or **Remove** the password to make your site publicly accessible. 
 
-<Steps>
-<Step title="Open the Password card">
-
-From your site's **Settings** page, locate the **Password** card.
-</Step>
-
-<Step title="Click Remove">
-
-Click **Remove** and confirm in the dialog. Your site will become publicly accessible.
-</Step>
-</Steps>
-
-## Permissions
-
-- **Viewing** the current password status requires the **view** permission.
-- **Setting, resetting, or removing** a password requires the **manage-settings** permission.
-
-See [Member permissions](/learn/dashboard/configuration/permissions) for details on roles and access levels.
+<Note title="Roles">
+  All [role types](/learn/dashboard/configuration/permissions) can view the current password. Only Admins can set, reset, or remove a password.
+</Note>

--- a/fern/products/dashboard/pages/password-protection.mdx
+++ b/fern/products/dashboard/pages/password-protection.mdx
@@ -1,0 +1,79 @@
+---
+title: Password protection
+description: Manage password protection for your documentation site from the Fern Dashboard.
+---
+
+<Markdown src="/snippets/team-plan.mdx"/>
+
+Protect your published documentation site with a shared password directly from the [Fern Dashboard](https://dashboard.buildwithfern.com/). When enabled, visitors must enter the password before they can view any content.
+
+<Note>
+  Password-protected sites are not indexed by search engines.
+</Note>
+
+For more details on how password protection works and how it compares to other authentication options, see [Password protection](/learn/docs/authentication/setup/password-protection).
+
+## Enable password protection
+
+<Steps>
+<Step title="Open the Dashboard">
+
+Navigate to the [Fern Dashboard](https://dashboard.buildwithfern.com/) and select the documentation site you want to protect.
+</Step>
+
+<Step title="Go to Settings">
+
+Open the **Settings** page for your docs site. You'll see a **Password** card at the top of the page.
+</Step>
+
+<Step title="Set a password">
+
+Enter a password and click **Save**. A confirmation dialog will appear — select **Enable** to activate password protection.
+</Step>
+</Steps>
+
+Once enabled, the card displays the current password along with when and by whom it was last updated.
+
+## Reset the password
+
+<Steps>
+<Step title="Open the Password card">
+
+From your site's **Settings** page, locate the **Password** card.
+</Step>
+
+<Step title="Click Reset">
+
+Click **Reset** below the current password field.
+</Step>
+
+<Step title="Enter a new password">
+
+Type your new password and click **Save**. Confirm the change in the dialog that appears.
+</Step>
+</Steps>
+
+<Warning>
+  Existing visitors will need to re-enter the new password.
+</Warning>
+
+## Remove password protection
+
+<Steps>
+<Step title="Open the Password card">
+
+From your site's **Settings** page, locate the **Password** card.
+</Step>
+
+<Step title="Click Remove">
+
+Click **Remove** and confirm in the dialog. Your site will become publicly accessible.
+</Step>
+</Steps>
+
+## Permissions
+
+- **Viewing** the current password status requires the **view** permission.
+- **Setting, resetting, or removing** a password requires the **manage-settings** permission.
+
+See [Member permissions](/learn/dashboard/configuration/permissions) for details on roles and access levels.

--- a/fern/products/dashboard/pages/password-protection.mdx
+++ b/fern/products/dashboard/pages/password-protection.mdx
@@ -8,7 +8,7 @@ description: Manage password protection for your documentation site from the Fer
 Protect your published documentation site with a shared password directly from the [Fern Dashboard](https://dashboard.buildwithfern.com/). When enabled, visitors must enter the password before they can view any content.
 
 <Note>
-  Password-protected sites are not indexed by search engines.
+  Password-protected sites aren't indexed by search engines.
 </Note>
 
 For more details on how password protection works and how it compares to other authentication options, see [Password protection](/learn/docs/authentication/setup/password-protection).

--- a/fern/products/dashboard/pages/permissions.mdx
+++ b/fern/products/dashboard/pages/permissions.mdx
@@ -47,6 +47,7 @@ Viewers have read-only access to the Dashboard (settings, analytics) and can dep
 | Manage organization settings  | Yes   | No                   | No     |
 | Manage members                | Yes   | No                   | No     |
 | Add or update a custom domain | Yes   | No                   | No     |
+| Manage password protection    | Yes   | No                   | No     |
 | View dashboard and analytics  | Yes   | Yes                  | Yes    |
 | Publish to production         | Yes   | Configure per Editor | No     |
 | Deploy previews               | Yes   | Yes                  | Yes    |

--- a/fern/products/docs/pages/authentication/password.mdx
+++ b/fern/products/docs/pages/authentication/password.mdx
@@ -12,7 +12,7 @@ Password protection allows you to restrict access to your documentation site usi
 When password protection is enabled, visitors to your documentation site are prompted to enter a password before they can view any content. Once authenticated, users can browse the site until their session expires.
 
 <Note>
-  When password protection is active, search engines will not index your site.
+  When password protection is active, search engines won't index your site.
 </Note>
 
 ## Setting up password protection

--- a/fern/products/docs/pages/authentication/password.mdx
+++ b/fern/products/docs/pages/authentication/password.mdx
@@ -7,6 +7,8 @@ subtitle: Protect your documentation site with a shared password for simple acce
 
 Password protection allows you to restrict access to your documentation site using a shared password. This is useful for pre-release documentation, internal resources, or any content you want to keep private without requiring individual user accounts.
 
+[Set up and manage password protection](/learn/dashboard/configuration/password-protection) in the [Fern Dashboard](https://dashboard.buildwithfern.com/).
+
 ## How it works
 
 When password protection is enabled, visitors to your documentation site are prompted to enter a password before they can view any content. Once authenticated, users can browse the site until their session expires.
@@ -14,34 +16,3 @@ When password protection is enabled, visitors to your documentation site are pro
 <Note>
   When password protection is active, search engines won't index your site.
 </Note>
-
-## Setting up password protection
-
-You can manage password protection directly from the [Fern Dashboard](https://dashboard.buildwithfern.com/).
-
-<Steps>
-<Step title="Open the Dashboard">
-
-Navigate to the [Fern Dashboard](https://dashboard.buildwithfern.com/) and select the documentation site you want to protect.
-</Step>
-
-<Step title="Go to Settings">
-
-Open the **Settings** page for your docs site. You'll see a **Password** card at the top of the settings page.
-</Step>
-
-<Step title="Set a password">
-
-Enter a password and click **Save**. A confirmation dialog will appear — select **Enable** to activate password protection.
-</Step>
-</Steps>
-
-Once enabled, the settings card shows the current password along with when and by whom it was last updated.
-
-## Managing an existing password
-
-From the **Password** card in your site's settings, you can:
-
-- **View the current password** — Click the eye icon to reveal the password.
-- **Reset the password** — Click **Reset**, enter a new password, and confirm. Existing visitors will need to re-enter the new password.
-- **Remove password protection** — Click **Remove** and confirm. Your site will become publicly accessible.

--- a/fern/products/docs/pages/authentication/password.mdx
+++ b/fern/products/docs/pages/authentication/password.mdx
@@ -11,6 +11,37 @@ Password protection allows you to restrict access to your documentation site usi
 
 When password protection is enabled, visitors to your documentation site are prompted to enter a password before they can view any content. Once authenticated, users can browse the site until their session expires.
 
+<Note>
+  When password protection is active, search engines will not index your site.
+</Note>
+
 ## Setting up password protection
 
-To enable password protection for your documentation site, [contact Fern](https://buildwithfern.com/contact) or reach out via Slack. Fern will configure the password for your site.
+You can manage password protection directly from the [Fern Dashboard](https://dashboard.buildwithfern.com/).
+
+<Steps>
+<Step title="Open the Dashboard">
+
+Navigate to the [Fern Dashboard](https://dashboard.buildwithfern.com/) and select the documentation site you want to protect.
+</Step>
+
+<Step title="Go to Settings">
+
+Open the **Settings** page for your docs site. You'll see a **Password** card at the top of the settings page.
+</Step>
+
+<Step title="Set a password">
+
+Enter a password and click **Save**. A confirmation dialog will appear — select **Enable** to activate password protection.
+</Step>
+</Steps>
+
+Once enabled, the settings card shows the current password along with when and by whom it was last updated.
+
+## Managing an existing password
+
+From the **Password** card in your site's settings, you can:
+
+- **View the current password** — Click the eye icon to reveal the password.
+- **Reset the password** — Click **Reset**, enter a new password, and confirm. Existing visitors will need to re-enter the new password.
+- **Remove password protection** — Click **Remove** and confirm. Your site will become publicly accessible.


### PR DESCRIPTION
## Summary

Documents the new self-serve password protection feature added to the Fern Dashboard in [fern-api/fern-platform#7377](https://github.com/fern-api/fern-platform/pull/7377). Previously, the password protection docs page directed users to contact Fern — this PR replaces that with step-by-step instructions for the dashboard-based workflow.

**Changes:**
- **Updated** `docs/authentication/password.mdx` — replaced "contact Fern" setup instructions with dashboard steps (enable, reset, remove), added SEO indexing note
- **Added** `dashboard/pages/password-protection.mdx` — new dedicated dashboard page covering enable/reset/remove flows and permission requirements
- **Updated** `dashboard/dashboard.yml` — added nav entry under Configuration
- **Updated** `dashboard/pages/overview.mdx` — added password protection card to the Setup section

### Updates since last revision
- Fixed Vale lint warnings: used contractions (`aren't`, `won't`) instead of full forms per project style rules.

## Local Testing

Both pages were verified locally with `fern docs dev`:

**Docs > Authentication > Password protection** (`/learn/docs/authentication/setup/password-protection`):
![Password protection docs page](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOiJlbWFpbHw2OTM3MjFmZGNhOTBjYmE1ZDcxMDkwMjgiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfc2JkaXJzeHp5eHRjdHphai9lZGNmMDVmNi1lNzQzLTQyNDctYmRlMS1lZDExYmU4MmYzNjAiLCJpYXQiOjE3NzE4Njk5OTYsImV4cCI6MTc3MjQ3NDc5Nn0.J_M5NAlY9qf_OmxAvLClgaQ3XUr_-YlEFM6AI3FQqOo)

**Dashboard > Configuration > Password protection** (`/learn/dashboard/configuration/password-protection`):
![Password protection dashboard page](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOiJlbWFpbHw2OTM3MjFmZGNhOTBjYmE1ZDcxMDkwMjgiLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmdfc2JkaXJzeHp5eHRjdHphai8zNGU3MDlmNy04NDhmLTQyN2QtODlmNi1jOTQ1MzBhYmQyMDYiLCJpYXQiOjE3NzE4Njk5OTcsImV4cCI6MTc3MjQ3NDc5N30.3IJa0p5pxjzOxYqkbLAxsWwcdySBIVf8wzs88CnM0rY)

All components (`<Steps>`, `<Note>`, `<Warning>`, `<Card>`) render correctly and navigation links resolve locally.

**Preview deployment:** https://fern-preview-ec40e485-ee96-4e5e-a0e1-3e9652e4e887.docs.buildwithfern.com/learn

## Review & Testing Checklist for Human

- [ ] **Verify the feature is live**: The platform PR (#7377) was merged but then reverted (`dbdf34adcf`). Confirm the dashboard password protection UI is actually deployed before merging these docs.
- [ ] **Verify UI descriptions match the actual dashboard**: Button labels ("Save", "Reset", "Remove", "Enable"), dialog text, and card placement were inferred from reading the React source code, not from using the live UI. Walk through the dashboard Settings page to confirm accuracy.
- [ ] **Verify internal links resolve in preview**: Check that `/learn/dashboard/configuration/password-protection` and `/learn/docs/authentication/setup/password-protection` work in the preview deployment.

**Recommended test plan**: Open the [preview deployment](https://fern-preview-ec40e485-ee96-4e5e-a0e1-3e9652e4e887.docs.buildwithfern.com/learn), navigate to both the Dashboard > Configuration > Password protection page and the Docs > Authentication > Setup > Password protection page, and verify content renders and all links work. Then open the live Fern Dashboard and compare the described UI (button labels, card placement, dialog text) against the actual Settings page.

### Notes
- Requested by: @paarthfern
- [Link to Devin run](https://app.devin.ai/sessions/0db11c33a8494afdbe003fbb0d44e215)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/3743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
