### PR TITLE
chore: bump CI actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/auto-merge-on-docs-release.yml
+++ b/.github/workflows/auto-merge-on-docs-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find and merge dependent PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const version = context.payload.client_payload.version;

--- a/.github/workflows/check-devin-pr-assignee.yml
+++ b/.github/workflows/check-devin-pr-assignee.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'devin-ai-integration[bot]' }}
     steps:
       - name: Auto-assign requester from PR description
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create lychee config
         run: |
@@ -326,7 +326,7 @@ jobs:
 
 
       - name: Upload URLs (early, for debugging)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: urls
           path: |
@@ -706,7 +706,7 @@ jobs:
 
       - name: Upload errors-only report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lychee-report
           path: ./lychee-report.md
@@ -714,7 +714,7 @@ jobs:
 
       - name: Upload lychee outputs and verification results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: lychee-outputs
           path: |
@@ -727,7 +727,7 @@ jobs:
       - name: Create PR for broken links
         id: create-pr
         if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_github.outputs.has_missing == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DEVIN_PROMPT: |
             @devin-ai-integration Please fix the broken links detected by the scheduled link checker.
@@ -968,7 +968,7 @@ jobs:
 
       - name: Send Slack notification for broken links
         if: steps.create-pr.outputs.pr_created == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SLACK_TOKEN: ${{ secrets.DEVIN_AI_PR_BOT_SLACK_TOKEN }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -326,7 +326,7 @@ jobs:
 
 
       - name: Upload URLs (early, for debugging)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: urls
           path: |
@@ -706,7 +706,7 @@ jobs:
 
       - name: Upload errors-only report
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: lychee-report
           path: ./lychee-report.md
@@ -714,7 +714,7 @@ jobs:
 
       - name: Upload lychee outputs and verification results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: lychee-outputs
           path: |

--- a/.github/workflows/fern-scribe.yml
+++ b/.github/workflows/fern-scribe.yml
@@ -16,12 +16,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -62,7 +62,7 @@ jobs:
 
       - name: Comment on issue
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({
@@ -74,7 +74,7 @@ jobs:
 
       - name: Comment on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read # For checking out code
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch full history for git diff
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Fern CLI
         uses: fern-api/setup-fern-cli@v1

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -9,7 +9,7 @@ jobs:
   update-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
       - name: update-csharp-version
@@ -36,7 +36,7 @@ jobs:
         run: curl -s https://api.github.com/repos/fern-api/fern/releases/latest | jq -r -j '.tag_name' > fern/snippets/version-number-cli.mdx
       - name: create PR
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "update versions from docker hub"
           title: "Update versions from docker hub"

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -15,11 +15,11 @@ jobs:
       github.event.pull_request.user.login != 'fern-support' &&
       github.event.pull_request.user.login != 'github-actions'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             fern/**/*.md


### PR DESCRIPTION
## Summary

Bumps all external GitHub Actions to their latest Node.js 24-compatible major versions to address Node.js 20 deprecation warnings. Version-only changes across 8 workflow files — no workflow logic modified.

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v5 |
| `actions/github-script` | v7 | v8 |
| `actions/setup-node` | v4 | v5 |
| `actions/upload-artifact` | v4 | v6 |
| `peter-evans/create-pull-request` | v7 | v8 |
| `tj-actions/changed-files` | v41 | v47 |

**Actions left as-is** (no newer major version or already current): `actions/stale@v10`, `errata-ai/vale-action@reviewdog`, `fern-api/setup-fern-cli@v1`, `lycheeverse/lychee-action@v2`, `peter-evans/enable-pull-request-automerge@v3`, `thollander/actions-comment-pull-request@v2.4.3`

## Breaking Change Audit

- **`actions/checkout` v4→v5**: Node.js 24 runtime only. Inputs used (`fetch-depth`, `token`) unchanged. v6 was intentionally skipped — it changes credential persistence behavior and can break docker actions. ✔ Safe.
- **`actions/github-script` v7→v8**: Node.js 24 runtime only. Inputs used (`github-token`, `script`) unchanged. ✔ Safe.
- **`actions/setup-node` v4→v5**: Auto-caching breaking change exists, but this repo has no `packageManager` field in `package.json`, so it does not apply. The `fern-scribe.yml` workflow explicitly sets `cache: 'npm'` which is still supported. ✔ Safe.
- **`actions/upload-artifact` v4→v6**: v5 was preliminary Node.js 24 support (still defaulted to Node.js 20); v6 is the full Node.js 24 version. Inputs used (`name`, `path`, `if-no-files-found`) unchanged across both versions. ✔ Safe.
- **`peter-evans/create-pull-request` v7→v8**: Node.js 24 runtime only. Inputs used (`base`, `branch`, `commit-message`, `delete-branch`, `title`) unchanged. ✔ Safe.
- **`tj-actions/changed-files` v41→v47**: v42 changed directory-trailing-slash matching behavior; v43 changed `any_changed` default when no patterns specified. Our usage only passes `files` with glob patterns (no trailing slashes, no reliance on `any_changed` defaults), so neither breaking change applies. ✔ Safe.

## Review & Testing Checklist for Human

- [ ] Verify `tj-actions/changed-files` v41→v47 doesn't change output behavior for the `vale.yml` workflow — we only use the `files` input with glob patterns; confirm the filtered file list output format is unchanged
- [ ] Verify `actions/upload-artifact` v4→v6 (skipping v5) works correctly for the `check-links.yml` artifact uploads (`urls`, `lychee-report`, `lychee-outputs`)
- [ ] After merging, monitor the next scheduled runs of `check-links.yml` and `vale.yml` to confirm they work as expected

### Notes
- `upload-artifact` was bumped directly from v4 to v6 (not v5). v5 was a preliminary Node.js 24 release that still defaulted to Node.js 20; v6 is the proper Node.js 24 version.
- This repo has no `packageManager` field in `package.json`, so the `actions/setup-node@v5` auto-caching breaking change does not apply here.

Link to Devin session: https://app.devin.ai/sessions/3838526ec6224c6b9dc01df9ed56530e
Requested by: @davidkonigsberg