### PR TITLE
Add Previews page to self-hosted docs

### DIFF
--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -346,7 +346,7 @@ navigation:
       - page: Authentication
         path: ./pages/enterprise/self-hosted-authentication.mdx
         slug: authentication
-      - page: Previews
+      - page: Previews / static export
         path: ./pages/enterprise/self-hosted-static-export.mdx
         slug: previews
       - page: Health check endpoints

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -346,9 +346,9 @@ navigation:
       - page: Authentication
         path: ./pages/enterprise/self-hosted-authentication.mdx
         slug: authentication
-      - page: Static export to S3
+      - page: Previews
         path: ./pages/enterprise/self-hosted-static-export.mdx
-        slug: static-export
+        slug: previews
       - page: Health check endpoints
         path: ./pages/enterprise/health-check-endpoints.mdx
   - section: Analytics & integrations

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -346,6 +346,9 @@ navigation:
       - page: Authentication
         path: ./pages/enterprise/self-hosted-authentication.mdx
         slug: authentication
+      - page: Static export to S3
+        path: ./pages/enterprise/self-hosted-static-export.mdx
+        slug: static-export
       - page: Health check endpoints
         path: ./pages/enterprise/health-check-endpoints.mdx
   - section: Analytics & integrations

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -346,7 +346,7 @@ navigation:
       - page: Authentication
         path: ./pages/enterprise/self-hosted-authentication.mdx
         slug: authentication
-      - page: Previews / static export
+      - page: Previews
         path: ./pages/enterprise/self-hosted-static-export.mdx
         slug: previews
       - page: Health check endpoints

--- a/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
@@ -102,6 +102,8 @@ instances:
 
 You can now deploy the image to your own infrastructure, allowing you to host the documentation on your own domain.
 
+Once deployed, you can set up [preview environments](/learn/docs/self-hosted/previews) to preview documentation changes on every pull request.
+
 </Step>
 </Steps>
 

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -10,6 +10,10 @@ availability: beta
 
 The self-hosted container includes a static export feature that crawls all pages, caches them, and produces a `.tar.gz` archive of static HTML and assets. You can use this in a CI/CD pipeline to build your docs container, export the static files, and push them to an S3 bucket (or any static file host).
 
+<Note>
+Static exports do not include search or the API Explorer (Try it) functionality. This feature is in beta and may change in the future.
+</Note>
+
 ## GitHub Actions workflow
 
 ```yaml title=".github/workflows/deploy-docs-s3.yml"

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -1,5 +1,5 @@
 ---
-title: Previews
+title: Previews / static export
 description: Export your self-hosted documentation as static files and deploy them to an S3 bucket using a CI/CD pipeline.
 availability: beta
 ---

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -8,22 +8,19 @@ availability: beta
 
 <Markdown src="/snippets/enterprise-plan.mdx" />
 
-There are two ways to set up preview environments for your self-hosted docs: deploy a full container per preview, or export static files to an object store.
+There are two ways to set up preview environments for your self-hosted docs: deploy a full container per preview, or export static files to an object store. Both approaches render content exactly as it would appear in production.
 
-## Container-based previews
+<AccordionGroup>
+<Accordion title="Container-based previews">
 
 Build and deploy the self-hosted container for each preview. This gives you an identical environment to production.
 
-**Pros:**
-- All features work, including search, API Explorer (Try it), and authentication
-- No differences from the final production container
+| | |
+|---|---|
+| **Pros** | Content renders like production, all features work (search, API Explorer, authentication) |
+| **Cons** | Requires hosting infrastructure (container runtime, load balancer, DNS), must clean up resources, higher cost at scale |
 
-**Cons:**
-- Requires hosting infrastructure (container runtime, load balancer, DNS)
-- Must clean up containers and resources after previews are no longer needed
-- Higher cost at scale
-
-### GitHub Actions workflow
+#### GitHub Actions workflow
 
 ```yaml title=".github/workflows/preview-docs-container.yml"
 name: preview-docs-container
