### PR TITLE
Add changelog entry for Python library docs

### DIFF
--- a/fern/products/docs/pages/changelog/2026-03-02.mdx
+++ b/fern/products/docs/pages/changelog/2026-03-02.mdx
@@ -29,6 +29,6 @@ Then generate the reference pages:
 fern docs md generate
 ```
 
-This parses your Python source code on the server, generates MDX pages locally, and writes a `_navigation.yml` file to the output directory. The generated pages are resolved as first-class navigation sections in `fern docs dev` and `fern generate --docs`.
+This parses your Python source code on the server and generates MDX pages locally. The generated pages are resolved as first-class navigation sections in `fern docs dev` and `fern generate --docs`.
 
 Python is the first supported language, with more languages on the way.

--- a/fern/products/docs/pages/changelog/2026-03-02.mdx
+++ b/fern/products/docs/pages/changelog/2026-03-02.mdx
@@ -1,9 +1,34 @@
 ---
-tags: ["api-reference"]
+tags: ["api-reference", "configuration"]
 ---
 
 ## Python library docs
 
-Add Python library reference documentation to your Fern docs site. Fern generates browsable, structured documentation directly from your Python SDK source code, including modules, classes, methods, and type signatures. To get started, add a `library` navigation item and configure `libraries` in your `docs.yml`, then run `fern docs md generate` to produce the reference pages.
+Add Python library reference documentation to your Fern docs site. Fern generates browsable, structured documentation directly from your Python SDK source code, including modules, classes, methods, and type signatures.
+
+To set up library docs, add a `libraries` configuration and a `library` navigation item to your `docs.yml`:
+
+```yaml title="docs.yml"
+libraries:
+  my-python-sdk:
+    input:
+      git: https://github.com/your-org/your-python-sdk
+    output:
+      path: ./generated/my-python-sdk
+    lang: python
+
+navigation:
+  - section: SDK Reference
+    contents:
+      - library: my-python-sdk
+```
+
+Then generate the reference pages:
+
+```bash
+fern docs md generate
+```
+
+This parses your Python source code on the server, generates MDX pages locally, and writes a `_navigation.yml` file to the output directory. The generated pages are resolved as first-class navigation sections in `fern docs dev` and `fern generate --docs`.
 
 Python is the first supported language, with more languages on the way.

--- a/fern/products/docs/pages/changelog/2026-03-02.mdx
+++ b/fern/products/docs/pages/changelog/2026-03-02.mdx
@@ -1,0 +1,9 @@
+---
+tags: ["api-reference"]
+---
+
+## Python library docs
+
+Add Python library reference documentation to your Fern docs site. Fern generates browsable, structured documentation directly from your Python SDK source code, including modules, classes, methods, and type signatures. To get started, add a `library` navigation item and configure `libraries` in your `docs.yml`, then run `fern docs md generate` to produce the reference pages.
+
+Python is the first supported language, with more languages on the way.


### PR DESCRIPTION
## Summary

Adds a changelog entry (`2026-03-02.mdx`) for the Python library docs feature in the Docs product changelog. The entry describes the ability to generate Python library reference documentation from SDK source code using `fern docs md generate`.

Tagged as `api-reference` and `configuration`. Vale linting passes with no errors or warnings.

### Updates since last revision

- Added CLI commands and usage details per reviewer request:
  - Full `docs.yml` configuration example showing `libraries` config and `library` navigation item
  - `fern docs md generate` CLI command
  - Brief explanation of what the command does (server-side parsing, local MDX generation)
- Removed `_navigation.yml` implementation detail per reviewer request

The config structure (`input.git`, `output.path`, `lang`) was derived from the CLI source schemas (`LibraryConfigurationSchema.ts`, `LibraryReferenceConfigurationSchema.ts`), not from an existing published example.

## Review & Testing Checklist for Human

- [ ] Verify the `docs.yml` configuration example is accurate — the structure was inferred from CLI source code schemas, not copied from an official example or existing customer config
- [ ] Verify the feature description and workflow accurately reflects what shipped (sourced from CLI changelogs 2026-02-06 through 2026-02-13)
- [ ] Decide if a "Learn more" link should be added — no dedicated docs page for library docs was found in the repo, so one was omitted
- [ ] Preview the rendered entry at the [preview URL](https://fern-preview-4b7dbffa-d5e2-4d11-a6c6-c63a708a59fa.docs.buildwithfern.com/learn/docs/changelog/2026/3/2) and confirm formatting looks correct

### Notes
- Requested by @paarthfern
- [Devin Session](https://app.devin.ai/sessions/a7aef974d64149c3a62af0633ca9b2a9)