### PR TITLE
fix: use #id selector and var(--header-height-real) for Ask AI panel header

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -1184,7 +1184,7 @@ h1, h2, h3 {
 /*** START -- ASK AI PANEL STYLING ***/
 @media (min-width: 1024px) {
   #fern-ask-ai-panel-header {
-    height: var(--header-height-real);
+    height: calc(var(--header-height-real) + 1px);
   }
 }
 /*** END -- ASK AI PANEL STYLING ***/

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -1184,7 +1184,7 @@ h1, h2, h3 {
 /*** START -- ASK AI PANEL STYLING ***/
 @media (min-width: 1024px) {
   .fern-ask-ai-panel-header {
-    height: 76px;
+    height: var(--header-height-real);
   }
 }
 /*** END -- ASK AI PANEL STYLING ***/

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -1183,7 +1183,7 @@ h1, h2, h3 {
 
 /*** START -- ASK AI PANEL STYLING ***/
 @media (min-width: 1024px) {
-  .fern-ask-ai-panel-header {
+  #fern-ask-ai-panel-header {
     height: var(--header-height-real);
   }
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded `height: 76px` on `.fern-ask-ai-panel-header` with `height: var(--header-height-real)` so the Ask AI panel header dynamically matches the site header height rather than using a fixed pixel value.

Also switches the CSS selector from a class (`.fern-ask-ai-panel-header`) to an ID (`#fern-ask-ai-panel-header`) to match the element's actual `id` attribute set in the platform code.

## Review & Testing Checklist for Human

- [ ] Confirm the Ask AI panel header element has `id="fern-ask-ai-panel-header"` at runtime (not just a class). If the element only has a class, this rule will silently stop applying.
- [ ] Verify that `--header-height-real` resolves to the expected value on desktop (≥1024px) when the Ask AI panel is open. If the variable is missing in some theme or layout context, the height will collapse to `auto`.
- [ ] Visually confirm the Ask AI panel header aligns with the main site header after this change — open Ask AI on a docs page and check that the two headers are the same height.

### Notes
- This only applies at `min-width: 1024px` (the existing media query was not changed).
- The previous `76px` value was a hardcoded approximation; `--header-height-real` is set dynamically by the docs platform based on the configured `headerHeight` layout property.
- The ID `fern-ask-ai-panel-header` is defined as a constant (`FERN_ASK_AI_PANEL_HEADER_ID`) in the `fern-platform` repo and applied to the header div in `desktop-ask-ai-panel.tsx`.

Link to Devin session: https://app.devin.ai/sessions/8c422125206a41d8bbd4dcd3e48cbb2e
Requested by: @kgowru