### PR TITLE
docs: add OpenAPI specification endpoint documentation and changelog

### DIFF
--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -173,9 +173,6 @@ navigation:
       - page: llms.txt
         path: ./pages/ai/llms-txt.mdx
         slug: llms-txt
-      - page: OpenAPI spec
-        path: ./pages/ai/openapi-spec.mdx
-        slug: openapi-spec
       - section: Ask Fern
         slug: ask-fern
         contents:
@@ -391,6 +388,9 @@ navigation:
         path: ./pages/developer-tools/vale.mdx  
       - page: View Markdown
         path: ./pages/developer-tools/view-markdown.mdx
+      - page: Download OpenAPI spec
+        path: ./pages/ai/openapi-spec.mdx
+        slug: openapi-spec
   - section: Resources
     collapsed: true
     hidden: true

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -173,6 +173,9 @@ navigation:
       - page: llms.txt
         path: ./pages/ai/llms-txt.mdx
         slug: llms-txt
+      - page: OpenAPI Specification
+        path: ./pages/ai/openapi-spec.mdx
+        slug: openapi-spec
       - section: Ask Fern
         slug: ask-fern
         contents:

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -173,7 +173,7 @@ navigation:
       - page: llms.txt
         path: ./pages/ai/llms-txt.mdx
         slug: llms-txt
-      - page: OpenAPI Specification
+      - page: OpenAPI spec
         path: ./pages/ai/openapi-spec.mdx
         slug: openapi-spec
       - section: Ask Fern

--- a/fern/products/docs/pages/ai/llms-txt.mdx
+++ b/fern/products/docs/pages/ai/llms-txt.mdx
@@ -19,7 +19,7 @@ description: Fern automatically creates llms.txt files for AI developer tools. F
 
 Fern generates two files for LLMs:
 
-- **`llms.txt`** contains a lightweight summary of your documentation site with each page distilled into a one-sentence description and URL. For sites with API endpoints, it also links to your [OpenAPI specification](/learn/docs/ai-features/openapi-spec) as a standalone, machine-readable file so AI tools can parse your full API schema directly.
+- **`llms.txt`** contains a lightweight summary of your documentation site with each page distilled into a one-sentence description and URL. For sites with API endpoints, it also links to your [OpenAPI specification](/learn/docs/developer-tools/openapi-spec) as a standalone, machine-readable file so AI tools can parse your full API schema directly.
 
 - **`llms-full.txt`** contains complete documentation content including the full text of all pages. For API documentation, this includes your complete API Reference with resolved OpenAPI specifications and SDK code examples for enabled languages.
 

--- a/fern/products/docs/pages/ai/llms-txt.mdx
+++ b/fern/products/docs/pages/ai/llms-txt.mdx
@@ -19,7 +19,7 @@ description: Fern automatically creates llms.txt files for AI developer tools. F
 
 Fern generates two files for LLMs:
 
-- **`llms.txt`** contains a lightweight summary of your documentation site with each page distilled into a one-sentence description and URL.
+- **`llms.txt`** contains a lightweight summary of your documentation site with each page distilled into a one-sentence description and URL. For sites with API endpoints, it also links to your [OpenAPI specification](/learn/docs/ai-features/openapi-spec) as a standalone, machine-readable file so AI tools can parse your full API schema directly.
 
 - **`llms-full.txt`** contains complete documentation content including the full text of all pages. For API documentation, this includes your complete API Reference with resolved OpenAPI specifications and SDK code examples for enabled languages.
 

--- a/fern/products/docs/pages/ai/openapi-spec.mdx
+++ b/fern/products/docs/pages/ai/openapi-spec.mdx
@@ -1,13 +1,17 @@
 ---
-title: OpenAPI Specification
-description: Fern automatically serves your raw OpenAPI 3.1 specification as JSON or YAML from your documentation site.
+title: OpenAPI spec
+description: Fern serves your OpenAPI 3.1 spec from your docs site so AI tools and LLMs can discover and interact with your API programmatically.
 ---
 
