### PR TITLE
docs: add URI and path-based auto-pagination documentation

### DIFF
--- a/fern/products/api-def/ferndef-pages/endpoints.mdx
+++ b/fern/products/api-def/ferndef-pages/endpoints.mdx
@@ -314,7 +314,7 @@ types:
 
 ### Pagination
 
-Endpoints can specify pagination configuration to enable auto-pagination in [generated SDKs](/learn/sdks/deep-dives/auto-pagination). Fern supports offset-based, cursor-based, URI-based, and path-based pagination schemes.
+Endpoints can specify pagination configuration to enable auto-pagination in [generated SDKs](/learn/sdks/deep-dives/auto-pagination). Fern supports offset, cursor, URI, and path-based pagination schemes.
 
 <CodeBlocks>
 ```yaml title="Offset pagination" {8-12}

--- a/fern/products/api-def/ferndef-pages/endpoints.mdx
+++ b/fern/products/api-def/ferndef-pages/endpoints.mdx
@@ -314,7 +314,7 @@ types:
 
 ### Pagination
 
-Endpoints can specify pagination configuration to enable auto-pagination in [generated SDKs](/learn/sdks/deep-dives/auto-pagination). Fern supports both offset-based and cursor-based pagination schemes.
+Endpoints can specify pagination configuration to enable auto-pagination in [generated SDKs](/learn/sdks/deep-dives/auto-pagination). Fern supports offset-based, cursor-based, URI-based, and path-based pagination schemes.
 
 <CodeBlocks>
 ```yaml title="Offset pagination" {8-12}
@@ -371,6 +371,46 @@ types:
           next:
             properties:
               starting_after: optional<string>
+```
+
+```yaml title="URI pagination" {8-10}
+service:
+  base-path: /plants
+  auth: false
+  endpoints:
+    list:
+      path: ""
+      method: GET
+      pagination:
+        next_uri: $response.next_page_url
+        results: $response.data
+      response: ListPlantsResponse
+
+types:
+  ListPlantsResponse:
+    properties:
+      data: list<Plant>
+      next_page_url: optional<string>
+```
+
+```yaml title="Path pagination" {8-10}
+service:
+  base-path: /plants
+  auth: false
+  endpoints:
+    list:
+      path: ""
+      method: GET
+      pagination:
+        next_path: $response.next_page_path
+        results: $response.data
+      response: ListPlantsResponse
+
+types:
+  ListPlantsResponse:
+    properties:
+      data: list<Plant>
+      next_page_path: optional<string>
 ```
 </CodeBlocks>
 

--- a/fern/products/api-def/openapi-pages/extensions/pagination.mdx
+++ b/fern/products/api-def/openapi-pages/extensions/pagination.mdx
@@ -10,7 +10,7 @@ description: Configure auto-pagination for list endpoints using the x-fern-pagin
 
 The `x-fern-pagination` extension configures auto-pagination for list endpoints in your OpenAPI specification. [Fern's generated SDKs](/learn/sdks/deep-dives/auto-pagination) provide simple iterators that handle pagination automatically, so SDK users can loop through all results without managing pagination complexity manually.
 
-To configure pagination, annotate the desired endpoint with the `x-fern-pagination` extension, specify the pagination scheme (`offset` or `cursor`), and indicate where your results are located using dot-access notation.
+To configure pagination, annotate the desired endpoint with the `x-fern-pagination` extension, specify the pagination scheme (`offset`, `cursor`, `next_uri`, or `next_path`), and indicate where your results are located using dot-access notation.
 
 <CodeBlocks>
 ```yaml title="Offset pagination" {5-7}
