### PR TITLE
fix: escape `<String>` in Java changelog MDX to fix docs validation

### DIFF
--- a/fern/products/sdks/overview/java/changelog/2026-03-18.mdx
+++ b/fern/products/sdks/overview/java/changelog/2026-03-18.mdx
@@ -41,7 +41,7 @@ try-with-resources, calling `disconnect()` automatically on scope exit.
 lets callers tune max retries, backoff delay, and queue size before
 calling `connect()`.
 
-**Generic onMessage(Consumer<String>) handler** — fires for every
+**Generic `onMessage(Consumer<String>)` handler** — fires for every
 incoming text frame with the raw JSON string, before type-specific
 dispatch. Useful for logging or custom routing.
 


### PR DESCRIPTION
## Summary

The docs build was failing because `<String>` in the Java SDK changelog entry (`2026-03-18.mdx`, line 44) was being parsed as an unclosed HTML/JSX tag by the MDX compiler.

Fixed by wrapping `onMessage(Consumer<String>)` in backticks, which is also more consistent with how other code references in the same file are formatted.

**CI error:** `Failed to parse products/sdks/overview/java/changelog/2026-03-18.mdx: Expected a closing tag for <String> (44:29-44:37) before the end of strong`

## Review & Testing Checklist for Human

- [ ] Verify the docs build passes (CI should confirm this)
- [ ] Confirm the rendered changelog entry looks correct on the preview site

Link to Devin session: https://app.devin.ai/sessions/cfc4d746f9814cd9944225c7ede073da
Requested by: @davidkonigsberg