-Fern docs sites automatically serve your raw OpenAPI 3.1 specification, making it easy for users to download and use the spec for SDK generation, contract testing, or integration with other tools.
+<Markdown src="/snippets/agent-directive.mdx"/>
+
+Fern docs sites automatically serve your raw OpenAPI 3.1 specification, so anyone — or any tool — can download it for SDK generation, contract testing, or importing into tools like Postman. 
+
+The spec is also linked from your site's [`llms.txt`](/learn/docs/ai-features/llms-txt), so AI coding assistants like Cursor, Copilot, and Claude can discover and use it to generate accurate API calls and build integrations.
 
 ## Available endpoints
 
-Every Fern docs site exposes the OpenAPI specification at the following paths:
+Every Fern docs site exposes the OpenAPI specification at these paths:
 
 | Endpoint | Format | Content-Type |
 |----------|--------|--------------|
@@ -15,45 +19,23 @@ Every Fern docs site exposes the OpenAPI specification at the following paths:
 | `/openapi.yaml` | YAML | `application/x-yaml` |
 | `/openapi.yml` | YAML | `application/x-yaml` |
 
+The spec includes all endpoints with request/response schemas, authentication schemes (Bearer, Basic, API Key, OAuth), webhooks, type definitions as component schemas, and server URLs from your environment configuration. It's generated from the same API definition that powers your docs, so it's always up to date.
+
 ## Usage
 
-To access the OpenAPI specification for your docs site, simply append the endpoint to your docs URL:
+Append the endpoint to your docs URL to download the spec:
 
 ```bash
-# JSON format
+# Download as JSON
 curl https://your-docs-site.com/openapi.json
 
-# YAML format
+# Download as YAML
 curl https://your-docs-site.com/openapi.yaml
 ```
 
-## Multiple APIs
-
-If your documentation site includes multiple API definitions, the endpoint returns a listing of available APIs. Use the `api` query parameter to select a specific one:
+If your docs site includes multiple API definitions, the endpoint returns a listing of available APIs. Use the `api` query parameter to select a specific one:
 
 ```bash
-# List available APIs
-curl https://your-docs-site.com/openapi.json
-
 # Get a specific API's spec
 curl https://your-docs-site.com/openapi.json?api=my-api-id
 ```