@@ -64,6 +64,56 @@ paths:
                 properties:
                   next:
                     type: string
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Plant'
+```
+
+```yaml title="URI pagination" {5-7}
+paths:
+  /plants:
+    get:
+      operationId: list_plants
+      x-fern-pagination:
+        next_uri: $response.next_page_url
+        results: $response.results
+      responses:
+        '200':
+          description: List of plants
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_page_url:
+                    type: string
+                    nullable: true
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Plant'
+```
+
+```yaml title="Path pagination" {5-7}
+paths:
+  /plants:
+    get:
+      operationId: list_plants
+      x-fern-pagination:
+        next_path: $response.next_page_path
+        results: $response.results
+      responses:
+        '200':
+          description: List of plants
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  next_page_path:
+                    type: string
+                    nullable: true
                   results:
                     type: array
                     items:

--- a/fern/products/sdks/guides/configure-auto-pagination.mdx
+++ b/fern/products/sdks/guides/configure-auto-pagination.mdx
@@ -7,7 +7,7 @@ description: Paginate through API responses with offset, cursor, URI, and path-b
 
 <Markdown src="/snippets/pro-plan.mdx"/>
 
-Fern's auto pagination supports offset-based, cursor-based, URI-based, and path-based
+Fern's auto pagination supports offset, cursor, URI, and path-based
 pagination schemes, providing SDK users with simple iterators to loop through all
 results instead of managing pagination complexity manually.
 

--- a/fern/products/sdks/guides/configure-auto-pagination.mdx
+++ b/fern/products/sdks/guides/configure-auto-pagination.mdx
@@ -1,15 +1,15 @@
 ---
 title: Configure auto pagination
-description: Paginate through API responses easily with offset, cursor, and link-based pagination.
+description: Paginate through API responses easily with offset, cursor, URI, and path-based pagination.
 ---
 
 <Markdown src="/snippets/agent-directive.mdx"/>
 
 <Markdown src="/snippets/pro-plan.mdx"/>
 
-Fern's auto pagination supports offset-based and cursor-based pagination schemes,
-providing SDK users with simple iterators to loop through all results instead of
-managing pagination complexity manually.
+Fern's auto pagination supports offset-based, cursor-based, URI-based, and path-based
+pagination schemes, providing SDK users with simple iterators to loop through all
+results instead of managing pagination complexity manually.
 
 This page describes how to configure auto pagination for your API endpoints.
 
@@ -96,8 +96,8 @@ your results are located.
 
 To set up auto pagination for OpenAPI:
 
-1. Annotate the desired paginated endpoint with the [`x-fern-pagination` extension](/api-definitions/openapi/extensions/pagination)
-2. Specify the pagination scheme (`offset` or `cursor`)
+1. Annotate the desired paginated endpoint with the [`x-fern-pagination` extension](/learn/api-definitions/openapi/extensions/pagination)
+2. Specify the pagination scheme (`offset`, `cursor`, `next_uri`, or `next_path`)
 3. Specify where your `results` are located using dot-access notation
 
 
@@ -105,7 +105,7 @@ To set up auto pagination for OpenAPI:
 ```yaml Offset {4-6}
 ...
 paths:
-  /path/to/my/endpoint:
+  /plants:
     x-fern-pagination: # Add pagination extension
       offset: $request.page_number # Specify offset pagination scheme
       results: $response.results # Specify result location
@@ -115,11 +115,33 @@ paths:
 ```yaml Cursor {5-8}
 ...
 paths:
-  /path/to/my/endpoint:
+  /plants:
     get:
       x-fern-pagination: # Add pagination extension
         cursor: $request.cursor # Specify cursor pagination scheme
         next_cursor: $response.next
