### PR TITLE
Fix broken redirects for bare API definition paths and update old-pattern links

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -506,7 +506,7 @@ redirects:
   
   # # API Definition OpenAPI specific redirects first
   - source: /learn/api-definition/openapi/endpoints
-    destination: /learn/api-definitions/openapi/endpoints
+    destination: /learn/api-definitions/openapi/endpoints/http
   - source: /learn/api-definition/openapi/endpoints/:slug*
     destination: /learn/api-definitions/openapi/endpoints/:slug*
   - source: /learn/api-definition/openapi/extensions
@@ -519,6 +519,14 @@ redirects:
     destination: /learn/api-definitions/openapi/frameworks
   - source: /learn/api-definition/openapi/frameworks/:slug*
     destination: /learn/api-definitions/openapi/frameworks/:slug*
+  - source: /learn/api-definition/openapi/webhooks
+    destination: /learn/api-definitions/openapi/endpoints/webhooks
+  - source: /learn/api-definition/openapi/streaming-and-sse
+    destination: /learn/api-definitions/openapi/endpoints/sse
+  - source: /learn/api-definition/openapi/audiences
+    destination: /learn/api-definitions/openapi/extensions/audiences
+  - source: /learn/api-definition/openapi/examples
+    destination: /learn/api-definitions/openapi/extensions/examples
   - source: /learn/api-definition/openapi/:slug*
     destination: /learn/api-definitions/openapi/:slug*
   - source: /learn/openapi-definition/extensions/webhooks
@@ -727,16 +735,8 @@ redirects:
     destination: /learn/docs/customization/custom-react-components
 
   # API Definition redirects
-  - source: /learn/api-definition/openapi/webhooks
-    destination: /learn/api-definitions/openapi/endpoints/webhooks
   - source: /learn/api-definition/introduction
     destination: /learn/api-definitions/overview/what-is-an-api-definition
-  - source: /learn/api-definition/openapi/streaming-and-sse
-    destination: /learn/api-definitions/openapi/endpoints/streaming-and-sse
-  - source: /learn/api-definition/openapi/audiences
-    destination: /learn/api-definitions/openapi/audiences
-  - source: /learn/api-definition/openapi/examples
-    destination: /learn/api-definitions/openapi/examples
   - source: /learn/api-definition/fern/comparison-with-open-api
     destination: /learn/api-definitions/ferndef/overview
   - source: /learn/api-definitions/openapi/openapi.yml

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -503,10 +503,16 @@ redirects:
   # ============================================================================
   
   # # API Definition OpenAPI specific redirects first
+  - source: /learn/api-definition/openapi/endpoints
+    destination: /learn/api-definitions/openapi/endpoints
   - source: /learn/api-definition/openapi/endpoints/:slug*
     destination: /learn/api-definitions/openapi/endpoints/:slug*
+  - source: /learn/api-definition/openapi/extensions
+    destination: /learn/api-definitions/openapi/extensions
   - source: /learn/api-definition/openapi/extensions/:slug*
     destination: /learn/api-definitions/openapi/extensions/:slug*
+  - source: /learn/api-definition/openapi/frameworks
+    destination: /learn/api-definitions/openapi/frameworks
   - source: /learn/api-definition/openapi/frameworks/:slug*
     destination: /learn/api-definitions/openapi/frameworks/:slug*
   - source: /learn/api-definition/openapi/:slug*
@@ -529,8 +535,12 @@ redirects:
     destination: /learn/api-definitions/openapi/sync-your-open-api-specification
 
   # API Definition Fern specific redirects first
+  - source: /learn/api-definition/fern/endpoints
+    destination: /learn/api-definitions/ferndef/endpoints
   - source: /learn/api-definition/fern/endpoints/:slug*
     destination: /learn/api-definitions/ferndef/endpoints/:slug*