@@ -64,21 +61,19 @@ jobs:
           echo "Deploy self-hosted-docs:${{ github.sha }} to your platform"
 ```
 
-## Static export previews <Badge intent="warning" minimal>Beta</Badge>
+</Accordion>
+<Accordion title="Static export previews">
+
+<Badge intent="warning" minimal>Beta</Badge>
 
 Export the docs as static HTML and assets and upload them to an object store such as S3, Google Cloud Storage (GCS), or R2.
 
-**Pros:**
-- Static files can be served from any object store (S3, GCS, R2, etc.) with no running servers
-- Scale to thousands of previews without spinning up containers or load balancers
-- Low cost and simple cleanup
+| | |
+|---|---|
+| **Pros** | Content renders like production, serves from any object store (S3, GCS, R2) with no running servers, scales to thousands of previews, low cost and simple cleanup |
+| **Cons** | No search, no API Explorer (Try it), no authentication |
 
-**Cons:**
-- No search functionality
-- No API Explorer (Try it)
-- No authentication
-
-### GitHub Actions workflow
+#### GitHub Actions workflow
 
 ```yaml title=".github/workflows/preview-docs-static.yml"
 name: preview-docs-static
@@ -162,3 +157,6 @@ jobs:
         if: always()
         run: docker rm -f docs-container
 ```
+
+</Accordion>
+</AccordionGroup>

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -66,7 +66,7 @@ jobs:
 
 ## Static export previews <Badge intent="warning" minimal>Beta</Badge>
 
-Export the docs as static HTML and assets and upload them to an object store such as S3, GCS, or R2.
+Export the docs as static HTML and assets and upload them to an object store such as S3, Google Cloud Storage (GCS), or R2.
 
 **Pros:**
 - Static files can be served from any object store (S3, GCS, R2, etc.) with no running servers

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -1,0 +1,147 @@
+---
+title: Static export to S3
+description: Export your self-hosted documentation as static files and deploy them to an S3 bucket using a CI/CD pipeline.
+---
+
+<Markdown src="/snippets/agent-directive.mdx"/>
+
+<Markdown src="/snippets/enterprise-plan.mdx" />
+
+The self-hosted container includes a static export feature that crawls all pages, caches them, and produces a `.tar.gz` archive of static HTML and assets. You can use this in a CI/CD pipeline to build your docs container, export the static files, and push them to an S3 bucket (or any static file host).
+
+## How it works
+
+The export process runs inside a self-hosted container:
+
+1. The container starts and all internal services initialize (PostgreSQL, MinIO, FDR, Next.js).
+2. A warmup phase crawls every page to populate the cache.
+3. The export collects all cached HTML pages and Next.js static assets into a `tar.gz` archive.
+4. The archive is copied out of the container and uploaded to S3.
+
+## GitHub Actions workflow
+
+The following GitHub Actions workflow builds the self-hosted container with your docs, runs the static export, and syncs the output to an S3 bucket.
+
+### Prerequisites
+
+Add these secrets to your GitHub repository settings:
+
+| Secret | Description |
+|---|---|
+| `DOCKERHUB_USERNAME` | Docker Hub username with access to the private `fernapi/fern-self-hosted` image |
+| `DOCKERHUB_TOKEN` | Docker Hub access token |
+| `AWS_ACCESS_KEY_ID` | AWS access key with S3 write permissions |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
+| `AWS_S3_BUCKET` | Target S3 bucket name (e.g., `my-docs-bucket`) |
+| `AWS_REGION` | AWS region for the S3 bucket (e.g., `us-east-1`) |
+
+### Workflow file
+
+Create `.github/workflows/deploy-docs-s3.yml` in your repository:
+
+```yaml title=".github/workflows/deploy-docs-s3.yml"
+name: deploy-docs-to-s3
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build docs container
+        run: docker build -t self-hosted-docs .
+
+      - name: Start container
+        run: |
+          docker run -d \
+            --name docs-container \
+            -e WARMUP=true \
+            self-hosted-docs
+
+      - name: Wait for container to be healthy
+        run: |
+          echo "Waiting for container to be healthy..."
+          MAX_ATTEMPTS=60
+          ATTEMPT=0
+          while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            if docker exec docs-container sh -c \
+              'TOKEN=$(cat /tmp/.cache-admin-token 2>/dev/null); \
+               curl -f -s --max-time 5 \
+               -H "Authorization: Bearer $TOKEN" \
+               http://localhost:3000/__cache/stats' > /dev/null 2>&1; then
+              echo "Container is healthy."
+              break
+            fi
+            echo "  Not ready yet... ($ATTEMPT/$MAX_ATTEMPTS)"
+            sleep 5
+          done
+          if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+            echo "Error: container did not become healthy."
+            exit 1
+          fi
+
+      - name: Export static site
+        run: |
+          docker exec docs-container /scripts/export.sh
+          docker cp docs-container:/tmp/fern-static-export.tar.gz ./export.tar.gz
+
+      - name: Extract static files
+        run: |
+          mkdir -p ./site
+          tar -xzf export.tar.gz -C ./site
+
+      - name: Upload to S3
+        if: github.ref == 'refs/heads/main'
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --delete
+        env:
+          SOURCE_DIR: ./site
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f docs-container
+```
+
+This workflow requires a `Dockerfile` in your repository root. See [Set up self-hosted documentation](/learn/docs/self-hosted/set-up) for Dockerfile setup instructions.
+
+### Pull request previews
+
+On pull requests, the workflow builds the container and runs the export without uploading to S3. The upload step only runs on pushes to the `main` branch, controlled by the `if: github.ref == 'refs/heads/main'` condition. To enable PR preview uploads, remove that condition or change it to also match `pull_request` events.
+
+## Using the AWS CLI directly
+
+If you prefer the AWS CLI over the GitHub Action, replace the upload step:
+
+```yaml
+      - name: Upload to S3
+        if: github.ref == 'refs/heads/main'
+        run: aws s3 sync ./site s3://${{ secrets.AWS_S3_BUCKET }} --delete
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+```
+
+## Base path configuration
+
+If your docs are served from a sub-path (e.g., `/docs`), set `NEXT_PUBLIC_BASE_PATH` in your Dockerfile before running `fern-generate`. The static export preserves the base path in all generated files. See [Base path](/learn/docs/self-hosted/set-up#base-path) for details.

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -1,5 +1,5 @@
 ---
-title: Static export to S3
+title: Previews
 description: Export your self-hosted documentation as static files and deploy them to an S3 bucket using a CI/CD pipeline.
 availability: beta
 ---
@@ -10,35 +10,7 @@ availability: beta
 
 The self-hosted container includes a static export feature that crawls all pages, caches them, and produces a `.tar.gz` archive of static HTML and assets. You can use this in a CI/CD pipeline to build your docs container, export the static files, and push them to an S3 bucket (or any static file host).
 
-## How it works
-
-The export process runs inside a self-hosted container:
-
-1. The container starts and all internal services initialize (PostgreSQL, MinIO, FDR, Next.js).
-2. A warmup phase crawls every page to populate the cache.
-3. The export collects all cached HTML pages and Next.js static assets into a `tar.gz` archive.
-4. The archive is copied out of the container and uploaded to S3.
-
 ## GitHub Actions workflow
-
-The following GitHub Actions workflow builds the self-hosted container with your docs, runs the static export, and syncs the output to an S3 bucket.
-
-### Prerequisites
-
-Add these secrets to your GitHub repository settings:
-
-| Secret | Description |
-|---|---|
-| `DOCKERHUB_USERNAME` | Docker Hub username with access to the private `fernapi/fern-self-hosted` image |
-| `DOCKERHUB_TOKEN` | Docker Hub access token |
-| `AWS_ACCESS_KEY_ID` | AWS access key with S3 write permissions |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
-| `AWS_S3_BUCKET` | Target S3 bucket name (e.g., `my-docs-bucket`) |
-| `AWS_REGION` | AWS region for the S3 bucket (e.g., `us-east-1`) |
-
-### Workflow file
-
-Create `.github/workflows/deploy-docs-s3.yml` in your repository:
 
 ```yaml title=".github/workflows/deploy-docs-s3.yml"
 name: deploy-docs-to-s3
