### PR TITLE
Add discoverability redirects for ~130 guessable URL patterns

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -831,3 +831,205 @@ redirects:
     destination: /learn/cli-api-reference/cli-reference/overview
   - source: /learn/cli-reference/path/to/file.pdf
     destination: /learn/cli-api-reference/cli-reference/overview
+
+  # ============================================================================
+  # DISCOVERABILITY REDIRECTS — guessable URL patterns that return 404
+  # ============================================================================
+
+  # --- SDK language shorthand paths (skip /generators/ segment) ---
+  # Users/crawlers guess /learn/sdks/<lang>/... instead of /learn/sdks/generators/<lang>/...
+  - source: /learn/sdks/typescript/:slug*
+    destination: /learn/sdks/generators/typescript/:slug*
+  - source: /learn/sdks/python/:slug*
+    destination: /learn/sdks/generators/python/:slug*
+  - source: /learn/sdks/go/:slug*
+    destination: /learn/sdks/generators/go/:slug*
+  - source: /learn/sdks/java/:slug*
+    destination: /learn/sdks/generators/java/:slug*
+  - source: /learn/sdks/csharp/:slug*
+    destination: /learn/sdks/generators/csharp/:slug*
+  - source: /learn/sdks/php/:slug*
+    destination: /learn/sdks/generators/php/:slug*
+  - source: /learn/sdks/ruby/:slug*
+    destination: /learn/sdks/generators/ruby/:slug*
+  - source: /learn/sdks/swift/:slug*
+    destination: /learn/sdks/generators/swift/:slug*
+  - source: /learn/sdks/rust/:slug*
+    destination: /learn/sdks/generators/rust/:slug*
+  - source: /learn/sdks/postman/:slug*
+    destination: /learn/sdks/generators/postman/:slug*
+
+  # .NET / dotnet aliases → csharp
+  - source: /learn/sdks/net/:slug*
+    destination: /learn/sdks/generators/csharp/:slug*
+  - source: /learn/sdks/dotnet/:slug*
+    destination: /learn/sdks/generators/csharp/:slug*
+  - source: /learn/sdks/generators/net/:slug*
+    destination: /learn/sdks/generators/csharp/:slug*
+  - source: /learn/sdks/generators/dotnet/:slug*
+    destination: /learn/sdks/generators/csharp/:slug*
+
+  # --- SDK top-level shorthand paths ---
+  - source: /learn/sdks/quickstart
+    destination: /learn/sdks/overview/quickstart
+  - source: /learn/sdks/introduction
+    destination: /learn/sdks/overview/introduction
+  - source: /learn/sdks/how-it-works
+    destination: /learn/sdks/overview/how-it-works
+  - source: /learn/sdks/custom-code
+    destination: /learn/sdks/overview/custom-code
+  - source: /learn/sdks/project-structure
+    destination: /learn/sdks/overview/project-structure
+  - source: /learn/sdks/autorelease
+    destination: /learn/sdks/overview/autorelease
+  - source: /learn/sdks/configuration
+    destination: /learn/sdks/reference/generators-yml
+  - source: /learn/sdks/changelog
+    destination: /learn/sdks/generators/typescript/changelog
+
+  # --- API definition shorthand paths (skip /api-definitions/ segment) ---
+  # Users/crawlers guess /learn/openapi/... instead of /learn/api-definitions/openapi/...
+  - source: /learn/openapi/:slug*
+    destination: /learn/api-definitions/openapi/:slug*
+  - source: /learn/asyncapi/:slug*
+    destination: /learn/api-definitions/asyncapi/:slug*
+  - source: /learn/openrpc/:slug*
+    destination: /learn/api-definitions/openrpc/:slug*
+  - source: /learn/grpc/:slug*
+    destination: /learn/api-definitions/grpc/:slug*
+
+  # --- CLI shorthand paths ---
+  - source: /learn/cli/overview
+    destination: /learn/cli-api-reference/cli-reference/overview
+  - source: /learn/cli/commands
+    destination: /learn/cli-api-reference/cli-reference/commands
+  - source: /learn/cli/options
+    destination: /learn/cli-api-reference/cli-reference/options
+  - source: /learn/cli/changelog
+    destination: /learn/cli-api-reference/cli-reference/changelog
+  - source: /learn/cli/:slug*
+    destination: /learn/cli-api-reference/cli-reference/:slug*
+
+  # --- Docs top-level shorthand paths ---
+  - source: /learn/docs/overview
+    destination: /learn/docs/getting-started/overview
+  - source: /learn/docs/quickstart
+    destination: /learn/docs/getting-started/quickstart
+  - source: /learn/docs/project-structure
+    destination: /learn/docs/getting-started/project-structure
+  - source: /learn/docs/navigation
+    destination: /learn/docs/configuration/navigation
+  - source: /learn/docs/components
+    destination: /learn/docs/writing-content/components/overview
+  - source: /learn/docs/markdown
+    destination: /learn/docs/writing-content/markdown-basics
+  - source: /learn/docs/api-reference
+    destination: /learn/docs/api-references/generate-api-ref
+
+  # --- Docs component shorthand paths ---
+  - source: /learn/docs/components/accordions
+    destination: /learn/docs/writing-content/components/accordions
+  - source: /learn/docs/components/cards
+    destination: /learn/docs/writing-content/components/cards
+  - source: /learn/docs/components/callouts
+    destination: /learn/docs/writing-content/components/callouts
+  - source: /learn/docs/components/code-blocks
+    destination: /learn/docs/writing-content/components/code-blocks
+  - source: /learn/docs/components/steps
+    destination: /learn/docs/writing-content/components/steps
+  - source: /learn/docs/components/tables
+    destination: /learn/docs/writing-content/components/tables
+  - source: /learn/docs/components/badges
+    destination: /learn/docs/writing-content/components/badges
+  - source: /learn/docs/components/frames
+    destination: /learn/docs/writing-content/components/frames
+  - source: /learn/docs/components/icons
+    destination: /learn/docs/writing-content/components/icons
+  - source: /learn/docs/components/tooltips
+    destination: /learn/docs/writing-content/components/tooltips
+  - source: /learn/docs/components/:slug*
+    destination: /learn/docs/writing-content/components/:slug*
+
+  # --- Docs feature shorthand paths ---
+  - source: /learn/docs/ask-fern
+    destination: /learn/docs/ai-features/ask-fern/overview
+  - source: /learn/docs/llms-txt
+    destination: /learn/docs/ai-features/llms-txt
+  - source: /learn/docs/writer
+    destination: /learn/docs/ai-features/fern-writer
+  - source: /learn/docs/fern-writer
+    destination: /learn/docs/ai-features/fern-writer
+  - source: /learn/docs/ai-examples
+    destination: /learn/docs/ai-features/ai-examples
+
+  # --- Docs authentication shorthand paths ---
+  - source: /learn/docs/password-protection
+    destination: /learn/docs/authentication/setup/password-protection
+  - source: /learn/docs/sso
+    destination: /learn/docs/authentication/setup/sso
+  - source: /learn/docs/jwt
+    destination: /learn/docs/authentication/setup/jwt
+  - source: /learn/docs/oauth
+    destination: /learn/docs/authentication/setup/oauth
+  - source: /learn/docs/rbac
+    destination: /learn/docs/authentication/features/rbac
+
+  # --- Docs API reference shorthand paths ---
+  - source: /learn/docs/api-explorer
+    destination: /learn/docs/api-references/api-explorer
+  - source: /learn/docs/sdk-snippets
+    destination: /learn/docs/api-references/sdk-snippets
+
+  # --- Docs customization shorthand paths ---
+  - source: /learn/docs/custom-css
+    destination: /learn/docs/customization/custom-css-js
+  - source: /learn/docs/custom-react-components
+    destination: /learn/docs/customization/custom-react-components
+  - source: /learn/docs/announcement-banner
+    destination: /learn/docs/customization/announcement-banner
+  - source: /learn/docs/hiding-content
+    destination: /learn/docs/customization/hiding-content
+  - source: /learn/docs/search
+    destination: /learn/docs/customization/search
+  - source: /learn/docs/frontmatter
+    destination: /learn/docs/configuration/page-level-settings
+
+  # --- Docs preview & publish shorthand paths ---
+  - source: /learn/docs/domain
+    destination: /learn/docs/preview-publish/setting-up-your-domain
+  - source: /learn/docs/publishing
+    destination: /learn/docs/preview-publish/publishing-your-docs
+  - source: /learn/docs/preview
+    destination: /learn/docs/preview-publish/preview-changes
+
+  # --- Docs SEO shorthand paths ---
+  - source: /learn/docs/redirects
+    destination: /learn/docs/seo/redirects
+  - source: /learn/docs/slugs
+    destination: /learn/docs/seo/configuring-slugs
+
+  # --- Docs configuration shorthand paths ---
+  - source: /learn/docs/versions
+    destination: /learn/docs/configuration/versions
+  - source: /learn/docs/products
+    destination: /learn/docs/configuration/products
+  - source: /learn/docs/tabs
+    destination: /learn/docs/configuration/tabs
+  - source: /learn/docs/changelogs
+    destination: /learn/docs/configuration/changelogs
+  - source: /learn/docs/reusable-snippets
+    destination: /learn/docs/writing-content/reusable-snippets
+
+  # --- Docs integration shorthand paths ---
+  - source: /learn/docs/intercom
+    destination: /learn/docs/integrations/support/intercom
+  - source: /learn/docs/google-analytics
+    destination: /learn/docs/integrations/analytics/google
+  - source: /learn/docs/posthog
+    destination: /learn/docs/integrations/analytics/posthog
+  - source: /learn/docs/segment
+    destination: /learn/docs/integrations/analytics/segment
+  - source: /learn/docs/fullstory
+    destination: /learn/docs/integrations/analytics/fullstory
+  - source: /learn/docs/mixpanel
+    destination: /learn/docs/integrations/analytics/mixpanel