+        results: $response.results # Specify result location
+...
+```
+
+```yaml URI {5-7}
+...
+paths:
+  /plants:
+    get:
+      x-fern-pagination: # Add pagination extension
+        next_uri: $response.next_page_url # Full URL for the next page
+        results: $response.results # Specify result location
+...
+```
+
+```yaml Path {5-7}
+...
+paths:
+  /plants:
+    get:
+      x-fern-pagination: # Add pagination extension
+        next_path: $response.next_page_path # Relative path for the next page
         results: $response.results # Specify result location
 ...
 ```
@@ -131,7 +153,7 @@ paths:
 To set up auto pagination for the Fern Definition:
 
 1. Annotate the desired paginated endpoint with the [`pagination` field](/learn/api-definitions/ferndef/endpoints/overview#pagination)
-1. Specify the pagination scheme (`offset` or `cursor`)
+1. Specify the pagination scheme (`offset`, `cursor`, `next_uri`, or `next_path`)
 1. Specify where your `results` are located using dot-access notation.
 
 <Tip title="Offset pagination options">
@@ -157,6 +179,22 @@ service:
       pagination: # Add pagination field
         cursor: $request.starting_after # Specify cursor pagination scheme
         next_cursor: $response.page.next.starting_after
+        results: $response.data # Specify result location
+```
+```yaml URI {5-6}
+service:
+  endpoints:
+    listWithUriPagination:
+      pagination: # Add pagination field
+        next_uri: $response.next_page_url # Full URL for the next page
+        results: $response.data # Specify result location
+```
+```yaml Path {5-6}
+service:
+  endpoints:
+    listWithPathPagination:
+      pagination: # Add pagination field
+        next_path: $response.next_page_path # Relative path for the next page
         results: $response.data # Specify result location
 ```
 </CodeBlocks>

--- a/fern/products/sdks/guides/configure-auto-pagination.mdx
+++ b/fern/products/sdks/guides/configure-auto-pagination.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure auto pagination
-description: Paginate through API responses easily with offset, cursor, URI, and path-based pagination.
+description: Paginate through API responses with offset, cursor, URI, and path-based pagination.
 ---
 
 <Markdown src="/snippets/agent-directive.mdx"/>

--- a/fern/products/sdks/overview/typescript/design.mdx
+++ b/fern/products/sdks/overview/typescript/design.mdx
@@ -148,7 +148,8 @@ Fern supports the following pagination schemes:
 |-------------------|--------------------------------------------------|
 | Offset-based      | <Icon icon="check" color="var(--accent-a11)" />            |
 | Cursor-based      | <Icon icon="check" color="var(--accent-a11)" />            |
-| Link-based        |                                                  |
+| URI-based         | <Icon icon="check" color="var(--accent-a11)" />            |
+| Path-based        | <Icon icon="check" color="var(--accent-a11)" />            |
 
 #### Configuration
 
@@ -195,6 +196,28 @@ paths:
         results: $response.results
 ...
 ```
+
+```yaml URI
+...
+paths:
+  /path/to/my/endpoint:
+    get:
+      x-fern-pagination:
+        next_uri: $response.next_page_url
+        results: $response.results
+...
+```
+
+```yaml Path
+...
+paths:
+  /path/to/my/endpoint:
+    get:
+      x-fern-pagination:
+        next_path: $response.next_page_path
+        results: $response.results
+...
+```
 </CodeBlocks>
 </Tab>
 
@@ -217,6 +240,24 @@ service:
       pagination: 
         cursor: $request.starting_after
         next_cursor: $response.page.next.starting_after
+        results: $response.data
+```
+
+```yaml URI
+service:
+  endpoints:
+    listWithUriPagination:
+      pagination: 
+        next_uri: $response.next_page_url
+        results: $response.data
+```
+
+```yaml Path
+service:
+  endpoints:
+    listWithPathPagination:
+      pagination: 
+        next_path: $response.next_page_path
         results: $response.data
 ```
 

--- a/fern/snippets/pagination-properties.mdx
+++ b/fern/snippets/pagination-properties.mdx
@@ -3,6 +3,8 @@
 | `offset` | Path to the offset parameter in the request (e.g., `$request.page`) |
 | `cursor` | Path to the cursor parameter in the request (e.g., `$request.cursor`) |
 | `next_cursor` | Path to the next cursor value in the response (required for cursor pagination) |
+| `next_uri` | Path to the full next-page URL in the response (e.g., `$response.next_page_url`) |
+| `next_path` | Path to the relative path for the next page in the response (e.g., `$response.next_page_path`) |
 | `results` | Path to the results array in the response (e.g., `$response.data`) |
 | `step` | Path to the page size parameter, ensures offset increments correctly |
 | `has-next-page` | Path to a boolean indicator for additional pages |

