### PR TITLE
fix: correct invalid TOML escape in lychee config that broke link checking

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -65,7 +65,7 @@ jobs:
             "^#",
             
             # All GitHub URLs - checked separately in dedicated steps
-            "^https://github\.com/"
+            "^https://github\\.com/"
           ]
           EOF
 


### PR DESCRIPTION
# fix: correct invalid TOML escape in lychee config that broke link checking

## Summary

The `check-links.yml` workflow has been silently broken since the Feb 27 fix in #3877. That commit moved `^https://github\.com/` from a CLI `--exclude` arg into the `lychee.toml` config's `exclude` array, but used a single backslash (`\.`) instead of a double backslash (`\\.`).

In TOML double-quoted strings, `\.` is an **invalid escape sequence** (only `\\`, `\t`, `\n`, `\"`, etc. are recognized). This causes the entire config file to fail to parse. Since the lychee step has `fail: false`, the error is silently swallowed and the workflow reports "no broken links" without actually checking anything.

The fix: `\.` → `\\.`, matching the escaping used by every other pattern in the same array.

**Verified locally** that `\.` causes a TOML parse error and `\\.` parses correctly (tested with Python's `tomllib`, which follows the same TOML spec as Rust's `toml` crate used by lychee).

## Review & Testing Checklist for Human

- [ ] **Trigger a manual workflow run** of `Check Links` after merging to confirm lychee now produces real output (should take ~15-20 min and check hundreds of links)
- [ ] **Verify the fix matches the pattern**: compare line 68 (`"^https://github\\.com/"`) against other lines in the same `exclude` array — they all use `\\.` for literal dots
- [ ] **Check the workflow run summary** after the first post-merge run to confirm the link counts (Total, Successful, Errors) are non-zero, indicating lychee is actually running

### Notes
- [Link to Devin session](https://app.devin.ai/sessions/002e3e77e53448eabcd1c4be2f48ae72)
- Requested by: @davidkonigsberg