@@ -122,27 +94,3 @@ jobs:
         if: always()
         run: docker rm -f docs-container
 ```
-
-This workflow requires a `Dockerfile` in your repository root. See [Set up self-hosted documentation](/learn/docs/self-hosted/set-up) for Dockerfile setup instructions.
-
-### Pull request previews
-
-On pull requests, the workflow builds the container and runs the export without uploading to S3. The upload step only runs on pushes to the `main` branch, controlled by the `if: github.ref == 'refs/heads/main'` condition. To enable PR preview uploads, remove that condition or change it to also match `pull_request` events.
-
-## Using the AWS CLI directly
-
-If you prefer the AWS CLI over the GitHub Action, replace the upload step:
-
-```yaml
-      - name: Upload to S3
-        if: github.ref == 'refs/heads/main'
-        run: aws s3 sync ./site s3://${{ secrets.AWS_S3_BUCKET }} --delete
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-```
-
-## Base path configuration
-
-If your docs are served from a sub-path (e.g., `/docs`), set `NEXT_PUBLIC_BASE_PATH` in your Dockerfile before running `fern-generate`. The static export preserves the base path in all generated files. See [Base path](/learn/docs/self-hosted/set-up#base-path) for details.

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -10,7 +10,9 @@ availability: beta
 
 There are two ways to set up preview environments for your self-hosted docs. Both approaches render content exactly as it would appear in production.
 
-## Comparison
+## Choosing an approach
+
+For most teams, **static export** is the best starting point. It requires no additional infrastructure beyond an object store, scales to thousands of previews with near-zero cost, and is simple to clean up. Choose **container-based** previews if you need search, API Explorer, or authentication in your preview environments.
 
 | | Container-based | Static export <Badge intent="warning" minimal>Beta</Badge> |
 |---|---|---|
@@ -24,6 +26,8 @@ There are two ways to set up preview environments for your self-hosted docs. Bot
 | **Cleanup** | Must tear down containers and resources | Simple — delete static files |
 
 ## GitHub Actions workflows
+
+The following workflows can be added to your repository to automatically build and deploy preview environments on every pull request.
 
 <AccordionGroup>
 <Accordion title="Container-based preview workflow">

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -8,19 +8,27 @@ availability: beta
 
 <Markdown src="/snippets/enterprise-plan.mdx" />
 
-There are two ways to set up preview environments for your self-hosted docs: deploy a full container per preview, or export static files to an object store. Both approaches render content exactly as it would appear in production.
+There are two ways to set up preview environments for your self-hosted docs. Both approaches render content exactly as it would appear in production.
+
+## Comparison
+
+| | Container-based | Static export <Badge intent="warning" minimal>Beta</Badge> |
+|---|---|---|
+| **Content rendering** | Identical to production | Identical to production |
+| **Search** | Yes | No |
+| **API Explorer (Try it)** | Yes | No |
+| **Authentication** | Yes | No |
+| **Infrastructure** | Requires container hosting, load balancer, DNS | Serves from any object store (S3, GCS, R2) |
+| **Scaling** | One container per preview | Thousands of previews with no servers |
+| **Cost** | Higher | Low |
+| **Cleanup** | Must tear down containers and resources | Simple — delete static files |
+
+## GitHub Actions workflows
 
 <AccordionGroup>
-<Accordion title="Container-based previews">
+<Accordion title="Container-based preview workflow">
 
-Build and deploy the self-hosted container for each preview. This gives you an identical environment to production.
-
-| | |
-|---|---|
-| **Pros** | Content renders like production, all features work (search, API Explorer, authentication) |
-| **Cons** | Requires hosting infrastructure (container runtime, load balancer, DNS), must clean up resources, higher cost at scale |
-
-#### GitHub Actions workflow
+Build and deploy the self-hosted container for each preview. This gives you an identical environment to production, including search, API Explorer, and authentication.
 
 ```yaml title=".github/workflows/preview-docs-container.yml"
 name: preview-docs-container