--- a/fern/snippets/pagination-properties.mdx
+++ b/fern/snippets/pagination-properties.mdx
@@ -3,7 +3,7 @@
 | `offset` | Path to the offset parameter in the request (e.g., `$request.page`) |
 | `cursor` | Path to the cursor parameter in the request (e.g., `$request.cursor`) |
 | `next_cursor` | Path to the next cursor value in the response (required for cursor pagination) |
-| `next_uri` | Path to the full next-page URL in the response (e.g., `$response.next_page_url`) |
+| `next_uri` | Path to the next page's URL in the response (e.g., `$response.next_page_url`) |
 | `next_path` | Path to the relative path for the next page in the response (e.g., `$response.next_page_path`) |
 | `results` | Path to the results array in the response (e.g., `$response.data`) |
 | `step` | Path to the page size parameter, ensures offset increments correctly |


### PR DESCRIPTION
# docs: add URI and path-based auto-pagination documentation

## Summary

Documents the `next_uri` and `next_path` pagination schemes that were added to the Fern CLI (v3.72.0) and SDK generators. These schemes enable HATEOAS-style pagination where the API response contains a full URL or relative path to the next page, rather than using offset or cursor request parameters.

Changes span 5 files:
- **configure-auto-pagination.mdx** — Added URI and Path tabs to both OpenAPI and Fern Definition code examples; updated intro and scheme lists. Also fixed a broken link (`/api-definitions/...` → `/learn/api-definitions/...`).
- **pagination.mdx** (OpenAPI extension) — Added full URI and Path pagination OpenAPI examples with response schemas.
- **endpoints.mdx** (Fern Definition) — Added URI and Path pagination examples to the Pagination section.
- **design.mdx** (TypeScript) — Updated the supported pagination table (replaced empty "Link-based" row with checked "URI-based" and "Path-based" rows) and added configuration examples.
- **pagination-properties.mdx** (shared snippet) — Added `next_uri` and `next_path` rows to the properties table.

### Updates since last revision
- Removed adverb "easily" from `configure-auto-pagination.mdx` description field per Vale style check flagged by reviewdog.

## Review & Testing Checklist for Human

- [ ] **Verify rendered CodeBlocks/Tabs**: The URI and Path examples were added as new tabs inside existing `<CodeBlocks>` components across multiple pages. Preview the site to confirm they render correctly and tab switching works.
- [ ] **Verify highlighted line numbers**: Check that `{5-7}`, `{5-6}`, `{8-10}` line highlights in code blocks point to the correct lines in the rendered output.
- [ ] **Check the link fix**: `configure-auto-pagination.mdx` line 99 changed the link from `/api-definitions/openapi/extensions/pagination` to `/learn/api-definitions/openapi/extensions/pagination` — confirm the new path resolves correctly.

**Recommended test plan**: Use the preview deployment and navigate to:
- [`/learn/sdks/deep-dives/auto-pagination`](https://fern-preview-5a4a3bb1-57cd-44d2-a70d-98ec6633fca8.docs.buildwithfern.com/learn/sdks/deep-dives/auto-pagination)
- [`/learn/api-definitions/openapi/extensions/pagination`](https://fern-preview-5a4a3bb1-57cd-44d2-a70d-98ec6633fca8.docs.buildwithfern.com/learn/api-definitions/openapi/extensions/pagination)
- [`/learn/api-definitions/ferndef/endpoints/overview#pagination`](https://fern-preview-5a4a3bb1-57cd-44d2-a70d-98ec6633fca8.docs.buildwithfern.com/learn/api-definitions/ferndef/endpoints/overview#pagination)
- [`/learn/sdks/generators/typescript/design`](https://fern-preview-5a4a3bb1-57cd-44d2-a70d-98ec6633fca8.docs.buildwithfern.com/learn/sdks/generators/typescript/design)

### Notes
- Requested by: @iamnamananand996
- [Devin Session](https://app.devin.ai/sessions/0ccf24b3b17e4dc699b28387fd086d79)