+  - source: /learn/api-definition/fern/api-yml
+    destination: /learn/api-definitions/ferndef/api-yml
   - source: /learn/api-definition/fern/api-yml/:slug*
     destination: /learn/api-definitions/ferndef/api-yml/:slug*
   - source: /learn/api-definition/fern/:slug* 

--- a/fern/products/api-def/ferndef-pages/endpoints.mdx
+++ b/fern/products/api-def/ferndef-pages/endpoints.mdx
@@ -13,7 +13,7 @@ improves clarity and makes the generated SDKs more idiomatic.
 Each service defines:
 
 1. A **base-path**: A common prefix for all the endpoints' HTTP paths
-2. Whether the service requires [authentication](/learn/api-definition/fern/authentication)
+2. Whether the service requires [authentication](/learn/api-definitions/ferndef/authentication)
 3. **Endpoints**
 
 <CodeBlock title='user.yml'>
@@ -86,7 +86,7 @@ service:
 
 The full path for the endpoint is the concatenation of:
 
-- The [environment](/learn/api-definition/fern/api-yml/environments) URL
+- The [environment](/learn/api-definitions/ferndef/api-yml/environments) URL
 - The service `base-path`
 - The endpoint `path`
 
@@ -496,7 +496,7 @@ errors:
 ```
 </CodeBlock>
 
-You can learn more about how to define errors on the [Errors](/learn/api-definition/fern/errors) page.
+You can learn more about how to define errors on the [Errors](/learn/api-definitions/ferndef/errors) page.
 
 ## Specifying examples
 

--- a/fern/products/api-def/ferndef-pages/overview.mdx
+++ b/fern/products/api-def/ferndef-pages/overview.mdx
@@ -9,7 +9,7 @@ A Fern Definition is a set of YAML files that are the single source of truth for
 inside of which describes your API requests, responses, models, paths, methods, errors, and authentication scheme.
 
 <Note>
-  Want to use OpenAPI instead? No worries, we support that [as well](/learn/api-definition/introduction/what-is-an-api-definition#openapi-swagger)
+  Want to use OpenAPI instead? No worries, we support that [as well](/learn/api-definitions/overview/what-is-an-api-definition#openapi-swagger)
 </Note>
 
 ## Fern Definition structure
@@ -38,10 +38,10 @@ This will create the following folder structure in your project:
 
 Each Fern Definition file may define:
 
-- **[Custom types](/learn/api-definition/fern/types)**. Use **custom types** to build your data model.
+- **[Custom types](/learn/api-definitions/ferndef/types)**. Use **custom types** to build your data model.
 - **[Endpoints](/learn/api-definitions/ferndef/endpoints/overview)**. A **service** is a set of related REST endpoints.
-- **[Errors](/learn/api-definition/fern/errors)**. An **error** represents a failed (non-200) response from an endpoint.
-- **[Imports](/learn/api-definition/fern/imports)**. Use **imports** to share types across files.
+- **[Errors](/learn/api-definitions/ferndef/errors)**. An **error** represents a failed (non-200) response from an endpoint.
+- **[Imports](/learn/api-definitions/ferndef/imports)**. Use **imports** to share types across files.
 
 ```yml imdb.yml maxLines=0
 service:
@@ -104,5 +104,5 @@ software companies.
 
 <Info>
   Despite being a different format for describing APIs, **you are never locked in to Fern.** It's easy to convert your
-  [Fern Definition to OpenAPI](/learn/api-definition/fern/export-openapi).
+  [Fern Definition to OpenAPI](/learn/api-definitions/ferndef/export-openapi).
 </Info>

--- a/fern/products/api-def/ferndef-pages/packages.mdx
+++ b/fern/products/api-def/ferndef-pages/packages.mdx
@@ -40,9 +40,9 @@ client.roles.admin.get();
 ## Package configuration
 
 Each package can have a special definition file called `__package__.yml`. Like any