@@ -62,18 +70,9 @@ jobs:
 ```
 
 </Accordion>
-<Accordion title="Static export previews">
-
-<Badge intent="warning" minimal>Beta</Badge>
+<Accordion title="Static export preview workflow">
 
 Export the docs as static HTML and assets and upload them to an object store such as S3, Google Cloud Storage (GCS), or R2.
-
-| | |
-|---|---|
-| **Pros** | Content renders like production, serves from any object store (S3, GCS, R2) with no running servers, scales to thousands of previews, low cost and simple cleanup |
-| **Cons** | No search, no API Explorer (Try it), no authentication |
-
-#### GitHub Actions workflow
 
 ```yaml title=".github/workflows/preview-docs-static.yml"
 name: preview-docs-static

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -8,7 +8,7 @@ availability: beta
 
 <Markdown src="/snippets/enterprise-plan.mdx" />
 
-The self-hosted container includes a static export feature that crawls all pages, caches them, and produces a `.tar.gz` archive of static HTML and assets. You can use this in a CI/CD pipeline to build your docs container, export the static files, and push them to an S3 bucket (or any static file host).
+You can use a CI/CD pipeline to build your docs container, export the static files, and push them to an S3 bucket (or any static file host).
 
 <Note>
 Static exports do not include search or the API Explorer (Try it) functionality. This feature is in beta and may change in the future.

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -8,11 +8,16 @@ availability: beta
 
 <Markdown src="/snippets/enterprise-plan.mdx" />
 
