### PR TITLE
Update TS SDK generator config docs: add omitFernHeaders and offsetSemantics, remove generateWireTests and noScripts

### DIFF
--- a/fern/products/sdks/overview/typescript/configuration.mdx
+++ b/fern/products/sdks/overview/typescript/configuration.mdx
@@ -169,10 +169,6 @@ Choose whether you want to support Node.js 16 and above (`Node16`), or Node.js 1
 *    `Node18` uses the native FormData API, and accepts a wider range of types for file uploads, such as `Buffer`, `File`, `Blob`, `Readable`, `ReadableStream`, `ArrayBuffer`, and `Uint8Array`
 </ParamField>
 
-<ParamField path="generateWireTests" type="boolean" default="true" toc={true}>
-Generates [mock server (wire) tests](/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
-</ParamField>
-
 <ParamField path="generateSubpackageExports" type="boolean" default="false" toc={true}>
 Generates subpackage exports that allow users to import individual clients directly, rather than importing the entire SDK. This enables JavaScript bundlers to tree-shake unused code, significantly reducing bundle sizes.
 
@@ -342,16 +338,23 @@ import { AcmePayments, AcmePaymentsClient } from "@acme/node";
 	```
 </ParamField>
 
-<ParamField path="noScripts" type="boolean" toc={true}>
-Prevent the generator from running any scripts such as `yarn format` or `yarn install`. If any of the scripts cause errors, toggling this option will allow you to receive the generated code.
-</ParamField>
-
 <ParamField path="noSerdeLayer" type="boolean" default="true" toc={true}>
 Controls whether the serde layer is enabled for serialization/deserialization.
 
 When `noSerdeLayer: false`, the generated client includes custom serialization code that transforms property names to camelCase, validates requests/responses at runtime, and supports complex types.
 
 See [TypeScript serde layer](/sdks/generators/typescript/serde-layer) for detailed guidance on when to enable this option.
+</ParamField>
+
+<ParamField path="offsetSemantics" type="'item-index' | 'page-index'" default="item-index" toc={true}>
+Controls how the offset parameter is interpreted for [auto-paginated](/learn/sdks/deep-dives/auto-pagination) endpoints.
+
+*    `item-index`: The offset counts individual items (e.g., offset 20 skips the first 20 items).
+*    `page-index`: The offset counts pages (e.g., offset 3 skips to page 3).
+</ParamField>
+
+<ParamField path="omitFernHeaders" type="boolean" default="false" toc={true}>
+When enabled, the generated SDK omits the `X-Fern-Language`, `X-Fern-SDK-Name`, and `X-Fern-SDK-Version` headers from HTTP requests. These headers are included by default to help API providers identify SDK traffic.
 </ParamField>
 
 <ParamField path="outputSourceFiles" type="boolean" default="true" toc={true}>


### PR DESCRIPTION
## Summary

Updates the TypeScript SDK generator configuration docs page to better align with the source of truth (`TypescriptCustomConfigSchema.ts` in fern-api/fern).

**Added:**
- `offsetSemantics` — controls how the offset parameter is interpreted for auto-paginated endpoints (`item-index` vs `page-index`)
- `omitFernHeaders` — controls whether Fern-specific headers (`X-Fern-Language`, `X-Fern-SDK-Name`, `X-Fern-SDK-Version`) are included in HTTP requests

**Removed:**
- `generateWireTests` — marked as beta/internal in the generator schema
- `noScripts` — marked as beta/internal in the generator schema

## Review & Testing Checklist for Human
- [ ] Verify the link `/learn/sdks/deep-dives/auto-pagination` in the `offsetSemantics` description resolves correctly on the preview deployment (the `deep-dives` slug is reused across multiple sections in `sdks.yml`)
- [ ] Confirm the `offsetSemantics` and `omitFernHeaders` descriptions accurately reflect the generator behavior
- [ ] Confirm `generateWireTests` and `noScripts` should be removed from public-facing docs (they are labeled "beta (not in docs)" in the [schema](https://github.com/fern-api/fern/blob/main/generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts#L63-L70))

### Notes
- [Devin session](https://app.devin.ai/sessions/b4723c63caf34a14bb6def0211758101)
- Requested by @Swimburger
- An audit found ~25 total undocumented config options. This PR addresses only the 4 options the user requested. The remaining options may be documented in follow-up work.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
