### PR TITLE
fix: escape `<=` in CLI changelog to fix MDX parse error

### DIFF
--- a/fern/products/cli-api-reference/cli-changelog/2026-03-02.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2026-03-02.mdx
@@ -19,7 +19,7 @@ treated as required `string` types.
 
 
 ## 4.0.0
-**`(chore):`** Deprecate IR versions <= 52. Cuts down on binary size, build time, and migrations.
+**`(chore):`** Deprecate IR versions `<= 52`. Cuts down on binary size, build time, and migrations.
 
 **Breaking changes**: To upgrade to this version of the CLI, generators now have
 minimal versions they need to be upgraded to with `fern generator upgrade --include-major`:


### PR DESCRIPTION
## Summary

The bare `<=` in the 4.0.0 changelog entry (`Deprecate IR versions <= 52.`) was causing an MDX parse error because `<` is interpreted as the start of a JSX element. Wrapping it in backticks (`` `<= 52` ``) escapes it.

This was blocking docs publishing — see [failed CI job](https://github.com/fern-api/docs/actions/runs/22668809264/job/65707268491?pr=4012).

The source of this changelog text is `packages/cli/cli/versions.yml` in [fern-api/fern](https://github.com/fern-api/fern), where a companion PR applies the same fix to prevent the issue from recurring on the next changelog sync.

## Review & Testing Checklist for Human
- [ ] Verify the rendered changelog entry for 4.0.0 displays correctly (`` `<= 52` `` should render as inline code)

### Notes
- [Devin Session](https://app.devin.ai/sessions/eeb73143b75146918c6762016c50edc2)
- Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
