### PR TITLE
Hide autorelease page and add early access banner

### DIFF
--- a/fern/products/sdks/autorelease.mdx
+++ b/fern/products/sdks/autorelease.mdx
@@ -5,6 +5,10 @@ description: Automate SDK releases with Fern Autorelease. Detects API spec chang
 
 <Markdown src="/snippets/agent-directive.mdx"/>
 
+<Note title="Early Access">
+Fern Autorelease is currently in early access. [Contact us](https://buildwithfern.com/contact) to get started.
+</Note>
+
 Fern Autorelease automates SDK releases end-to-end. When your API specification changes, Autorelease regenerates SDKs, determines the version bump, and publishes to package registries.
 
 ## How it works

--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -24,6 +24,7 @@ navigation:
         path: ./capabilities.mdx
         slug: capabilities
       - page: Fern Autorelease
+        hidden: true
         path: ./autorelease.mdx
         slug: autorelease
   - section: Generators


### PR DESCRIPTION
## Summary

Two small changes to the Fern Autorelease docs page:

1. **Hidden from navigation**: Added `hidden: true` to the autorelease entry in `sdks.yml` so it no longer appears in the sidebar, while remaining accessible via direct URL (`/learn/sdks/overview/autorelease`).
2. **Early access banner**: Added a `<Note title="Early Access">` banner at the top of `autorelease.mdx` indicating the feature is in early access with a link to the contact page.

## Review & Testing Checklist for Human

- [ ] Verify that `hidden: true` hides the page from the sidebar nav but keeps it accessible via direct URL — confirm this matches the intended behavior (vs. fully removing the page)
- [ ] Verify the `<Note>` banner renders correctly on the live page at `/learn/sdks/overview/autorelease`
- [ ] Confirm the [contact link](https://buildwithfern.com/contact) is the correct destination for early access inquiries

### Notes
- Requested by: @Swimburger
- [Devin Session](https://app.devin.ai/sessions/646cf30725364943bad8349536a2bd52)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
