### PR TITLE
Add library reference generation docs for Python and C++

### DIFF
--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -273,6 +273,10 @@ navigation:
           - page: GraphQL Reference
             path: ./pages/api-references/generate-graphql-ref.mdx
             slug: generate-graphql-ref
+          - page: Library reference
+            path: ./pages/api-references/generate-library-ref.mdx
+            slug: generate-library-ref
+            hidden: true
       - section: Customization
         skip-slug: true
         contents:

--- a/fern/products/docs/pages/api-references/generate-library-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-library-ref.mdx
@@ -1,0 +1,130 @@
+---
+title: Generate library reference
+subtitle: Generate reference documentation for Python and C++ libraries.
+description: Use Fern Docs to generate reference documentation for Python and C++ libraries.
+---
+
+<Note>
+  Library reference generation is in beta. To get started, contact [support@buildwithfern.com](mailto:support@buildwithfern.com).
+</Note>
+
+Fern generates reference documentation for Python and C++ libraries. Point Fern at your library source code and Fern renders modules, classes, functions, and types as an interactive reference, similar to an API Reference.
+
+## Supported languages
+
+| Language | Source format | Status |
+|----------|--------------|--------|
+| Python   | Python source files (`.py`) | Beta |
+| C++      | C++ header files (`.h`, `.hpp`) | Beta |
+
+## Configuration
+
+<Tabs>
+<Tab title="Python">
+
+<Steps>
+<Step title="Set up your project structure">
+
+Add your Python library source to your `/fern` directory and create a `generators.yml` that references it:
+
+```yaml generators.yml
+api:
+  specs:
+    - python-library: ./src
+```
+
+</Step>
+<Step title="Add the library reference to your navigation">
+
+Add `- api: Library Reference` to your navigation in `docs.yml`:
+
+```yml docs.yml
+navigation:
+  - api: Library Reference
+```
+
+Fern automatically discovers your modules, classes, functions, and types from your Python source files.
+</Step>
+<Step title="Customize the layout">
+
+For a full list of configuration options and layout customizations, see [Customize API Reference layout](/learn/docs/api-references/customize-api-reference-layout).
+
+</Step>
+</Steps>
+
+</Tab>
+<Tab title="C++">
+
+<Steps>
+<Step title="Set up your project structure">
+
+Add your C++ headers to your `/fern` directory and create a `generators.yml` that references them:
+
+```yaml generators.yml
+api:
+  specs:
+    - cpp-library: ./include
+```
+
+</Step>
+<Step title="Add the library reference to your navigation">
+
+Add `- api: Library Reference` to your navigation in `docs.yml`:
+
+```yml docs.yml
+navigation:
+  - api: Library Reference
+```
+
+Fern automatically discovers your classes, functions, enums, and types from your C++ header files.
+</Step>
+<Step title="Customize the layout">
+
+For a full list of configuration options and layout customizations, see [Customize API Reference layout](/learn/docs/api-references/customize-api-reference-layout).
+
+</Step>
+</Steps>
+
+</Tab>
+</Tabs>
+
+### Include more than one library reference
+
+To include multiple library references in your documentation, use the `api-name` property. The `api-name` corresponds to the folder name containing your library source.
+
+<Files>
+  <Folder name="fern" defaultOpen>
+    <File name="fern.config.json" />
+    <File name="docs.yml" />
+    <Folder name="plant-sdk" defaultOpen>
+      <Folder name="src" defaultOpen>
+        <File name="plants.py" comment="Python library source" />
+      </Folder>
+      <File name="generators.yml" />
+    </Folder>
+    <Folder name="garden-sdk" defaultOpen>
+      <Folder name="include" defaultOpen>
+        <File name="garden.hpp" comment="C++ library headers" />
+      </Folder>
+      <File name="generators.yml" />
+    </Folder>
+  </Folder>
+</Files>
+
+```yaml title="docs.yml"
+navigation:
+  - api: Plant SDK
+    api-name: plant-sdk
+  - api: Garden SDK
+    api-name: garden-sdk
+```
+
+### Configuration properties
+
+<ParamField path="api.specs[].python-library" required={false}>
+  Path to your Python library source directory. Fern scans this directory for modules, classes, and functions to generate reference documentation.
+</ParamField>
+
+<ParamField path="api.specs[].cpp-library" required={false}>
+  Path to your C++ library header directory. Fern scans this directory for classes, functions, enums, and types to generate reference documentation.
+</ParamField>

