### PR TITLE
Document Fern.HamburgerMenu and mobile menu examples

### DIFF
--- a/fern/products/docs/pages/customization/custom-header-footer.mdx
+++ b/fern/products/docs/pages/customization/custom-header-footer.mdx
@@ -157,4 +157,95 @@ export default function CustomHeader() {
 }
 ```
 </Accordion>
+<Accordion title="Custom mobile menu">
+
+On mobile viewports, Fern includes a built-in sidebar that opens via a swipe gesture. If your custom header provides its own mobile navigation, you can disable Fern's default mobile sidebar and replace it with your own.
+
+The example below demonstrates how to:
+
+1. Use a `useEffect` hook to inject a style that hides Fern's default mobile swipe panel
+2. Render a hamburger button (visible only on mobile) that toggles a custom side panel using React state and Tailwind classes
+
+```tsx components/CustomHeader.tsx
+import { useEffect, useState } from "react";
+
+export default function CustomHeader({ Fern }) {
+    const [menuOpen, setMenuOpen] = useState(false);
+
+    // Hide Fern's default mobile swipe panel
+    useEffect(() => {
+        const style = document.createElement("style");
+        style.textContent = `
+            #fern-sidebar[data-viewport="mobile"],
+            #fern-sidebar-overlay {
+                display: none !important;
+            }
+        `;
+        document.head.appendChild(style);
+        return () => {
+            style.remove();
+        };
+    }, []);
+
+    return (
+        <header className="relative w-full py-4 px-6 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+            <div className="max-w-7xl mx-auto flex items-center justify-between">
+                <Fern.Logo />
+
+                {/* Desktop navigation */}
+                <nav className="hidden lg:flex items-center gap-6">
+                    <Fern.NavbarLinks />
+                    <Fern.ThemeSwitch />
+                </nav>
+
+                {/* Mobile menu button - visible only on small screens */}
+                <button
+                    className="lg:hidden p-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800"
+                    onClick={() => setMenuOpen(!menuOpen)}
+                    aria-label="Toggle menu"
+                >
+                    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        {menuOpen ? (
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        ) : (
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                        )}
+                    </svg>
+                </button>
+            </div>
+
+            {/* Custom mobile side panel */}
+            <div
+                className={`
+                    fixed top-[var(--header-height)] right-0 bottom-0 w-72
+                    bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800
+                    transform transition-transform duration-300 ease-in-out z-50
+                    ${menuOpen ? "translate-x-0" : "translate-x-full"}
+                    lg:hidden
+                `}
+            >
+                <nav className="flex flex-col p-6 gap-4">
+                    <Fern.NavbarLinks />
+                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+                        <Fern.ThemeSwitch />
+                    </div>
+                </nav>
+            </div>
+
+            {/* Overlay when mobile menu is open */}
+            {menuOpen && (
+                <div
+                    className="fixed inset-0 top-[var(--header-height)] bg-black/40 z-40 lg:hidden"
+                    onClick={() => setMenuOpen(false)}
+                />
+            )}
+        </header>
+    );
+}
+```
+
+<Note>
+The `useEffect` hook injects a CSS rule targeting `#fern-sidebar[data-viewport="mobile"]` and `#fern-sidebar-overlay` to hide Fern's default mobile sidebar. This prevents the built-in swipe-to-open gesture from displaying Fern's sidebar, so your custom panel is the only mobile navigation.
+</Note>
+</Accordion>
 </AccordionGroup>