-other definition file, it can contain [imports](/learn/api-definition/fern/imports),
-[types](/learn/api-definition/fern/types), [endpoints](/learn/api-definitions/ferndef/endpoints/overview),
-and [errors](/learn/api-definition/fern/errors).
+other definition file, it can contain [imports](/learn/api-definitions/ferndef/imports),
+[types](/learn/api-definitions/ferndef/types), [endpoints](/learn/api-definitions/ferndef/endpoints/overview),
+and [errors](/learn/api-definitions/ferndef/errors).
 
 Endpoints in `__package__.yml` will appear at the root of the package.
 For example, the following generated SDK:

--- a/fern/products/api-def/ferndef-pages/types.mdx
+++ b/fern/products/api-def/ferndef-pages/types.mdx
@@ -25,7 +25,7 @@ Types describe the data model of your API.
 | `map` | Key-value mapping, e.g., `map<string, integer>` |
 | `optional` | Optional value, e.g., `optional<string>` |
 | `literal` | Literal value, e.g., `literal<"Plants">` |
-| `file` | File upload type, e.g., [file uploads](/learn/api-definition/fern/endpoints/multipart) |
+| `file` | File upload type, e.g., [file uploads](/learn/api-definitions/ferndef/endpoints/multipart) |
 | `unknown` | Represents arbitrary JSON |
 
 ## Custom types