--- a/fern/products/docs/pages/api-references/generate-library-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-library-ref.mdx
@@ -8,123 +8,98 @@ description: Use Fern Docs to generate reference documentation for Python and C+
   Library reference generation is in beta. To get started, contact [support@buildwithfern.com](mailto:support@buildwithfern.com).
 </Note>
 
-Fern generates reference documentation for Python and C++ libraries. Point Fern at your library source code and Fern renders modules, classes, functions, and types as an interactive reference, similar to an API Reference.
+Fern generates reference documentation for Python and C++ libraries. Point Fern at a Git repository containing your library source code and Fern renders modules, classes, functions, and types as an interactive reference, similar to an API Reference.
 
 ## Supported languages
 
-| Language | Source format | Status |
-|----------|--------------|--------|
-| Python   | Python source files (`.py`) | Beta |
-| C++      | C++ header files (`.h`, `.hpp`) | Beta |
+| Language | `lang` value | Status |
+|----------|-------------|--------|
+| Python   | `python`    | Beta   |
+| C++      | `cpp`       | Beta   |
 
 ## Configuration
+
+Add a `libraries` section to your `docs.yml` to define one or more library references. Each library requires a Git URL (`input.git`), an output path (`output.path`), and a language (`lang`).
 
 <Tabs>
 <Tab title="Python">
 
-<Steps>
-<Step title="Set up your project structure">
-
-Add your Python library source to your `/fern` directory and create a `generators.yml` that references it:
-
-```yaml generators.yml
-api:
-  specs:
-    - python-library: ./src
+```yaml docs.yml
+libraries:
+  plant-sdk:
+    input:
+      git: "https://github.com/org/plant-sdk"
+      subpath: "src/sdk"               # optional
+    output:
+      path: "./pages/reference"
+    lang: python
 ```
-
-</Step>
-<Step title="Add the library reference to your navigation">
-
-Add `- api: Library Reference` to your navigation in `docs.yml`:
-
-```yml docs.yml
-navigation:
-  - api: Library Reference
-```
-
-Fern automatically discovers your modules, classes, functions, and types from your Python source files.
-</Step>
-<Step title="Customize the layout">
-
-For a full list of configuration options and layout customizations, see [Customize API Reference layout](/learn/docs/api-references/customize-api-reference-layout).
-
-</Step>
-</Steps>
 
 </Tab>
 <Tab title="C++">
 
-<Steps>
-<Step title="Set up your project structure">
-
-Add your C++ headers to your `/fern` directory and create a `generators.yml` that references them:
-
-```yaml generators.yml
-api:
-  specs:
-    - cpp-library: ./include
+```yaml docs.yml
+libraries:
+  garden-sdk:
+    input:
+      git: "https://github.com/org/garden-sdk"
+      subpath: "include"               # optional
+    output:
+      path: "./pages/reference"
+    lang: cpp
+    config:                             # optional
+      doxyfile: "./Doxyfile.txt"        # C++ only
 ```
-
-</Step>
-<Step title="Add the library reference to your navigation">
-
-Add `- api: Library Reference` to your navigation in `docs.yml`:
-
-```yml docs.yml
-navigation:
-  - api: Library Reference
-```
-
-Fern automatically discovers your classes, functions, enums, and types from your C++ header files.
-</Step>
-<Step title="Customize the layout">
-
-For a full list of configuration options and layout customizations, see [Customize API Reference layout](/learn/docs/api-references/customize-api-reference-layout).
-
-</Step>
-</Steps>
 
 </Tab>
 </Tabs>
 
-### Include more than one library reference
+Fern clones the repository, reads the source files, and generates reference pages at the specified output path.
 
-To include multiple library references in your documentation, use the `api-name` property. The `api-name` corresponds to the folder name containing your library source.
+### Multiple libraries
 
-<Files>
-  <Folder name="fern" defaultOpen>
-    <File name="fern.config.json" />
-    <File name="docs.yml" />
-    <Folder name="plant-sdk" defaultOpen>
-      <Folder name="src" defaultOpen>
-        <File name="plants.py" comment="Python library source" />
-      </Folder>
-      <File name="generators.yml" />
-    </Folder>
-    <Folder name="garden-sdk" defaultOpen>
-      <Folder name="include" defaultOpen>
-        <File name="garden.hpp" comment="C++ library headers" />
-      </Folder>
-      <File name="generators.yml" />
-    </Folder>
-  </Folder>
-</Files>
+Define more than one library in the `libraries` section:
 
