### PR TITLE
Document `casing` sub-field for `x-fern-enum` extension

### DIFF
--- a/fern/products/api-def/openapi-pages/extensions/enums.mdx
+++ b/fern/products/api-def/openapi-pages/extensions/enums.mdx
@@ -1,7 +1,7 @@
 ---
-title: Enum descriptions, names, and availability
-headline: Enum descriptions, names, and availability (OpenAPI)
-description: Add descriptions, custom names, and deprecation status to OpenAPI enum values with the `x-fern-enum` extension.
+title: Enum descriptions, names, casing, and availability
+headline: Enum descriptions, names, casing, and availability (OpenAPI)
+description: Add descriptions, custom names, per-language casing overrides, and deprecation status to OpenAPI enum values with the `x-fern-enum` extension.
 ---
 
 <Markdown src="/snippets/agent-directive.mdx"/>
@@ -65,3 +65,36 @@ export enum Operand {
   LessThan = "<"
 }
 ```
+
+## Custom casing
+
+Use the `casing` field to specify exact casing for each target language's naming convention. This gives more granular control than `name` alone, which sets a single default name for generated code.
+
+The `casing` field supports four optional sub-fields:
+
+- `snake` — override for snake_case (used in languages like Python)
+- `camel` — override for camelCase (used in languages like TypeScript/Java)
+- `screamingSnake` — override for SCREAMING_SNAKE_CASE (used in languages like Go)
+- `pascal` — override for PascalCase (used in languages like C#)
+
+```yaml title="openapi.yml" {13-17}
+components:
+  schemas:
+    Status:
+      type: string
+      enum:
+        - active
+        - in-progress
+      x-fern-enum:
+        active:
+          description: The item is active
+        in-progress:
+          name: InProgress
+          casing:
+            snake: in_progress
+            camel: inProgress
+            screamingSnake: IN_PROGRESS
+            pascal: InProgress
+```
+
+You can use `casing` alongside `name`. The `name` field sets the default generated name, while `casing` provides per-language overrides. If both are specified, the `casing` values take precedence for their respective language targets.


### PR DESCRIPTION
## Summary

Adds a new "Custom casing" section to the `x-fern-enum` extension docs page, documenting the `casing` sub-field that allows per-language casing overrides for enum values.

Changes:
- Updated frontmatter (title, headline, description) to mention casing
- Added `## Custom casing` section after the existing "Custom names" section
- Documents the four optional sub-fields: `snake`, `camel`, `screamingSnake`, `pascal`
- Includes a YAML example with line highlights
- Explains how `casing` interacts with `name`

## Review & Testing Checklist for Human

- [ ] **Verify `casing` sub-field names and semantics match the actual Fern implementation** — the four fields (`snake`, `camel`, `screamingSnake`, `pascal`) and their described language mappings (Python, TS/Java, Go, C#) were taken from the task description and not verified against source code
- [ ] **Check the YAML example is valid and the line highlights `{13-17}` point to the correct lines** (the `casing` block)
- [ ] Preview the page to confirm the updated title renders well in navigation and the new section looks good

### Notes
- Vale style checks were not run locally (Vale CLI not installed on the build machine); CI should catch any violations.
- No new pages or links were added, so no navigation or redirect changes needed.

Link to Devin session: https://app.devin.ai/sessions/2b9bd7d4bb33434997ba0f902132d39d
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