-
-## Use cases
-
-- **SDK generation**: Download the spec and use tools like [Fern](https://buildwithfern.com) to generate client libraries in languages or ecosystems not yet supported.
-- **Contract testing**: Use the spec to validate that your API implementation matches the documented specification.
-- **API exploration**: Import the spec into tools like Postman, Insomnia, or Swagger UI for interactive exploration.
-- **CI/CD integration**: Automatically fetch the latest spec in your pipeline for validation or code generation.
-
-## How it works
-
-Fern generates a complete OpenAPI 3.1 specification from your API definition, including:
-
-- All endpoints with request/response schemas
-- Authentication schemes (Bearer, Basic, API Key, OAuth)
-- Webhooks
-- Type definitions as component schemas
-- Server URLs from your environment configuration
-
-The specification is generated on-the-fly from the same API definition that powers your documentation site, so it is always up to date.

--- a/fern/products/docs/pages/ai/openapi-spec.mdx
+++ b/fern/products/docs/pages/ai/openapi-spec.mdx
@@ -1,5 +1,5 @@
 ---
-title: OpenAPI spec
+title: Download OpenAPI spec
 description: Fern serves your OpenAPI 3.1 spec from your docs site so AI tools and LLMs can discover and interact with your API programmatically.
 ---
 

--- a/fern/products/docs/pages/ai/openapi-spec.mdx
+++ b/fern/products/docs/pages/ai/openapi-spec.mdx
@@ -1,0 +1,59 @@
+---
+title: OpenAPI Specification
+description: Fern automatically serves your raw OpenAPI 3.1 specification as JSON or YAML from your documentation site.
+---
+
+Fern docs sites automatically serve your raw OpenAPI 3.1 specification, making it easy for users to download and use the spec for SDK generation, contract testing, or integration with other tools.
+
+## Available endpoints
+
+Every Fern docs site exposes the OpenAPI specification at the following paths:
+
+| Endpoint | Format | Content-Type |
+|----------|--------|--------------|
+| `/openapi.json` | JSON | `application/json` |
+| `/openapi.yaml` | YAML | `application/x-yaml` |
+| `/openapi.yml` | YAML | `application/x-yaml` |
+
+## Usage
+
+To access the OpenAPI specification for your docs site, simply append the endpoint to your docs URL:
+
+```bash
+# JSON format
+curl https://your-docs-site.com/openapi.json
+
+# YAML format
+curl https://your-docs-site.com/openapi.yaml
+```
+
+## Multiple APIs
+
+If your documentation site includes multiple API definitions, the endpoint returns a listing of available APIs. Use the `api` query parameter to select a specific one:
+
+```bash
+# List available APIs
+curl https://your-docs-site.com/openapi.json
+
+# Get a specific API's spec
+curl https://your-docs-site.com/openapi.json?api=my-api-id
+```
+
+## Use cases
+
+- **SDK generation**: Download the spec and use tools like [Fern](https://buildwithfern.com) to generate client libraries in languages or ecosystems not yet supported.
+- **Contract testing**: Use the spec to validate that your API implementation matches the documented specification.
+- **API exploration**: Import the spec into tools like Postman, Insomnia, or Swagger UI for interactive exploration.
+- **CI/CD integration**: Automatically fetch the latest spec in your pipeline for validation or code generation.
+
+## How it works
+
+Fern generates a complete OpenAPI 3.1 specification from your API definition, including:
+
+- All endpoints with request/response schemas
+- Authentication schemes (Bearer, Basic, API Key, OAuth)
+- Webhooks
+- Type definitions as component schemas
+- Server URLs from your environment configuration
+
+The specification is generated on-the-fly from the same API definition that powers your documentation site, so it is always up to date.

--- a/fern/products/docs/pages/ai/overview.mdx
+++ b/fern/products/docs/pages/ai/overview.mdx
@@ -41,8 +41,9 @@ AI helps keep your documentation current. Fern Writer is a Slack-based technical
 
 ## Optimize for AI
 
-Your site is automatically optimized for AI tools and search engines. Fern serves Markdown instead of HTML to AI agents, reducing token consumption and helping these tools process your content faster. Your site hosts `llms.txt` and `llms-full.txt` files so LLMs can index your documentation efficiently.
+Your site is automatically optimized for AI tools and search engines. Fern serves Markdown instead of HTML to AI agents, reducing token consumption and helping these tools process your content faster. Your site hosts `llms.txt` and `llms-full.txt` files so LLMs can index your documentation efficiently, and serves a machine-readable OpenAPI spec so AI tools can discover and interact with your API.
 
 <CardGroup cols={2}>
   <Card title="llms.txt" icon="file-text" href="/learn/docs/ai-features/llms-txt" />
+  <Card title="OpenAPI spec" icon="brackets-curly" href="/learn/docs/ai-features/openapi-spec" />
 </CardGroup>

--- a/fern/products/docs/pages/ai/overview.mdx
+++ b/fern/products/docs/pages/ai/overview.mdx
@@ -41,9 +41,8 @@ AI helps keep your documentation current. Fern Writer is a Slack-based technical
 
 ## Optimize for AI
 
-Your site is automatically optimized for AI tools and search engines. Fern serves Markdown instead of HTML to AI agents, reducing token consumption and helping these tools process your content faster. Your site hosts `llms.txt` and `llms-full.txt` files so LLMs can index your documentation efficiently, and serves a machine-readable OpenAPI spec so AI tools can discover and interact with your API.
+Your site is automatically optimized for AI tools and search engines. Fern serves Markdown instead of HTML to AI agents, reducing token consumption and helping these tools process your content faster. Your site hosts `llms.txt` and `llms-full.txt` files so LLMs can index your documentation efficiently.
 
 <CardGroup cols={2}>
   <Card title="llms.txt" icon="file-text" href="/learn/docs/ai-features/llms-txt" />
-  <Card title="OpenAPI spec" icon="brackets-curly" href="/learn/docs/ai-features/openapi-spec" />
 </CardGroup>

--- a/fern/products/docs/pages/changelog/2026-02-26.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-26.mdx
@@ -1,0 +1,9 @@
+---
+tags: ["api-references", "ai"]
+---
+
+## OpenAPI specification endpoints
+
+Your Fern docs site now automatically serves your raw OpenAPI 3.1 specification. Access it at `/openapi.json` or `/openapi.yaml` to download the spec for SDK generation, contract testing, or importing into tools like Postman.
+
+Learn more about the [OpenAPI specification endpoints](/learn/docs/ai-features/openapi-spec).

--- a/fern/products/docs/pages/changelog/2026-02-26.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-26.mdx
@@ -2,8 +2,8 @@
 tags: ["api-references", "ai"]
 ---
 
-## OpenAPI specification endpoints
+## OpenAPI specification for AI tools
 
-Your Fern docs site now automatically serves your raw OpenAPI 3.1 specification. Access it at `/openapi.json` or `/openapi.yaml` to download the spec for SDK generation, contract testing, or importing into tools like Postman.
+Your Fern docs site now serves your OpenAPI 3.1 specification at `/openapi.json` and `/openapi.yaml`, and links to it from `llms.txt`. AI coding assistants and LLM-based agents can use the spec to generate accurate API calls, build integrations, and stay in sync with your API — no manual setup required.
 
-Learn more about the [OpenAPI specification endpoints](/learn/docs/ai-features/openapi-spec).
+Learn more about [OpenAPI for AI](/learn/docs/ai-features/openapi-spec).

--- a/fern/products/docs/pages/changelog/2026-02-26.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-26.mdx
@@ -6,4 +6,4 @@ tags: ["api-references", "ai"]
 
 Your Fern docs site now serves your raw OpenAPI 3.1 specification at `/openapi.json` and `/openapi.yaml`. Download it for SDK generation, contract testing, or importing into tools like Postman. The spec is also linked from your site's `llms.txt`, so AI coding assistants can discover and use it automatically.
 
-Learn more about the [OpenAPI spec](/learn/docs/ai-features/openapi-spec).
+Learn more about the [OpenAPI spec](/learn/docs/developer-tools/openapi-spec).

--- a/fern/products/docs/pages/changelog/2026-02-26.mdx
+++ b/fern/products/docs/pages/changelog/2026-02-26.mdx
@@ -2,8 +2,8 @@
 tags: ["api-references", "ai"]
 ---
 
-## OpenAPI specification for AI tools
+## OpenAPI spec endpoints
 
-Your Fern docs site now serves your OpenAPI 3.1 specification at `/openapi.json` and `/openapi.yaml`, and links to it from `llms.txt`. AI coding assistants and LLM-based agents can use the spec to generate accurate API calls, build integrations, and stay in sync with your API — no manual setup required.
+Your Fern docs site now serves your raw OpenAPI 3.1 specification at `/openapi.json` and `/openapi.yaml`. Download it for SDK generation, contract testing, or importing into tools like Postman. The spec is also linked from your site's `llms.txt`, so AI coding assistants can discover and use it automatically.
 
-Learn more about [OpenAPI for AI](/learn/docs/ai-features/openapi-spec).
+Learn more about the [OpenAPI spec](/learn/docs/ai-features/openapi-spec).


### PR DESCRIPTION
# docs: add OpenAPI specification endpoint documentation and changelog

## Summary

Adds documentation and a changelog entry for the new OpenAPI specification endpoints feature being implemented in [fern-platform#7610](https://github.com/fern-api/fern-platform/pull/7610). Fern docs sites will now serve raw OpenAPI 3.1 specs at `/openapi.json` and `/openapi.yaml`.

**Changes:**
- New docs page at `fern/products/docs/pages/ai/openapi-spec.mdx` explaining the endpoints, multi-API support, and use cases
- Changelog entry for 2026-02-26 announcing the feature
- Navigation entry added under "AI features" section, after the llms.txt page

## Review & Testing Checklist for Human

- [ ] **Verify the companion platform PR is merged first** — this documents functionality from [fern-platform#7610](https://github.com/fern-api/fern-platform/pull/7610). If that PR's behavior changes (e.g., different endpoints, query params, content types), these docs need to be updated to match.
- [ ] **Check the changelog link resolves** — the changelog entry links to `/learn/docs/ai-features/openapi-spec`. Confirm the slug chain (`docs` → `ai-features` → `openapi-spec`) produces the expected URL.
- [ ] **Preview the rendered page** — verify the MDX table, code blocks, and list formatting render correctly on the docs site.

### Notes
- This PR should be merged **after** the companion implementation PR [fern-platform#7610](https://github.com/fern-api/fern-platform/pull/7610) ships, otherwise the docs will reference endpoints that don't exist yet.
- **Link to Devin run:** https://app.devin.ai/sessions/ee868921248d47958249e87d299f6638
- **Requested by:** @thesandlord