### PR TITLE
Remove unimplemented instance prop from If component docs

### DIFF
--- a/fern/products/docs/pages/component-library/default-components/if.mdx
+++ b/fern/products/docs/pages/component-library/default-components/if.mdx
@@ -1,27 +1,13 @@
 ---
 title: If
-description: Show or hide content based on which instance, product, or version the reader is viewing, or their role if your docs use authentication.
+description: Show or hide content based on which product or version the reader is viewing, or their role if your docs use authentication.
 ---
 
 <Markdown src="/snippets/agent-directive.mdx"/>
 
-The `<If>` component lets you show or hide content based on which instance, product, or version the reader is viewing, or their role if your docs use authentication.
+The `<If>` component lets you show or hide content based on which product or version the reader is viewing, or their role if your docs use authentication.
 
 ## Variants
-
-### By instance
-
-Use the `instance` prop to show content only when the reader is viewing a specific [instance](/learn/docs/configuration/site-level-settings#instances-configuration). The values in the `instance` array correspond to the instance names defined in your `docs.yml`.
-
-```jsx Markdown
-<If instance={["development"]}>
-  This content only appears in the development instance.
-</If>
-
-<If instance={["production"]}>
-  This content only appears in the production instance.
-</If>
-```
 
 ### By product
 
@@ -90,10 +76,6 @@ Use the `not` prop to invert any condition, showing content when the condition d
 ```
 
 ## Properties
-
-<ParamField path="instance" type="string[]" required={false}>
-  Show content only when the reader is viewing one of the specified instances. Values correspond to instance names defined in your `docs.yml`.
-</ParamField>
 
 <ParamField path="products" type="string[]" required={false}>
   Show content only when the reader is viewing one of the specified products. Values correspond to product slugs defined in your `docs.yml`.


### PR DESCRIPTION
## Summary

Removes all references to the `instance` prop from the `<If>` component documentation page. This prop was documented but never implemented in the actual component code (`fern-platform` bundle and dashboard `If.tsx` files have no `instance` prop, no hook to read the current instance, and no matching logic). Additionally, instances in `docs.yml` don't have a `name` property, so there was no clear value to reference even if it were implemented.

Changes:
- Removed the "By instance" variant section (heading, description, and code example)
- Removed the `instance` ParamField from the Properties section
- Updated the page description and intro paragraph to no longer mention "instance"

## Review & Testing Checklist for Human
- [ ] Verify the rendered page at `/learn/docs/component-library/if` looks correct with the instance section removed (check preview deployment)
- [ ] Confirm no other docs pages link to the now-removed `#by-instance` anchor

### Notes
This was identified during a customer question about how the `instance` property works — investigation confirmed the prop doesn't exist in the `If` component source code in either `packages/fern-docs/bundle/src/mdx/components/if/If.tsx` or `packages/fern-dashboard/src/docs/mdx/components/if/If.tsx`.

Link to Devin session: https://app.devin.ai/sessions/ef9d753808ed4deebd646b1af588c63c
Requested by: @fern-support