--- a/fern/products/docs/pages/customization/custom-header-footer.mdx
+++ b/fern/products/docs/pages/customization/custom-header-footer.mdx
@@ -103,6 +103,7 @@ The following components are available on the `Fern` prop:
 | `<Fern.NavbarLinks />` | The [navigation links](/docs/configuration/site-level-settings#navbar-links-configuration) configured under `navbar-links` in `docs.yml`. |
 | `<Fern.LoginButton />` | The login/signup button for [authenticated docs](/docs/authentication/overview). |
 | `<Fern.ThemeSwitch />` | Toggle between [light and dark mode](/docs/configuration/site-level-settings#theme-configuration). |
+| `<Fern.HamburgerMenu />` | Fern's built-in mobile sidebar toggle button. Shows a hamburger/close icon and opens the dismissible sidebar. Only visible on mobile viewports. |
 </Accordion>
 <Accordion title="Use React hooks">
 
@@ -157,14 +158,42 @@ export default function CustomHeader() {
 }
 ```
 </Accordion>
+<Accordion title="Mobile sidebar toggle">
+
+Use `<Fern.HamburgerMenu />` to render Fern's built-in mobile sidebar toggle button in your custom header. This opens the same dismissible sidebar that the default header uses, including any navigation links, version/product switchers, and search.
+
+```tsx components/CustomHeader.tsx
+export default function CustomHeader({ Fern }) {
+    return (
+        <header className="w-full py-4 px-6 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+            <div className="max-w-7xl mx-auto flex items-center justify-between">
+                <Fern.Logo />
+
+                {/* Desktop navigation */}
+                <nav className="hidden lg:flex items-center gap-6">
+                    <Fern.NavbarLinks />
+                    <Fern.ThemeSwitch />
+                </nav>
+
+                {/* Mobile: Fern's built-in hamburger menu toggle */}
+                <Fern.HamburgerMenu />
+            </div>
+        </header>
+    );
+}
+```
+
+The button automatically shows a hamburger icon when the sidebar is closed and a close icon when open. It is only visible on mobile viewports (`< 1024px`).
+
+</Accordion>
 <Accordion title="Custom mobile menu">
 
-On mobile viewports, Fern includes a built-in sidebar that opens via a swipe gesture. If your custom header provides its own mobile navigation, you can disable Fern's default mobile sidebar and replace it with your own.
+If you need a fully custom mobile navigation instead of Fern's built-in sidebar, you can disable the default mobile sidebar and build your own panel using React state and Tailwind classes.
 
 The example below demonstrates how to:
 
 1. Use a `useEffect` hook to inject a style that hides Fern's default mobile swipe panel
-2. Render a hamburger button (visible only on mobile) that toggles a custom side panel using React state and Tailwind classes
+2. Render a hamburger button (visible only on mobile) that toggles a custom side panel
 
 ```tsx components/CustomHeader.tsx
 import { useEffect, useState } from "react";

--- a/fern/products/docs/pages/customization/custom-header-footer.mdx
+++ b/fern/products/docs/pages/customization/custom-header-footer.mdx
@@ -183,7 +183,7 @@ export default function CustomHeader({ Fern }) {
 }
 ```
 
-The button automatically shows a hamburger icon when the sidebar is closed and a close icon when open. It is only visible on mobile viewports (`< 1024px`).
+The button automatically shows a hamburger icon when the sidebar is closed and a close icon when open. It's only visible on mobile viewports (`< 1024px`).
 
 </Accordion>
 <Accordion title="Custom mobile menu">


### PR DESCRIPTION
# Document Fern.HamburgerMenu and mobile menu examples

## Summary
Updates the [Header and footer](https://buildwithfern.com/docs/customization/header-and-footer) documentation page with:

1. **`Fern.HamburgerMenu` in the component table** — Adds a new row to the "Reuse built-in Fern components" table documenting the built-in mobile sidebar toggle button.
2. **New "Mobile sidebar toggle" accordion** — Shows how to use `<Fern.HamburgerMenu />` in a custom header to render Fern's native hamburger/close button that opens the built-in dismissible sidebar.
3. **"Custom mobile menu" accordion** (from initial revision) — Preserved as the advanced alternative for customers who need a fully custom mobile navigation panel. Uses `useEffect` to inject CSS hiding Fern's default mobile sidebar, and builds a custom side panel with `useState` + Tailwind classes.

## Updates since last revision
- Added `<Fern.HamburgerMenu />` row to the built-in components table
- Added a new "Mobile sidebar toggle" accordion as the **recommended** approach (simple, uses Fern's built-in button)
- Reframed the "Custom mobile menu" accordion as the escape hatch for customers who need full control over mobile nav

> **Dependency:** This documentation references `Fern.HamburgerMenu`, which is being added to the platform in [fern-platform#8166](https://github.com/fern-api/fern-platform/pull/8166). That PR must be merged before or alongside this one.

## Review & Testing Checklist for Human
- [ ] **Platform PR dependency**: Verify [fern-platform#8166](https://github.com/fern-api/fern-platform/pull/8166) is merged (or will be merged before this) — otherwise `<Fern.HamburgerMenu />` will not exist at runtime and the documented example won't work.
- [ ] **HamburgerMenu behavior accuracy**: The docs state the button "is only visible on mobile viewports (`< 1024px`)" and "automatically shows a hamburger icon when closed and a close icon when open." Verify these claims match the actual `MobileMenuButton` component behavior.
- [ ] **Deploy preview rendering**: Check the rendered accordions on the docs preview to ensure all three accordions ("Reuse built-in Fern components", "Mobile sidebar toggle", "Custom mobile menu") render correctly with proper code blocks and `<Note>` components.
- [ ] **Scroll-lock side effect** (Custom mobile menu only): The `useEffect` CSS hack hides the mobile sidebar visually, but Fern's swipe listener still runs on `document`-level pointer events. A swipe gesture could activate `RemoveScroll` and block page scrolling even with the sidebar hidden. Verify whether this is an issue in practice.
- [ ] **CSS selector stability** (Custom mobile menu only): Confirm `#fern-sidebar[data-viewport="mobile"]` and `#fern-sidebar-overlay` are stable selectors.

### Notes
- Requested by: @kgowru
- [Devin Session](https://app.devin.ai/sessions/14ea3b2ce7e542eabb5fe78b2f029c52)