### PR DESCRIPTION
## Summary

Adds redirects for URL patterns that users and crawlers commonly guess but currently return 404. These are "discoverability" redirects — they don't fix broken links, they catch logical URL guesses that miss intermediate path segments.

**Categories of redirects added:**

| Category | Example source → destination | Count |
|---|---|---|
| SDK language shorthand | `/learn/sdks/typescript/quickstart` → `/learn/sdks/generators/typescript/quickstart` | ~40 |
| .NET/dotnet aliases | `/learn/sdks/net/...` and `/learn/sdks/dotnet/...` → `generators/csharp/...` | 4 |
| SDK top-level shortcuts | `/learn/sdks/quickstart` → `/learn/sdks/overview/quickstart` | 8 |
| API def shorthand | `/learn/openapi/overview` → `/learn/api-definitions/openapi/overview` | 4 wildcards |
| CLI shorthand | `/learn/cli/commands` → `/learn/cli-api-reference/cli-reference/commands` | 5 |
| Docs shortcuts | `/learn/docs/quickstart`, `/learn/docs/ask-fern`, `/learn/docs/posthog`, etc. | ~60 |

All 160 source URLs were confirmed as 404 on production. All destination URLs were confirmed as 200.

## Review & Testing Checklist for Human

- [ ] **Redirect ordering/precedence**: These new wildcards are appended at the end of the redirects block. Verify that Fern's redirect engine uses first-match semantics so that existing specific redirects (e.g., `/learn/sdks/capabilities/method-names`) aren't overridden by new broad wildcards (e.g., `/learn/sdks/typescript/:slug*`). If Fern uses last-match, this PR could break existing redirects.
- [ ] **`/learn/sdks/changelog` destination**: Currently points to `/learn/sdks/generators/typescript/changelog` since there's no unified SDK changelog page. Confirm this is an acceptable default or if it should point to `/learn/sdks/overview/introduction` instead.
- [ ] **Test a sample on preview deployment**: After deploy, spot-check ~10 redirects across different categories (especially the wildcard patterns like `/learn/sdks/typescript/quickstart` and `/learn/openapi/overview`).

### Notes
- Redirects are purely additive (appended after all existing redirects) — no existing redirect rules were modified.
- Wildcard redirects (`:slug*`) will also redirect paths where the destination doesn't exist (e.g., `/learn/sdks/typescript/nonexistent` → `/learn/sdks/generators/typescript/nonexistent`, which will still 404). This is standard behavior and still moves the user closer to the right URL structure.

Link to Devin session: https://app.devin.ai/sessions/2dd15abd3d26412d9f73c60a6facb94d
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
