### PR TITLE
Fix hard-verified broken links and redirect destinations

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -211,7 +211,7 @@ redirects:
   - source: /learn/sdks/guides/publish-to-package-managers/pypi
     destination: /learn/sdks/generators/python/publishing
   - source: /learn/sdks/guides/publish-to-package-managers/nuget
-    destination: /learn/sdks/generators/net/publishing
+    destination: /learn/sdks/generators/csharp/publishing
   - source: /learn/sdks/guides/publish-to-package-managers/pkgsite
     destination: /learn/sdks/generators/go/publishing
   - source: /learn/sdks/guides/publish-to-package-managers/maven-central
@@ -237,7 +237,7 @@ redirects:
   - source: /learn/sdks/overview/github
     destination: /learn/sdks/overview/project-structure
   - source: /learn/sdks/introduction/customer-showcase
-    destination: /learn/sdks/customer-showcase
+    destination: /learn/sdks/overview/introduction
   - source: /learn/sdks/introduction/changelog/ts/:slug*
     destination: /learn/sdks/generators/typescript/changelog/:slug*
   - source: /learn/sdks/introduction/changelog/python/:slug*
@@ -293,7 +293,7 @@ redirects:
   
   # Building Your Docs redirects (older naming)
   - source: /learn/docs/building-your-docs/:slug*
-    destination: /learn/docs/building-and-customizing-your-docs/:slug*
+    destination: /learn/docs/getting-started/:slug*
 
   # Getting Started page redirects - specific cases first
   - source: /learn/docs/getting-started/customer-showcase
@@ -372,7 +372,7 @@ redirects:
   - source: /learn/docs/customization/custom-header-and-footer
     destination: /learn/docs/customization/header-and-footer
   - source: /learn/docs/content/frontmatter
-    destination: /learn/docs/customization/frontmatter
+    destination: /learn/docs/configuration/page-level-settings
   - source: /learn/docs/content/reusable-snippets
     destination: /learn/docs/writing-content/reusable-snippets
   - source: /learn/docs/writing-content/reusable-markdown
@@ -492,11 +492,11 @@ redirects:
     destination: /learn/cli-api-reference/cli-reference/options
   # CLI patterns
   - source: /learn/cli-api/cli-reference/:slug*
-    destination: /learn/cli-reference/:slug*
+    destination: /learn/cli-api-reference/cli-reference/:slug*
   - source: /learn/cli-api/cli/:slug*
-    destination: /learn/cli-reference/:slug*
+    destination: /learn/cli-api-reference/cli-reference/:slug*
   - source: /learn/cli-api/:slug*
-    destination: /learn/cli-reference/:slug*
+    destination: /learn/cli-api-reference/cli-reference/:slug*
   - source: /learn/cli-reference/changelog/:slug*
     destination: /learn/cli-api-reference/cli-reference/changelog/:slug*
 
@@ -526,7 +526,7 @@ redirects:
   - source: /learn/api-definition/openapi/audiences
     destination: /learn/api-definitions/openapi/extensions/audiences
   - source: /learn/api-definition/openapi/examples
-    destination: /learn/api-definitions/openapi/extensions/examples
+    destination: /learn/api-definitions/openapi/extensions/request-response-examples
   - source: /learn/api-definition/openapi/:slug*
     destination: /learn/api-definitions/openapi/:slug*
   - source: /learn/openapi-definition/extensions/webhooks
@@ -756,7 +756,7 @@ redirects:
   - source: /learn/api-definitions/openrpc/extensions/sdk-group-name
     destination: /learn/api-definitions/openrpc/extensions/sdk-group-names
   - source: /learn/api-definitions/openrpc/extensions/examples
-    destination: /learn/api-definitions/openrpc/examples
+    destination: /learn/api-definitions/openrpc/extensions/request-response-examples
   - source: /learn/api-definitions/openrpc/extensions/retry
     destination: /learn/api-definitions/openrpc/extensions/overview
   - source: /learn/overview/define-your-api/openapi/extensions

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -293,7 +293,7 @@ redirects:
   
   # Building Your Docs redirects (older naming)
   - source: /learn/docs/building-your-docs/:slug*
