### PR TITLE
Improve TypeScript SDK 3.56.0 changelog with naming configuration samples

### DIFF
--- a/fern/products/sdks/overview/typescript/changelog/2026-03-13.mdx
+++ b/fern/products/sdks/overview/typescript/changelog/2026-03-13.mdx
@@ -1,9 +1,40 @@
 ## 3.56.0
-**`(feat):`** Add a `naming` configuration object that allows users to independently control the
-namespace export and PascalCase class/type names (client, error, timeout error,
-environment, environment URLs, version). When individual overrides are not provided,
-they are derived from the namespace value using the existing `${PascalCase(namespace)}Suffix`
-pattern. The existing `namespaceExport` config continues to work for backwards compatibility.
+**`(feat):`** Add a `naming` configuration object that gives you fine-grained control over the
+exported namespace and generated class names (client, error, timeout error,
+environment, environment URLs, version).
+
+You can use it as a simple string shorthand to set the namespace:
+
+```yaml title="generators.yml"
+groups:
+  ts-sdk:
+    generators:
+      - name: fernapi/fern-typescript-node-sdk
+        config:
+          naming: acme
+```
+
+Or as a full object to override individual names:
+
+```yaml title="generators.yml"
+groups:
+  ts-sdk:
+    generators:
+      - name: fernapi/fern-typescript-node-sdk
+        config:
+          naming:
+            namespace: acme
+            client: AcmeApiClient
+            error: AcmeApiError
+            environment: AcmeRegion
+```
+
+When individual overrides are not provided, they are derived from the namespace
+using the `PascalCase(namespace) + Suffix` pattern (e.g. `namespace: acme` produces
+`AcmeClient`, `AcmeError`, `AcmeTimeoutError`, `AcmeEnvironment`, `AcmeEnvironmentUrls`,
+and `AcmeVersion` by default).
+
+The existing `namespaceExport` config continues to work for backwards compatibility.
 
 
 ## 3.55.0


### PR DESCRIPTION
## Summary

Replaces the dense paragraph in the TypeScript SDK 3.56.0 changelog entry with a more actionable version that includes two `generators.yml` configuration samples:

1. **String shorthand** — `naming: acme`
2. **Full object form** — with individual overrides for `namespace`, `client`, `error`, `environment`

Also lists the default derived names (e.g. `AcmeClient`, `AcmeError`, `AcmeTimeoutError`, etc.) so users understand what they get out of the box without overrides.

Config schema was verified against `generators/typescript-v2/ast/src/custom-config/TypescriptCustomConfigSchema.ts` and `generators/typescript-v2/browser-compatible-base/src/utils/getNamespaceExport.ts` in the `fern` repo.

## Review & Testing Checklist for Human

- [ ] Verify the generator name in the YAML examples (`fernapi/fern-typescript-node-sdk`) matches what users should actually reference in their `generators.yml`
- [ ] Confirm the listed default suffixes (`AcmeClient`, `AcmeError`, `AcmeTimeoutError`, `AcmeEnvironment`, `AcmeEnvironmentUrls`, `AcmeVersion`) are accurate — these were derived from `resolveNaming()` source code
- [ ] Check the rendered MDX in the docs preview to make sure code blocks display correctly with the `title="generators.yml"` attribute

### Notes
- Content-only change — no code or config files modified
- The `naming` object keys in the full example (`namespace`, `client`, `error`, `environment`) are a subset; `timeoutError`, `environmentUrls`, and `version` are also valid but omitted from the sample for brevity

Link to Devin session: https://app.devin.ai/sessions/2800abefce964a0e8cb370f9f364ac0a
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
