### PR TITLE
docs: add naming configuration for TypeScript SDK

### DIFF
--- a/fern/products/sdks/overview/typescript/configuration.mdx
+++ b/fern/products/sdks/overview/typescript/configuration.mdx
@@ -297,8 +297,21 @@ import { AcmePayments, AcmePaymentsClient } from "@acme/node";
 
 </ParamField>
 
-<ParamField path="naming" type="object" toc={true}>
-Customize the namespace export and class/type names independently. Each field is optional; unspecified names default to `${PascalCase(namespace)}Suffix`.
+<ParamField path="naming" type="string | object" toc={true}>
+Customize the namespace export and class/type names. Accepts a string shorthand or a full object.
+
+**String shorthand** — sets the namespace and derives all class names via PascalCase:
+
+```yaml title="generators.yml"
+config:
+  naming: acme
+```
+
+```typescript
+import { acme, AcmeClient } from "acme";
+```
+
+**Object form** — override individual names:
 
 ```yaml title="generators.yml"
 config:

--- a/fern/products/sdks/overview/typescript/configuration.mdx
+++ b/fern/products/sdks/overview/typescript/configuration.mdx
@@ -297,6 +297,34 @@ import { AcmePayments, AcmePaymentsClient } from "@acme/node";
 
 </ParamField>
 
+<ParamField path="naming" type="object" toc={true}>
+Customize the namespace export and class/type names independently. Each field is optional; unspecified names default to `${PascalCase(namespace)}Suffix`.
+
+```yaml title="generators.yml"
+config:
+  naming:
+    namespace: xai
+    client: XAiClient
+    error: XAiError
+    environment: XAiEnvironment
+```
+
+```typescript
+import { xai, XAiClient } from "xai";
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `namespace` | `string` | Namespace export name. Equivalent to `namespaceExport`. |
+| `client` | `string` | Client class name (default: `${PascalCase(namespace)}Client`). |
+| `error` | `string` | Generic API error class name (default: `${PascalCase(namespace)}Error`). |
+| `timeoutError` | `string` | Timeout error class name (default: `${PascalCase(namespace)}TimeoutError`). |
+| `environment` | `string` | Environment enum name (default: `${PascalCase(namespace)}Environment`). |
+| `environmentUrls` | `string` | Environment URLs type name (default: `${PascalCase(namespace)}EnvironmentUrls`). |
+| `version` | `string` | Version enum name (default: `${PascalCase(namespace)}Version`). |
+
+`namespaceExport` is still supported for backwards compatibility but `naming.namespace` takes precedence.
+</ParamField>
 
 <ParamField path="neverThrowErrors" type="boolean" default="false" toc={true}>
   When enabled, the client doesn't throw errors when a non-200 response is received from the server. Instead, the response is wrapped in an [`ApiResponse`](https://github.com/fern-api/fern/blob/main/seed/ts-sdk/alias/src/core/fetcher/APIResponse.ts).

--- a/fern/products/sdks/overview/typescript/configuration.mdx
+++ b/fern/products/sdks/overview/typescript/configuration.mdx
@@ -316,14 +316,14 @@ import { acme, AcmeClient } from "acme";
 ```yaml title="generators.yml"
 config:
   naming:
-    namespace: xai
-    client: XAiClient
-    error: XAiError
-    environment: XAiEnvironment
+    namespace: acme
+    client: AcmeSdkClient
+    error: AcmeSdkError
+    environment: AcmeSdkEnvironment
 ```
 
 ```typescript
-import { xai, XAiClient } from "xai";
+import { acme, AcmeSdkClient } from "acme";
 ```
 
 | Field | Type | Description |


### PR DESCRIPTION
# docs: add naming configuration for TypeScript SDK

## Summary

Adds documentation for the new `naming` configuration object in the TypeScript SDK generator (corresponding code change: https://github.com/fern-api/fern/pull/13545). This config allows users to independently control the namespace export and PascalCase class/type names (client, error, timeout error, environment, environment URLs, version).

The new `<ParamField>` block is placed immediately after the existing `namespaceExport` documentation and includes:
- A YAML + TypeScript example showing lowercase namespace with PascalCase overrides
- A table documenting all 7 optional fields and their defaults
- A note on backwards compatibility with `namespaceExport`

## Review & Testing Checklist for Human

- [ ] **Verify the import example is accurate**: The docs claim `namespace: xai` produces `import { xai, XAiClient } from "xai"`. Confirm the code PR actually uses the raw `namespace` value (not PascalCased) as the module-level export name.
- [ ] **Check rendered table**: Confirm the markdown table with 7 fields renders correctly on the preview deployment — markdown tables inside `<ParamField>` components can sometimes have rendering quirks.
- [ ] **Vale style check**: Verify no Vale style violations are flagged in CI (sentence case, passive voice, etc.).

**Test plan**: Open the preview deployment, navigate to the TypeScript SDK configuration page, and confirm the new `naming` section appears between `namespaceExport` and `neverThrowErrors` with correct formatting.

### Notes

- Companion code PR: https://github.com/fern-api/fern/pull/13545
- Link to Devin session: https://app.devin.ai/sessions/4ba47fb86534412697f8c6063795cd0c
- Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