-There are two ways to set up preview environments for your self-hosted docs. Both approaches render content exactly as it would appear in production.
+There are two ways to set up preview environments for your self-hosted docs:
+
+- **Container-based** — deploys the same self-hosted Docker container you use in production, giving you a full-fidelity preview with search, API Explorer, and authentication.
+- **Static export** — renders your docs to static HTML and assets that can be served from any object store (S3, GCS, R2), with no running containers required.
+
+Both approaches render content exactly as it would appear in production.
 
 ## Choosing an approach
 
-For most teams, **static export** is the best starting point. It requires no additional infrastructure beyond an object store, scales to thousands of previews with near-zero cost, and is simple to clean up. Choose **container-based** previews if you need search, API Explorer, or authentication in your preview environments.
+For most teams, **static export** is the best starting point because of its minimal infrastructure and setup. Choose **container-based** if you need search, API Explorer, or authentication in your previews.
 
 | | Container-based | Static export <Badge intent="warning" minimal>Beta</Badge> |
 |---|---|---|
@@ -32,7 +37,7 @@ The following workflows can be added to your repository to automatically build a
 <AccordionGroup>
 <Accordion title="Container-based preview workflow">
 
-Build and deploy the self-hosted container for each preview. This gives you an identical environment to production, including search, API Explorer, and authentication.
+This workflow builds the Docker image on each pull request and deploys it to your container hosting platform.
 
 ```yaml title=".github/workflows/preview-docs-container.yml"
 name: preview-docs-container
@@ -73,7 +78,7 @@ jobs:
 </Accordion>
 <Accordion title="Static export preview workflow">
 
-Export the docs as static HTML and assets and upload them to an object store such as S3, Google Cloud Storage (GCS), or R2.
+This workflow builds the container, runs the static export, and uploads the output to S3. Adapt the upload step for your object store.
 
 ```yaml title=".github/workflows/preview-docs-static.yml"
 name: preview-docs-static

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -1,6 +1,7 @@
 ---
 title: Static export to S3
 description: Export your self-hosted documentation as static files and deploy them to an S3 bucket using a CI/CD pipeline.