-```yaml title="docs.yml"
-navigation:
-  - api: Plant SDK
-    api-name: plant-sdk
-  - api: Garden SDK
-    api-name: garden-sdk
+```yaml docs.yml
+libraries:
+  plant-sdk:
+    input:
+      git: "https://github.com/org/plant-sdk"
+    output:
+      path: "./pages/plant-reference"
+    lang: python
+  garden-sdk:
+    input:
+      git: "https://github.com/org/garden-sdk"
+    output:
+      path: "./pages/garden-reference"
+    lang: cpp
+    config:
+      doxyfile: "./Doxyfile.txt"
 ```
 
-### Configuration properties
+## Configuration properties
 
-<ParamField path="api.specs[].python-library" required={false}>
-  Path to your Python library source directory. Fern scans this directory for modules, classes, and functions to generate reference documentation.
+<ParamField path="libraries.<name>.input.git" required>
+  Git URL of the repository containing your library source code. This is the only supported input type.
 </ParamField>
 
-<ParamField path="api.specs[].cpp-library" required={false}>
-  Path to your C++ library header directory. Fern scans this directory for classes, functions, enums, and types to generate reference documentation.
+<ParamField path="libraries.<name>.input.subpath">
+  Subdirectory within the repository to use as the library root. Use this when your library source isn't at the repository root.
+</ParamField>
+
+<ParamField path="libraries.<name>.output.path" required>
+  Local path where Fern writes the generated reference pages.
+</ParamField>
+
+<ParamField path="libraries.<name>.lang" required>
+  The language of the library. Must be `python` or `cpp`. This determines which generator processes the source code.
+</ParamField>
+
+<ParamField path="libraries.<name>.config">
+  Language-specific configuration options.
+</ParamField>
+
+<ParamField path="libraries.<name>.config.doxyfile">
+  Path to a Doxygen configuration file. C++ only. Fern reads this file and sends its content to the backend for processing.
 </ParamField>


### PR DESCRIPTION
## Summary

Adds a new hidden documentation page describing how to generate reference documentation for Python and C++ libraries using Fern Docs. The page is marked as beta and hidden from sidebar navigation, accessible only via direct URL.

**Changes:**
- New page: `fern/products/docs/pages/api-references/generate-library-ref.mdx`
- Navigation entry added to `docs.yml` under API References > Generation with `hidden: true`

The page covers the `docs.yml` `libraries` configuration schema, including:
- Beta callout with contact link
- Supported languages table (`python`, `cpp`)
- Tabbed configuration examples for Python and C++
- Multi-library setup example
- Configuration properties reference (`input.git`, `input.subpath`, `output.path`, `lang`, `config.doxyfile`)

### Updates since last revision
- Rewrote configuration section to use the correct `docs.yml` `libraries` schema (previously incorrectly used `generators.yml` with `api.specs`)
- Schema now matches the actual implementation: `input.git`, `input.subpath`, `output.path`, `lang`, and `config.doxyfile` (C++ only)

## Review & Testing Checklist for Human

- [ ] **Verify the `libraries` schema is complete and accurate**: The schema was derived from a screenshot of the implementation spec. Confirm all properties (`input.git`, `input.subpath`, `output.path`, `lang`, `config`, `config.doxyfile`) are documented correctly and no properties are missing.
- [ ] **Verify what Fern renders for each language**: The page claims Fern renders "modules, classes, functions, and types" — confirm this matches actual output for both Python and C++.
- [ ] **Confirm the page doesn't need to document how generated pages are wired into navigation**: The schema has `output.path` but the page doesn't explain how the generated reference pages appear in the docs site navigation. Verify whether additional `docs.yml` navigation config is needed.
- [ ] **Check page placement**: Page is under API References > Generation alongside REST, gRPC, GraphQL, etc. — confirm this is the right section for library docs.

**Suggested test plan:** Deploy a preview build and visit the page directly at `/learn/docs/api-references/generate-library-ref` to verify it renders correctly and is not visible in the sidebar.

### Notes
- [Link to Devin session](https://app.devin.ai/sessions/7212601e574e45ea8a25a01b4110be4c)
- Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
