### PR TITLE
Update quota docs: burst capacity from 10 to 20 generations

### DIFF
--- a/fern/products/sdks/how-it-works.mdx
+++ b/fern/products/sdks/how-it-works.mdx
@@ -68,10 +68,10 @@ Cloud (remote) generation uses a [leaky bucket](https://en.wikipedia.org/wiki/Le
 
 | Parameter | Value |
 | --- | --- |
-| Burst capacity | 10 generations |
+| Burst capacity | 20 generations |
 | Refill rate | 5 generations per minute |
 
-You can run up to 10 generations in quick succession. Fern then replenishes your allowance at 5 generations per minute, so if you hit the limit, subsequent requests will be throttled until enough capacity is restored. In practice, this only affects automated workflows that trigger many generations in a tight loop — occasional manual runs won't come close to the limit.
+You can run up to 20 generations in quick succession. Fern then replenishes your allowance at 5 generations per minute, so if you hit the limit, subsequent requests will be throttled until enough capacity is restored. In practice, this only affects automated workflows that trigger many generations in a tight loop — occasional manual runs won't come close to the limit.
 
 <Note>
 Rate limits apply only to cloud generation. [Local generation](/learn/sdks/deep-dives/self-hosted) using `--local` isn't subject to any quotas.


### PR DESCRIPTION
## Summary

Updates the public documentation for remote generation rate limits to reflect the increased burst capacity from 10 to 20 generations. The refill rate (5 generations per minute) remains unchanged.

Changes in `fern/products/sdks/how-it-works.mdx`:
- Burst capacity table value: 10 → 20
- Prose description: "up to 10 generations" → "up to 20 generations"

This is the docs companion to the backend change in `fern-api/fiddle` which updates `DEFAULT_QUOTA` burst from 10 to 20.

## Review & Testing Checklist for Human

- [ ] Verify the companion PR in `fern-api/fiddle` (updating `InMemoryOrganizationConfigStore.java`) is merged before or alongside this PR, so published docs match actual behavior
- [ ] Confirm the burst capacity value (20) and refill rate (5/min, unchanged) are correct per the intended policy change

### Notes
- [Link to Devin session](https://app.devin.ai/sessions/89b6175f622544bd8f1c1e9a7caeb684)
- Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