+availability: beta
 ---
 
 <Markdown src="/snippets/agent-directive.mdx"/>

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -35,9 +35,6 @@ name: preview-docs-container
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   preview-docs:
@@ -79,9 +76,6 @@ name: preview-docs-static
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   preview-docs:
@@ -141,7 +135,6 @@ jobs:
           tar -xzf export.tar.gz -C ./site
 
       - name: Upload to S3
-        if: github.ref == 'refs/heads/main'
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --delete
@@ -151,6 +144,15 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
+          DEST_DIR: pr-${{ github.event.pull_request.number }}
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            Preview: http://${{ secrets.AWS_S3_BUCKET }}.s3-website.${{ secrets.AWS_REGION }}.amazonaws.com/pr-${{ github.event.pull_request.number }}
+          pr-number: ${{ github.event.pull_request.number }}
 
       - name: Stop container
         if: always()

--- a/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-static-export.mdx
@@ -1,6 +1,6 @@
 ---
-title: Previews / static export
-description: Export your self-hosted documentation as static files and deploy them to an S3 bucket using a CI/CD pipeline.
+title: Previews
+description: Set up preview environments for your self-hosted documentation using containers or static exports.
 availability: beta
 ---
 
@@ -8,16 +8,25 @@ availability: beta
 
 <Markdown src="/snippets/enterprise-plan.mdx" />
 
-You can use a CI/CD pipeline to build your docs container, export the static files, and push them to an S3 bucket (or any static file host).
+There are two ways to set up preview environments for your self-hosted docs: deploy a full container per preview, or export static files to an object store.
 
-<Note>
-Static exports do not include search or the API Explorer (Try it) functionality. This feature is in beta and may change in the future.
-</Note>
+## Container-based previews
 
-## GitHub Actions workflow
+Build and deploy the self-hosted container for each preview. This gives you an identical environment to production.
 
-```yaml title=".github/workflows/deploy-docs-s3.yml"
-name: deploy-docs-to-s3
+**Pros:**
+- All features work, including search, API Explorer (Try it), and authentication
+- No differences from the final production container
+
+**Cons:**
+- Requires hosting infrastructure (container runtime, load balancer, DNS)
+- Must clean up containers and resources after previews are no longer needed
+- Higher cost at scale
+
+### GitHub Actions workflow
+
+```yaml title=".github/workflows/preview-docs-container.yml"
+name: preview-docs-container
 
 on:
   pull_request:
@@ -26,7 +35,62 @@ on:
       - main
 
 jobs:
-  deploy-docs:
+  preview-docs:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build docs container
+        run: docker build -t self-hosted-docs:${{ github.sha }} .
+
+      - name: Push container to registry
+        run: |
+          docker tag self-hosted-docs:${{ github.sha }} ${{ secrets.REGISTRY }}/self-hosted-docs:${{ github.sha }}
+          docker push ${{ secrets.REGISTRY }}/self-hosted-docs:${{ github.sha }}
+
+      - name: Deploy preview
+        run: |
+          # Deploy the container to your hosting platform
+          # (e.g. ECS, Cloud Run, Kubernetes, etc.)
+          # and retrieve the preview URL
+          echo "Deploy self-hosted-docs:${{ github.sha }} to your platform"
+```
+
+## Static export previews <Badge intent="warning" minimal>Beta</Badge>
+
+Export the docs as static HTML and assets and upload them to an object store such as S3, GCS, or R2.
+
+**Pros:**
+- Static files can be served from any object store (S3, GCS, R2, etc.) with no running servers
+- Scale to thousands of previews without spinning up containers or load balancers
+- Low cost and simple cleanup
+
+**Cons:**
+- No search functionality
+- No API Explorer (Try it)
+- No authentication
+
+### GitHub Actions workflow
+
+```yaml title=".github/workflows/preview-docs-static.yml"
+name: preview-docs-static
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  preview-docs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:


### PR DESCRIPTION
# Add Previews page to self-hosted docs

## Summary

Adds a new documentation page under **Self-hosted → Previews** (`/learn/docs/self-hosted/previews`) that explains two approaches for setting up preview environments for self-hosted docs:

1. **Container-based previews** — build and deploy the full self-hosted container per preview. All features work (search, API Explorer, auth), but requires hosting infrastructure and cleanup.
2. **Static export previews** (marked with a `<Badge intent="warning" minimal>Beta</Badge>`) — export static HTML/assets and upload to S3/GCS/R2. Scales cheaply to thousands of previews, but no search, API Explorer, or auth.

The page opens with a side-by-side **comparison table** so readers can evaluate trade-offs at a glance (content rendering, search, API Explorer, auth, infrastructure, scaling, cost, cleanup). Below the table, an `<AccordionGroup>` contains the GitHub Actions workflow examples for each approach.

Both workflows trigger on `pull_request` only. The static export workflow uploads to a PR-specific S3 path (`pr-<number>/`) and comments the preview URL back on the PR.

The page is marked with `availability: beta` in frontmatter and includes the enterprise plan callout.

### Updates since last revision
- Fixed static export workflow: removed `if: github.ref == 'refs/heads/main'` guard on the upload step — the whole point is to upload a preview per PR
- Both workflows now trigger on `pull_request` only (removed `push` to `main`)
- Static export uploads to a PR-specific S3 path via `DEST_DIR: pr-${{ github.event.pull_request.number }}`
- Added "Comment preview URL on PR" step using `thollander/actions-comment-pull-request@v3`

## Review & Testing Checklist for Human

- [ ] **Verify the static export GHA workflow is correct and runnable** — the health check polling (`/__cache/stats`), export script (`/scripts/export.sh`), and archive path (`/tmp/fern-static-export.tar.gz`) were derived from reading source code but have not been tested in a real CI environment. Confirm paths and behavior match the latest self-hosted container.
- [ ] **Verify `DEST_DIR` is a valid env var for `jakejarvis/s3-sync-action@v0.5.1`** — the S3 upload step uses `DEST_DIR: pr-${{ github.event.pull_request.number }}` to namespace previews per PR. Confirm this env var is supported by the action and produces the expected S3 key prefix.
- [ ] **Review the container-based GHA workflow** — the deploy step is a placeholder (`echo "Deploy ..."`). Confirm this is a useful starting point for users.
- [ ] **Verify the `<Badge>` renders correctly inside the markdown table header** — the syntax `Static export <Badge intent="warning" minimal>Beta</Badge>` is used in a table cell. Check the preview deployment to confirm it renders as expected.
- [ ] **Check whether `jakejarvis/s3-sync-action@v0.5.1` should be SHA-pinned** — the user's original example pinned actions to a commit SHA; this uses a version tag instead.

**Suggested test plan:** Deploy the docs preview and navigate to `/learn/docs/self-hosted/previews` to verify:
- Page renders with the beta availability badge and enterprise callout
- Comparison table displays correctly with the inline Beta badge
- Both accordions expand/collapse and display the GHA workflow code blocks with YAML syntax highlighting
- Navigation sidebar shows "Previews" under the Self-hosted section

### Notes
- Requested by: @thesandlord
- [Devin Session](https://app.devin.ai/sessions/492eb4707ee44ef58969a5475a2735b5)