### PR TITLE
chore: rename shouldGenerateWebsocketClients to generateWebSocketClients

### DIFF
--- a/fern/products/sdks/overview/typescript/changelog/2025-03-06.mdx
+++ b/fern/products/sdks/overview/typescript/changelog/2025-03-06.mdx
@@ -1,4 +1,4 @@
 ## 0.49.0
-**`(feat):`** This PR enables the Typescript generator to produce Websocket SDK endpoints. This can be enabled by adding the option `shouldGenerateWebsocketClients: true` to the Typescript generator config.
+**`(feat):`** This PR enables the Typescript generator to produce Websocket SDK endpoints. This can be enabled by adding the option `generateWebSocketClients: true` to the Typescript generator config.
 
 

--- a/fern/products/sdks/overview/typescript/configuration.mdx
+++ b/fern/products/sdks/overview/typescript/configuration.mdx
@@ -486,7 +486,7 @@ generate a `jsr.json` as well as a GitHub workflow to publish to JSR.
 
 </ParamField>
 
-<ParamField path="shouldGenerateWebsocketClients" type="boolean" toc={true}>
+<ParamField path="generateWebSocketClients" type="boolean" toc={true}>
 	Generate WebSocket clients from your AsyncAPI specs.
 </ParamField>
 

--- a/fern/products/sdks/overview/typescript/configuration.mdx
+++ b/fern/products/sdks/overview/typescript/configuration.mdx
@@ -488,6 +488,8 @@ generate a `jsr.json` as well as a GitHub workflow to publish to JSR.
 
 <ParamField path="generateWebSocketClients" type="boolean" toc={true}>
 	Generate WebSocket clients from your AsyncAPI specs.
+
+	Previously named `shouldGenerateWebsocketClients`, which is still accepted as a deprecated alias.
 </ParamField>
 
 <ParamField path="skipResponseValidation" type="boolean" default="false" toc={true}>


### PR DESCRIPTION
## Summary

Updates documentation to reflect the renamed TypeScript SDK generator config option: `shouldGenerateWebsocketClients` → `generateWebSocketClients`. This is the docs companion to https://github.com/fern-api/fern/pull/13562, which renamed the config flag in the generator code (keeping the old name as a deprecated fallback).

**Files changed:**
- `configuration.mdx` — Updated the `<ParamField>` path from `shouldGenerateWebsocketClients` to `generateWebSocketClients`, and added a note that the old name is still accepted as a deprecated alias
- `changelog/2025-03-06.mdx` — Updated the inline code reference to use the new config name

## Review & Testing Checklist for Human
- [ ] Decide whether the changelog entry (2025-03-06) should keep the original name `shouldGenerateWebsocketClients` since it's a historical record of what was released at that time, or use the new name for discoverability
- [ ] Verify the deprecation note wording in `configuration.mdx` reads well on the rendered docs site

### Notes
The generator-side change preserves backwards compatibility: `generateWebSocketClients` is preferred, but `shouldGenerateWebsocketClients` still works as a fallback. The configuration page now documents this fallback.

Link to Devin session: https://app.devin.ai/sessions/d8ce068101844e7b8b41db4d4546b912
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