-    destination: /learn/docs/getting-started/:slug*
+    destination: /learn/docs/building-and-customizing-your-docs/:slug*
 
   # Getting Started page redirects - specific cases first
   - source: /learn/docs/getting-started/customer-showcase

--- a/fern/products/docs/pages/component-library/writing-content/markdown-basics.mdx
+++ b/fern/products/docs/pages/component-library/writing-content/markdown-basics.mdx
@@ -60,7 +60,7 @@ Use a `/` character to begin a relative URL to another page on your docs site. T
 
 <CodeBlock title='Relative link example'>
 ```mdx
-Read the [Introduction](/learn/overview/introduction).
+Read the [Introduction](/learn/sdks/overview/introduction).
 ```
 </CodeBlock>
 

--- a/fern/products/docs/pages/component-library/writing-content/markdown-basics.mdx
+++ b/fern/products/docs/pages/component-library/writing-content/markdown-basics.mdx
@@ -15,7 +15,7 @@ Throughout this documentation, "Markdown" refers to both Markdown and MDX. [MDX]
 
 Add pages manually to your documentation by creating Markdown (`.md`) or MDX (`.mdx`) files. New to Markdown? See [Markdown Guide: Getting started](https://www.markdownguide.org/getting-started/).
 
-Place your pages inside your `fern/` folder and link to them from your [navigation settings](/learn/docs/building-your-docs/navigation) in the `docs.yml` file.
+Place your pages inside your `fern/` folder and link to them from your [navigation settings](/learn/docs/configuration/navigation) in the `docs.yml` file.
 
 In the example below, the MDX files are inside a folder named `pages/`.
 

--- a/fern/products/docs/pages/navigation/announcement-banner.mdx
+++ b/fern/products/docs/pages/navigation/announcement-banner.mdx
@@ -9,7 +9,7 @@ An announcement banner is a great way to draw attention to new features and prod
 
 ```yaml docs.yml
 announcement:
-    message: "🚀 New feature: Announcements are available! (<a href=\"https://buildwithfern.com/learn/docs/building-your-docs/announcements\" target=\"_blank\">Learn more</a>) 🚀"
+    message: "🚀 New feature: Announcements are available! (<a href=\"https://buildwithfern.com/learn/docs/customization/announcement-banner\" target=\"_blank\">Learn more</a>) 🚀"
 ```
 
 Markdown and HTML is supported in the announcement message. You can include links, images, and other formatting. [Custom CSS](/docs/customization/custom-css-js#custom-css) can be used to customize the style of the announcement.

--- a/fern/products/docs/pages/resources/stainless-comparison.mdx
+++ b/fern/products/docs/pages/resources/stainless-comparison.mdx
@@ -100,7 +100,7 @@ Stainless [deploys static files](https://www.stainless.com/docs/docs-platform/ho
 
 | Feature | Fern Docs | Stainless Docs |
 |---------|-----------|----------------|
-| **Cloud hosting** | ✅ [Vercel with AWS VPC backend](/learn/docs/getting-started/publishing-your-docs) | ✅ Cloudflare (default) |
+| **Cloud hosting** | ✅ [Vercel with AWS VPC backend](/learn/docs/preview-publish/publishing-your-docs) | ✅ Cloudflare (default) |
 | **Self-hosted** | ✅ [Full-stack Docker](/learn/docs/self-hosted/overview) (PostgreSQL, S3/MinIO, MeiliSearch) | ❌ Static files only |
 | **Custom domains** | ✅ [Full support](/learn/docs/preview-publish/setting-up-your-domain) | ✅ Full support |
 <br/>
@@ -113,8 +113,8 @@ Stainless doesn't currently document redirect capabilities. Fern's [redirect sys
 | Feature | Fern Docs | Stainless Docs |
 |---------|-----------|----------------|
 | **Redirects** | ✅ [299+ rules](/learn/docs/seo/redirects) with pattern matching (`:slug`, `:splat`) | ❌ None |
-| **SEO optimization** | ✅ [Meta tags, JSON-LD, RSS, OG images, Twitter cards](/learn/docs/seo/metadata) | ✅ Basic meta tags |
-| **Sitemap & robots.txt** | ✅ [Automatic generation](/learn/docs/seo/metadata) | ✅ Automatic (assumed) |
+| **SEO optimization** | ✅ [Meta tags, JSON-LD, RSS, OG images, Twitter cards](/learn/docs/seo/setting-seo-metadata) | ✅ Basic meta tags |
+| **Sitemap & robots.txt** | ✅ [Automatic generation](/learn/docs/seo/setting-seo-metadata) | ✅ Automatic (assumed) |
 <br/>
 </Accordion>
 


### PR DESCRIPTION
## Summary

Fixes 12 hard-verified broken URLs across 4 files: 6 broken internal links in MDX files and 6 redirect rules in `docs.yml` pointing to destinations that return 404.

**How these were found:** All 192 unique internal links in MDX content files and all 135 redirect destinations in `docs.yml` were tested against production. Only the URLs that returned 404 are fixed in this PR.

**Broken internal links fixed (MDX):**
| File | Old (404) | New (200) |
|---|---|---|
| `stainless-comparison.mdx` | `/learn/docs/getting-started/publishing-your-docs` | `/learn/docs/preview-publish/publishing-your-docs` |
| `stainless-comparison.mdx` (×2) | `/learn/docs/seo/metadata` | `/learn/docs/seo/setting-seo-metadata` |
| `markdown-basics.mdx` | `/learn/overview/introduction` (code example) | `/learn/sdks/overview/introduction` |
| `markdown-basics.mdx` | `/learn/docs/building-your-docs/navigation` | `/learn/docs/configuration/navigation` |
| `announcement-banner.mdx` | `.../building-your-docs/announcements` (code example) | `.../customization/announcement-banner` |

**Broken redirect destinations fixed (`docs.yml`):**
| Source pattern | Old destination (404) | New destination (200) |
|---|---|---|
| `.../nuget` | `/learn/sdks/generators/net/publishing` | `/learn/sdks/generators/csharp/publishing` |
| `.../customer-showcase` | `/learn/sdks/customer-showcase` | `/learn/sdks/overview/introduction` |
| `.../content/frontmatter` | `/learn/docs/customization/frontmatter` | `/learn/docs/configuration/page-level-settings` |
| `.../cli-api/*` (3 rules) | `/learn/cli-reference/:slug*` | `/learn/cli-api-reference/cli-reference/:slug*` |
| `.../openapi/examples` | `.../openapi/extensions/examples` | `.../openapi/extensions/request-response-examples` |
| `.../openrpc/.../examples` | `.../openrpc/examples` | `.../openrpc/extensions/request-response-examples` |

## Review & Testing Checklist for Human

- [ ] **`/learn/sdks/customer-showcase` → `/learn/sdks/overview/introduction`**: The customer showcase page no longer exists. Confirm that redirecting to the SDK overview/introduction page is the best fallback (vs. the homepage or another page).
- [ ] **`markdown-basics.mdx` link example**: One changed link is inside a `<CodeBlock>` used as an example of how to write relative links. Verify the new example URL (`/learn/sdks/overview/introduction`) still makes sense as a generic example for users.
- [ ] **Test redirects after deploy**: Visit these source URLs on the preview deployment and confirm they redirect correctly:
  - `/learn/sdks/guides/publish-to-package-managers/nuget` → should land on csharp/publishing
  - `/learn/cli-api/cli-reference/overview` → should land on cli-api-reference/cli-reference/overview
  - `/learn/api-definition/openapi/examples` → should land on openapi/extensions/request-response-examples
  - `/learn/docs/content/frontmatter` → should land on configuration/page-level-settings

### Notes
- All destination URLs were verified as returning HTTP 200 on production before committing.
- Existing redirect sources (230 non-wildcard rules) were also tested — none are broken, so no other changes were needed.
- The `building-your-docs/:slug*` wildcard redirect was intentionally **not** changed — it chains through `building-and-customizing-your-docs/:slug*` which has 12 specific sub-rules for individual slugs. Instead, the two MDX files that referenced `building-your-docs/` paths directly were updated to use canonical URLs.
- The old PR #4337 (speculative/guessable redirects) should be closed — it was superseded by this hard-verified approach.

Link to Devin session: https://app.devin.ai/sessions/2dd15abd3d26412d9f73c60a6facb94d
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