--- a/fern/products/api-def/openapi-pages/server-frameworks/fastapi.mdx
+++ b/fern/products/api-def/openapi-pages/server-frameworks/fastapi.mdx
@@ -71,7 +71,7 @@ async def your_post_endpoint(
 
 FastAPI allows you to specify examples for your data models, which Fern will pick up and use within your generated SDKs and documentation automatically.
 
-For more information on leveraging examples within Fern, please refer to the [Fern documentation](/learn/api-definition/openapi/extensions/others#request--response-examples).
+For more information on leveraging examples within Fern, please refer to the [Fern documentation](/learn/api-definitions/openapi/extensions/overview#request--response-examples).
 
 For more information on this FastAPI functionality, please refer to the [FastAPI documentation](https://fastapi.tiangolo.com/tutorial/schema-extra-example/).
 

--- a/fern/products/api-def/openapi-pages/server-frameworks/fastapi.mdx
+++ b/fern/products/api-def/openapi-pages/server-frameworks/fastapi.mdx
@@ -71,7 +71,7 @@ async def your_post_endpoint(
 
 FastAPI allows you to specify examples for your data models, which Fern will pick up and use within your generated SDKs and documentation automatically.
 
-For more information on leveraging examples within Fern, please refer to the [Fern documentation](/learn/api-definitions/openapi/extensions/overview#request--response-examples).
+For more information on leveraging examples within Fern, please refer to the [Fern documentation](/learn/api-definitions/openapi/extensions/request-response-examples).
 
 For more information on this FastAPI functionality, please refer to the [FastAPI documentation](https://fastapi.tiangolo.com/tutorial/schema-extra-example/).
 

--- a/fern/products/cli-api-reference/cli-changelog/2024-08-20.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2024-08-20.mdx
@@ -22,6 +22,6 @@ paths:
           required: true
 ```
 
-For more information, please check out the [docs](https://buildwithfern.com/learn/api-definition/openapi/extensions/parameter-names).
+For more information, please check out the [docs](https://buildwithfern.com/learn/api-definitions/openapi/extensions/parameter-names).
 
 

--- a/fern/products/cli-api-reference/cli-changelog/2024-09-04.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2024-09-04.mdx
@@ -57,6 +57,6 @@ types:
     type: `GenericTest<string>`
 ```
 
-More information can be found here: https://buildwithfern.com/learn/api-definition/fern/types#generics.
+More information can be found here: https://buildwithfern.com/learn/api-definitions/ferndef/types#generics.
 
 

--- a/fern/products/cli-api-reference/cli-changelog/2024-09-07.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2024-09-07.mdx
@@ -13,7 +13,7 @@ api:
       get-token:
         endpoint: endpoint.authorization
 ```
-[More Information](https://buildwithfern.com/learn/api-definition/fern/authentication#oauth-client-credentials)
+[More Information](https://buildwithfern.com/learn/api-definitions/ferndef/authentication#oauth-client-credentials)
 
 Docs configuration:
 ```yml

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -32,7 +32,7 @@ hideOnThisPage: true
 | Command | Description |
 |---------|-------------|
 | [`fern generate`](#fern-generate) | Build & publish SDK updates |
-| [`fern write-definition`](#fern-write-definition) | Convert OpenAPI specifications to [Fern Definition](/learn/api-definition/fern/overview) |
+| [`fern write-definition`](#fern-write-definition) | Convert OpenAPI specifications to [Fern Definition](/learn/api-definitions/ferndef/overview) |
 | [`fern write-overrides`](#fern-write-overrides) | Create OpenAPI customizations |
 | [`fern generator upgrade`](#fern-generator-upgrade) | Update SDK generators to latest versions |
 

--- a/fern/products/docs/pages/api-references/api-explorer.mdx
+++ b/fern/products/docs/pages/api-references/api-explorer.mdx
@@ -28,7 +28,7 @@ To automatically populate API keys for logged-in users, see [API key injection](
 
 ## Multiple environments
 
-When multiple server URLs are configured in [OpenAPI](/learn/api-definitions/openapi/extensions/server-names-and-url-templating) or the [Fern Definition](/learn/api-definition/fern/api-yml/environments), users can switch between environments (e.g., production and sandbox) from a dropdown in the API Explorer. The selected environment persists as they navigate between pages.
+When multiple server URLs are configured in [OpenAPI](/learn/api-definitions/openapi/extensions/server-names-and-url-templating) or the [Fern Definition](/learn/api-definitions/ferndef/api-yml/environments), users can switch between environments (e.g., production and sandbox) from a dropdown in the API Explorer. The selected environment persists as they navigate between pages.
 
 <div style="position: relative; padding-bottom: 50.63657407407407%; height: 0;"><iframe src="https://www.loom.com/embed/cb642161678e41cabcb677b900006f40?sid=5e45243c-3ba1-45cf-860b-72eee1970fc5?hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 

--- a/fern/products/docs/pages/api-references/audiences.mdx
+++ b/fern/products/docs/pages/api-references/audiences.mdx
@@ -8,7 +8,7 @@ subtitle: Use audiences to filter the endpoints, schemas, and properties that ar
 <Markdown src="/snippets/team-plan.mdx"/>
 
 Audiences are a useful tool for segmenting your API for different consumers. Common examples of audiences include `public` 
-and `beta`. You can configure audiences in both [the OpenAPI Specification](/learn/api-definitions/openapi/extensions/audiences) as well as [the Fern Definition](/learn/api-definition/fern/audiences).
+and `beta`. You can configure audiences in both [the OpenAPI Specification](/learn/api-definitions/openapi/extensions/audiences) as well as [the Fern Definition](/learn/api-definitions/ferndef/audiences).
 
 Once you've added audiences to your API Specification, you can filter to that audience by adding the `audience` property to the `api` object in your `docs.yml` navigation.
 

--- a/fern/products/docs/pages/api-references/generate-api-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-api-ref.mdx
@@ -5,7 +5,7 @@ description: Use Fern Docs to generate REST API Reference documentation from an 
 
 <Markdown src="/snippets/agent-directive.mdx"/>
 
-Fern generates REST API Reference documentation from an [OpenAPI specification](/learn/api-definition/openapi/overview) or [Fern Definition](/learn/api-definition/fern/overview). Once the API definition is set up, adding it to the docs takes just one line of configuration.
+Fern generates REST API Reference documentation from an [OpenAPI specification](/learn/api-definitions/openapi/overview) or [Fern Definition](/learn/api-definitions/ferndef/overview). Once the API definition is set up, adding it to the docs takes just one line of configuration.
 
 <Tip>
   Fern also supports [gRPC](/learn/docs/api-references/generate-grpc-ref), [GraphQL](/learn/docs/api-references/generate-graphql-ref), [WebSocket](/learn/docs/api-references/generate-websocket-ref) (AsyncAPI or Fern Definition), [OpenRPC](/learn/docs/api-references/generate-openrpc-ref), and [Webhook](/learn/docs/api-references/generate-webhook-ref) references.

--- a/fern/products/docs/pages/api-references/generate-websocket-ref.mdx
+++ b/fern/products/docs/pages/api-references/generate-websocket-ref.mdx
@@ -5,7 +5,7 @@ description: Use Fern Docs to generate WebSocket Reference documentation from an
 
 <Markdown src="/snippets/agent-directive.mdx"/>
 
-Fern generates WebSocket Reference documentation from an [AsyncAPI specification](/learn/api-definitions/asyncapi/overview) or [Fern Definition](/learn/api-definition/fern/websockets).
+Fern generates WebSocket Reference documentation from an [AsyncAPI specification](/learn/api-definitions/asyncapi/overview) or [Fern Definition](/learn/api-definitions/ferndef/websockets).
 
 <Frame caption={<a href="https://developers.deepgram.com/reference/text-to-speech/speak-streaming">Example of how a WebSocket API Reference renders in Fern</a>}>
   <img src="websocket-deepgram.png" alt="WebSocket API Reference Example" />

--- a/fern/products/docs/pages/api-references/http-snippets.mdx
+++ b/fern/products/docs/pages/api-references/http-snippets.mdx
@@ -20,7 +20,7 @@ If you configure [SDK snippets](/learn/docs/api-references/sdk-snippets), those 
 <Step title="Add request examples to your API definition">
 HTTP snippets are generated from request examples in your API definition:
 - For Fern Definition, follow the [examples documentation](/learn/api-definitions/ferndef/examples)
-- For OpenAPI, follow the [request/response examples documentation](/learn/api-definitions/openapi/extensions/overview#request--response-examples)
+- For OpenAPI, follow the [request/response examples documentation](/learn/api-definitions/openapi/extensions/request-response-examples)
 </Step>
 
 <Step title="Choose which languages to display">

--- a/fern/products/docs/pages/api-references/http-snippets.mdx
+++ b/fern/products/docs/pages/api-references/http-snippets.mdx
@@ -19,8 +19,8 @@ If you configure [SDK snippets](/learn/docs/api-references/sdk-snippets), those 
 
 <Step title="Add request examples to your API definition">
 HTTP snippets are generated from request examples in your API definition:
-- For Fern Definition, follow the [examples documentation](/learn/api-definition/fern/examples)
-- For OpenAPI, follow the [request/response examples documentation](/learn/api-definition/openapi/extensions/others#request--response-examples)
+- For Fern Definition, follow the [examples documentation](/learn/api-definitions/ferndef/examples)
+- For OpenAPI, follow the [request/response examples documentation](/learn/api-definitions/openapi/extensions/overview#request--response-examples)
 </Step>
 
 <Step title="Choose which languages to display">

--- a/fern/products/docs/pages/api-references/sdk-snippets.mdx
+++ b/fern/products/docs/pages/api-references/sdk-snippets.mdx
@@ -28,7 +28,7 @@ To configure SDK snippets, first name your SDKs in `generators.yml` and then ref
 ### Add examples to your API definition
 
 Fern needs to read request examples from your API definition to generate code snippets.
-- For Fern Definition, follow the [examples documentation](/learn/api-definition/fern/examples).
+- For Fern Definition, follow the [examples documentation](/learn/api-definitions/ferndef/examples).
 - For OpenAPI, follow [Swagger's examples documentation](https://swagger.io/docs/specification/adding-examples/).
 
 ### Define a package name for your SDK(s)


### PR DESCRIPTION
## Summary

Fixes a bug in the redirect rules in `docs.yml` where bare paths like `/learn/api-definition/fern/endpoints` (without a trailing sub-path) were redirecting to a literal `:slug*` URL instead of resolving properly. For example:

- `/learn/api-definition/fern/endpoints` → `308` → `/learn/api-definitions/ferndef/endpoints/:slug*` → **404**

This happened because the `:slug*` wildcard in rules like `source: /learn/api-definition/fern/endpoints/:slug*` greedily matched the bare path with an empty slug, then output the literal `:slug*` text in the destination. Sub-paths like `/endpoints/multipart` redirected correctly; only the bare parent paths were broken.

**Two fixes applied:**

1. **5 explicit bare-path redirects** added to `docs.yml` (placed before the wildcard rules) for: `openapi/endpoints`, `openapi/extensions`, `openapi/frameworks`, `fern/endpoints`, `fern/api-yml`

2. **All remaining old-pattern links updated** across 15 MDX source files (`/learn/api-definition/...` → `/learn/api-definitions/...`), eliminating reliance on redirects entirely for internal links. This includes links in changelog entries that used full `https://buildwithfern.com/learn/api-definition/...` URLs.

### Updates since last revision

- Resolved merge conflict with `main`, which had separately added explicit redirects for `openapi/extensions` → `.../extensions/overview`. The merged result keeps both.
- Fixed broken anchor links in `http-snippets.mdx` and `fastapi.mdx`: the old URL `/learn/api-definition/openapi/extensions/others#request--response-examples` was initially mapped to `.../extensions/overview#request--response-examples`, but the `#request--response-examples` anchor doesn't exist on the overview page. Now correctly points to the dedicated examples page at `/learn/api-definitions/openapi/extensions/request-response-examples`.

## Review & Testing Checklist for Human

- [ ] Verify the examples page link is correct: two files now point to `/learn/api-definitions/openapi/extensions/request-response-examples`. Confirm this page exists and matches the old `others` page content (cross-reference with `fern/products/docs/pages/ai/ai-examples.mdx:10` which already uses this URL).
- [ ] After deploy, verify the 5 bare-path redirects resolve (not 404) by visiting:
  - `/learn/api-definition/fern/endpoints`
  - `/learn/api-definition/fern/api-yml`
  - `/learn/api-definition/openapi/endpoints`
  - `/learn/api-definition/openapi/extensions`
  - `/learn/api-definition/openapi/frameworks`
- [ ] Spot-check a few updated links on the preview site to confirm they resolve: [Fern Definition overview](https://fern-preview-2754db6e-2675-41f5-8a53-64313fa70478.docs.buildwithfern.com/learn/api-definitions/ferndef/overview), [packages](https://fern-preview-2754db6e-2675-41f5-8a53-64313fa70478.docs.buildwithfern.com/learn/api-definitions/ferndef/packages), [endpoints](https://fern-preview-2754db6e-2675-41f5-8a53-64313fa70478.docs.buildwithfern.com/learn/api-definitions/ferndef/endpoints/overview)

### Notes
- The root cause of the [failed CI run](https://github.com/fern-api/docs/actions/runs/23086893377) after merging [PR #4276](https://github.com/fern-api/docs/pull/4276) was CDN cache lag — the link checker ran before content had fully propagated. That issue is transient. This PR addresses the underlying redirect bug and removes the old-pattern links so both issues won't recur.
- [PR #4277](https://github.com/fern-api/docs/pull/4277) can be closed as it contains the same stale broken links that are now fully resolved.
- Requested by: @davidkonigsberg
- [Link to Devin session](https://app.devin.ai/sessions/c396111848974c798d5f78b243bfc6ed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
