### PR TITLE
fix(docs): correct inaccurate autorelease documentation

### DIFF
--- a/fern/products/sdks/autorelease.mdx
+++ b/fern/products/sdks/autorelease.mdx
@@ -6,21 +6,19 @@ description: Automate SDK releases with Fern Autorelease. Detects API spec chang
 <Markdown src="/snippets/agent-directive.mdx"/>
 
 <Note title="Early Access">
-Fern Autorelease is currently in early access. [Contact us](https://buildwithfern.com/contact) to get started.
+Fern Autorelease is in early access. [Contact us](https://buildwithfern.com/contact) to get started.
 </Note>
 
 Fern Autorelease automates SDK releases end-to-end. When your API specification changes, Autorelease regenerates SDKs, determines the version bump, and publishes to package registries.
 
 ## How it works
 
-Autorelease detects changes to your spec using either **git-based detection** (monitors your spec repository for commits) or **pull-based detection** (periodically fetches your hosted spec from a URL). Once changes are detected, Autorelease:
+When changes to your API specification are committed, Autorelease:
 
 1. Regenerates SDKs for all configured languages
-2. Analyzes the API diff and determines the next version (semantic, calendar-based, integer, or custom)
+2. Analyzes the API diff and determines the appropriate [semantic version](https://semver.org/) bump
 3. Commits to repositories, tags releases, and publishes packages
 4. Updates changelogs automatically
-
-Autorelease pauses and requests confirmation if it's uncertain about the version bump. Publishing uses tokens stored in your GitHub Actions secrets—Fern never has access to these credentials.
 
 If a release fails, Autorelease pauses and sends alerts via Slack (if configured) or the Fern Dashboard where you can review and retry.
 
@@ -55,38 +53,9 @@ groups:
   />
 </Frame>
 
-### Customize Autorelease
+### Review releases before publishing
 
-You can customize Autorelease if you need to fetch from a hosted spec URL or review releases before publishing.
-
-<AccordionGroup>
-<Accordion title="Enable pull-based detection">
-
-Add a cron schedule to your `generators.yml`:
-
-```yaml generators.yml
-autorelease:
-  cron:
-    schedule: "0 0 * * 0"  # Weekly on Sunday at midnight
-```
-
-Or configure per-generator:
-
-```yaml generators.yml
-groups:
-  python-sdk:
-    generators:
-      - name: fernapi/fern-python-sdk
-        version: <Markdown src="/snippets/version-number-python.mdx"/>
-        autorelease:
-          cron:
-            schedule: "0 */6 * * *"  # Every 6 hours
-```
-</Accordion>
-
-<Accordion title="Review releases before publishing">
-
-[Set `mode: pull-request`](/learn/sdks/reference/generators-yml#pull-request) to review releases before publishing.  Autorelease will open a pull request for you to review instead of publishing directly.
+[Set `mode: pull-request`](/learn/sdks/reference/generators-yml#pull-request) to review releases before publishing. Autorelease opens a pull request for you to review instead of publishing directly.
 
 ```yaml generators.yml {8}
 groups: 
@@ -98,5 +67,16 @@ groups:
           repository: your-org/your-repo-name
           mode: pull-request
 ```
-</Accordion>
-</AccordionGroup>
+
+### Disable autorelease
+
+To disable Autorelease for a specific generator while keeping it enabled globally, set `autorelease: false` on that generator:
+
+```yaml generators.yml {6}
+groups:
+  internal-sdk:
+    generators:
+      - name: fernapi/fern-python-sdk
+        version: <Markdown src="/snippets/version-number-python.mdx"/>
+        autorelease: false
+```

--- a/fern/products/sdks/reference/generators-yml-reference.mdx
+++ b/fern/products/sdks/reference/generators-yml-reference.mdx
@@ -403,24 +403,9 @@ Enable or disable [Fern Autorelease](/learn/sdks/overview/autorelease) globally 
 autorelease: true
 ```
 
-<ParamField path="autorelease" type="boolean | object" default={false} required={false} toc={true}>
-  Set to `true` to enable Autorelease, `false` to disable it. Explicit configuration in `generators.yml` takes precedence over other enablement methods. [Per-generator settings](#autorelease-2) override this global configuration.
+<ParamField path="autorelease" type="boolean" default={false} required={false} toc={true}>
+  Set to `true` to enable Autorelease, `false` to disable it. [Per-generator settings](#autorelease-2) override this global configuration.
 </ParamField>
-
-<Accordion title="Enable with pull-based detection">
-
-Configure a cron schedule to periodically fetch and check for spec changes:
-
-```yaml title="generators.yml"
-autorelease:
-  cron:
-    schedule: "0 0 * * 0"  # Weekly on Sunday at midnight
-```
-
-<ParamField path="cron.schedule" type="string" required={true} toc={true}>
-  A cron expression defining how often to check for spec changes. Uses standard cron syntax.
-</ParamField>
-</Accordion>
 
 ## `aliases`
 
@@ -1011,29 +996,9 @@ groups:
         autorelease: true
 ```
 
-<ParamField path="autorelease" type="boolean | object" default={false} required={false} toc={true}>
+<ParamField path="autorelease" type="boolean" default={false} required={false} toc={true}>
   Set to `true` to enable Autorelease for this generator, `false` to disable it. Per-generator settings override the global [`autorelease`](#autorelease-1) configuration.
 </ParamField>
-
-<Accordion title="Enable with pull-based detection">
-
-Configure a cron schedule to periodically fetch and check for spec changes for this generator:
-
-```yml title="generators.yml" {6-8}
-groups:
-  ts-sdk:
-    generators:
-      - name: fernapi/fern-typescript-sdk
-      ...
-        autorelease:
-          cron:
-            schedule: "0 */6 * * *"  # Every 6 hours
-```
-
-<ParamField path="cron.schedule" type="string" required={true} toc={true}>
-  A cron expression defining how often to check for spec changes. Uses standard cron syntax.
-</ParamField>
-</Accordion>
 
 #### `snippets`
 


### PR DESCRIPTION
## Summary

Fixes inaccuracies in the autorelease docs page and the `generators.yml` reference page by removing content that doesn't match the actual schema/implementation.

**Verified against the source schema** (`fern-api/fern`): `autorelease` is `optional<boolean>` at both the global level (`GeneratorsConfigurationSchema`) and the per-generator level (`GeneratorInvocationSchema`). There is no object form.

**Changes:**

- **Removed fabricated cron/pull-based detection config** — the `autorelease.cron.schedule` object doesn't exist in the schema. Removed from both the overview page and the reference page (2 accordions).
- **Fixed type** from `boolean | object` → `boolean` in the `generators-yml-reference.mdx` ParamFields.
- **Replaced non-existent versioning types** ("calendar-based, integer, or custom") with "semantic version".
- **Removed unverifiable claims** about pause/confirmation behavior and credential access model.
- **Added "Disable autorelease" section** — the CLI changelog (2025-12-11) links to `#disable-autorelease` which didn't exist. The feature itself is real (`autorelease: false` per-generator).
- **Fixed Vale warning** — removed "currently" from early access note.

## Review & Testing Checklist for Human

- [ ] **Verify removed claims are actually wrong**: I removed "Autorelease pauses and requests confirmation if it's uncertain about the version bump" and "Publishing uses tokens stored in your GitHub Actions secrets—Fern never has access to these credentials." These couldn't be verified in the CLI code, but they _could_ be accurate server-side behaviors. Someone who knows the autorelease backend should confirm these should stay removed.
- [ ] **Verify the "Disable autorelease" section is accurate**: Confirm that setting `autorelease: false` on a per-generator basis correctly overrides a global `autorelease: true`.
- [ ] **Check the preview deployment** to confirm the page renders correctly after removing the AccordionGroup wrapper and promoting sections to h3 headings.

### Notes

The link in the CLI changelog entry (2025-12-11) to `#disable-autorelease` should now resolve correctly with the new section added.

Link to Devin session: https://app.devin.ai/sessions/7fbf767547a6450dbdfe5a695801a97c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
