### PR TITLE
Update C# SDK generator config docs to match source schema

### DIFF
--- a/fern/products/sdks/overview/csharp/configuration.mdx
+++ b/fern/products/sdks/overview/csharp/configuration.mdx
@@ -37,20 +37,12 @@ Customizes the name of the pagination helper class used for handling paginated A
 When enabled, generates enum types that can handle unknown values. This allows the SDK to process new enum values that may be added to the API without breaking existing client code, improving forward compatibility.
 </ParamField>
 
-<ParamField path="enable-wire-tests" type="boolean" default="false" required={false} toc={true}>
-Alias for `generate-mock-server-tests`. Generates [mock server (wire) tests](/learn/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
-</ParamField>
-
 <ParamField path="environment-class-name" type="string" required={false} toc={true}>
 Specifies the name of the environment configuration class used for managing different API environments (e.g., development, staging, production).
 </ParamField>
 
 <ParamField path="explicit-namespaces" type="boolean" required={false} toc={true}>
 When enabled, generates code with explicit namespace declarations throughout the SDK. This can help avoid naming conflicts and improve code clarity in larger projects.
-</ParamField>
-
-<ParamField path="exception-interceptor-class-name" type="string" required={false} toc={true}>
-Customizes the name of the exception interceptor class generated when `include-exception-handler` is enabled. Defaults to `{PackageName}ExceptionInterceptor`.
 </ParamField>
 
 <ParamField path="exported-client-class-name" type="string" required={false} toc={true}>
@@ -77,23 +69,6 @@ When enabled, path parameters are included as properties in the request object i
 Specifies the root namespace for all generated .NET code. This determines the namespace hierarchy that users will import when using the SDK.
 </ParamField>
 
-<ParamField path="output-path" type="string | object" required={false} toc={true}>
-Configures where generated files are placed. Accepts either a simple string (all files go to that path) or an object with specific paths:
-
-```yaml
-config:
-  # Simple: all files go to "src"
-  output-path: src
-
-  # Object: specify paths per project type
-  output-path:
-    library: path/to/src/ApiLib
-    test: path/to/test/ApiLib.Test
-    solution: .
-    other: path/to/src/ApiLib
-```
-</ParamField>
-
 <ParamField path="package-id" type="string" required={false} toc={true}>
 Sets the NuGet package identifier for the generated SDK. This is used when publishing the SDK to NuGet or other package repositories.
 </ParamField>
@@ -114,18 +89,6 @@ Controls the access modifier for the root client class. Use 'public' to make the
 When enabled, places core SDK classes (like base client classes and utilities) in the root namespace instead of nested namespaces. This can simplify imports for commonly used types.
 </ParamField>
 
-<ParamField path="simplify-object-dictionaries" type="boolean" required={false} toc={true}>
-When enabled, simplifies object dictionaries in generated code for better type safety.
-</ParamField>
-
-<ParamField path="use-default-request-parameter-values" type="boolean" required={false} toc={true}>
-When enabled, the SDK generates `= default` initializers for request record properties that have defaults. Properties with a default also have the `required` keyword removed, allowing users to omit them during initialization.
-</ParamField>
-
 <ParamField path="use-discriminated-unions" type="boolean" required={false} toc={true}>
 When enabled, generates discriminated union types for API responses that can contain multiple different object types. This provides type-safe handling of polymorphic responses.
-</ParamField>
-
-<ParamField path="use-undiscriminated-unions" type="boolean" required={false} toc={true}>
-When enabled, generates type-safe undiscriminated union types using runtime type detection instead of the `OneOf` library.
 </ParamField>

--- a/fern/products/sdks/overview/csharp/configuration.mdx
+++ b/fern/products/sdks/overview/csharp/configuration.mdx
@@ -12,14 +12,10 @@ groups:
   csharp-sdk:
     generators:
       - name: fernapi/fern-csharp-sdk
-		    version: <Markdown src="/snippets/version-number-csharp.mdx"/>
+        version: <Markdown src="/snippets/version-number-csharp.mdx"/>
         config:
-          client_class_name: YourApiClient
+          client-class-name: YourApiClient
 ```
-
-<ParamField path="additional-properties" type="boolean" required={false} toc={true}>
-When enabled, allows handling of additional properties not explicitly defined in the API specification. This provides flexibility for APIs that may include extra fields in responses.
-</ParamField>
 
 <ParamField path="base-api-exception-class-name" type="string" required={false} toc={true}>
 Customizes the name of the base API exception class that all API-specific exceptions will inherit from. This allows you to define a custom base exception class name for better integration with your existing error handling patterns.
@@ -38,7 +34,11 @@ Customizes the name of the pagination helper class used for handling paginated A
 </ParamField>
 
 <ParamField path="enable-forward-compatible-enums" type="boolean" required={false} toc={true}>
-When enabled, generates enum types that can handle unknown values gracefully. This allows the SDK to process new enum values that may be added to the API without breaking existing client code, improving forward compatibility.
+When enabled, generates enum types that can handle unknown values. This allows the SDK to process new enum values that may be added to the API without breaking existing client code, improving forward compatibility.
+</ParamField>
+
+<ParamField path="enable-wire-tests" type="boolean" default="false" required={false} toc={true}>
+Alias for `generate-mock-server-tests`. Generates [mock server (wire) tests](/learn/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
 </ParamField>
 
 <ParamField path="environment-class-name" type="string" required={false} toc={true}>
@@ -49,16 +49,20 @@ Specifies the name of the environment configuration class used for managing diff
 When enabled, generates code with explicit namespace declarations throughout the SDK. This can help avoid naming conflicts and improve code clarity in larger projects.
 </ParamField>
 
+<ParamField path="exception-interceptor-class-name" type="string" required={false} toc={true}>
+Customizes the name of the exception interceptor class generated when `include-exception-handler` is enabled. Defaults to `{PackageName}ExceptionInterceptor`.
+</ParamField>
+
 <ParamField path="exported-client-class-name" type="string" required={false} toc={true}>
 Sets the name of the exported client class that will be used in code examples and documentation. This is useful for customizing how the client appears in generated documentation.
 </ParamField>
 
 <ParamField path="generate-error-types" type="boolean" required={false} toc={true}>
-When enabled, generates specific error type classes for different API errors. This provides strongly-typed error handling instead of using generic exception types.
+When enabled, generates specific error type classes for different API errors. This provides strongly typed error handling instead of using generic exception types.
 </ParamField>
 
 <ParamField path="generate-mock-server-tests" type="boolean" default="true" required={false} toc={true}>
-Generates [mock server (wire) tests](/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
+Generates [mock server (wire) tests](/learn/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
 </ParamField>
 
 <ParamField path="include-exception-handler" type="boolean" required={false} toc={true}>
@@ -73,12 +77,33 @@ When enabled, path parameters are included as properties in the request object i
 Specifies the root namespace for all generated .NET code. This determines the namespace hierarchy that users will import when using the SDK.
 </ParamField>
 
-<ParamField path="package-name" type="string" required={false} toc={true}>
+<ParamField path="output-path" type="string | object" required={false} toc={true}>
+Configures where generated files are placed. Accepts either a simple string (all files go to that path) or an object with specific paths:
+
+```yaml
+config:
+  # Simple: all files go to "src"
+  output-path: src
+
+  # Object: specify paths per project type
+  output-path:
+    library: path/to/src/ApiLib
+    test: path/to/test/ApiLib.Test
+    solution: .
+    other: path/to/src/ApiLib
+```
+</ParamField>
+
+<ParamField path="package-id" type="string" required={false} toc={true}>
 Sets the NuGet package identifier for the generated SDK. This is used when publishing the SDK to NuGet or other package repositories.
 </ParamField>
 
 <ParamField path="read-only-memory-types" type="List<string>" required={false} toc={true}>
 Specifies a list of types that should be generated using ReadOnlyMemory&lt;T&gt; instead of regular arrays or collections. This can improve performance for large data transfers by reducing memory allocations.
+</ParamField>
+
+<ParamField path="redact-response-body-on-error" type="boolean" required={false} toc={true}>
+When enabled, prevents raw response bodies from leaking into exception messages and logs. Deserialization error exceptions pass `null` instead of the raw response body, and the base API exception class includes a custom `ToString()` override that excludes the response body.
 </ParamField>
 
 <ParamField path="root-client-class-access" type="'public' | 'internal'" required={false} toc={true}>
@@ -89,6 +114,18 @@ Controls the access modifier for the root client class. Use 'public' to make the
 When enabled, places core SDK classes (like base client classes and utilities) in the root namespace instead of nested namespaces. This can simplify imports for commonly used types.
 </ParamField>
 
+<ParamField path="simplify-object-dictionaries" type="boolean" required={false} toc={true}>
+When enabled, simplifies object dictionaries in generated code for better type safety.
+</ParamField>
+
+<ParamField path="use-default-request-parameter-values" type="boolean" required={false} toc={true}>
+When enabled, the SDK generates `= default` initializers for request record properties that have defaults. Properties with a default also have the `required` keyword removed, allowing users to omit them during initialization.
+</ParamField>
+
 <ParamField path="use-discriminated-unions" type="boolean" required={false} toc={true}>
 When enabled, generates discriminated union types for API responses that can contain multiple different object types. This provides type-safe handling of polymorphic responses.
+</ParamField>
+
+<ParamField path="use-undiscriminated-unions" type="boolean" required={false} toc={true}>
+When enabled, generates type-safe undiscriminated union types using runtime type detection instead of the `OneOf` library.
 </ParamField>

--- a/fern/products/sdks/snippets/readme-options.mdx
+++ b/fern/products/sdks/snippets/readme-options.mdx
@@ -108,7 +108,7 @@ Define a custom section in the generated README for a specific SDK.
   | Java | `group` | Maven `groupId` [from `coordinate` field](/sdks/generators/java/publishing#configure-maven-coordinate) |
   | Java | `artifact` | Maven `artifactId` [from `coordinate` field](/sdks/generators/java/publishing#configure-maven-coordinate) |
   | Java | `version` | SDK version |
-  | C#/.NET | `packageName` | Name of your package, as specified in the [`package-name` field](/sdks/generators/csharp/configuration#package-name) |
+  | C#/.NET | `packageName` | Name of your package, as specified in the [`package-id` field](/learn/sdks/generators/csharp/configuration#package-id) |
   | PHP | `packageName` | Name of your package, as specified in the [`package-name` field](/sdks/generators/php/configuration#package-name) |
   | Ruby | `packageName` | Name of your package, as specified in the [`package-name` field](/sdks/generators/ruby/configuration#package-name) |
   | Swift | `gitUrl` |  The [URL](/sdks/generators/swift/publishing#verify-package-availability) where your Swift package is published. For example, `https://github.com/fern-api/basic-swift-sdk` |


### PR DESCRIPTION
## Summary

Syncs the C# SDK generator configuration docs page with the actual `CsharpConfigSchema.ts` source of truth in `fern-api/fern`.

**Fixes:**
- Removed `additional-properties` — this config option was removed from the generator ([changelog 2026-01-22](https://buildwithfern.com/learn/sdks/generators/csharp/changelog#2026-01-22)); additional properties support is now always enabled
- Renamed `package-name` → `package-id` to match the actual config key in source
- Fixed intro YAML example: `client_class_name` (underscores) → `client-class-name` (hyphens), and fixed tab indentation on the `version` line
- Fixed internal links from `/sdks/deep-dives/testing` → `/learn/sdks/deep-dives/testing`
- Addressed Vale suggestions (removed adverb "gracefully", fixed "strongly-typed" → "strongly typed")
- Fixed broken anchor in `readme-options.mdx` where the C# row still referenced `#package-name` → updated to `#package-id`

**Added missing option (1):**
- `redact-response-body-on-error` — prevents response body leaking into exceptions

**Intentionally omitted from docs:**
- `experimental-*` options (5) — not yet stable
- `temporary-websocket-environments` — internal/temporary
- Deprecated options (`extra-dependencies`, `pascal-case-environments`, `experimental-enable-forward-compatible-enums`)
- `custom-readme-sections` — not documented for any SDK currently
- `enable-wire-tests`, `exception-interceptor-class-name`, `output-path`, `simplify-object-dictionaries`, `use-default-request-parameter-values`, `use-undiscriminated-unions` — omitted per maintainer guidance

## Review & Testing Checklist for Human

- [ ] **Verify `package-id` rename is safe** — the docs previously said `package-name`, but the source code uses `package-id` with no alias. Confirm users won't be broken by this docs rename (the generator itself only recognizes `package-id`).
- [ ] **Check link consistency in `readme-options.mdx`** — the C# row now uses a `/learn/`-prefixed link (`/learn/sdks/generators/csharp/configuration#package-id`) while surrounding rows for PHP, Ruby, TypeScript, etc. do not use the `/learn/` prefix. Verify whether snippet-included links resolve the same way as page links, or if this creates an inconsistency.
- [ ] **Verify links on the preview** — confirm `/learn/sdks/deep-dives/testing#mock-server-tests` and the C# configuration page anchors resolve correctly.

Recommended test: open the [preview deployment](https://fern-preview-25a51488-6876-4aec-9f31-8694170a9e72.docs.buildwithfern.com/learn/sdks/generators/csharp/configuration) and verify all ParamField entries render correctly. Also check the [readme options snippet](https://fern-preview-25a51488-6876-4aec-9f31-8694170a9e72.docs.buildwithfern.com/learn/sdks/generators/csharp/configuration#package-id) anchor resolves.

### Notes
- [Devin session](https://app.devin.ai/sessions/e6eb6a220bf5435f8d1cc773e3c732d1)
- Requested by @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
