### PR TITLE
fix(ci): enable anchor link validation in scheduled link checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -64,9 +64,6 @@ jobs:
             "^tel:",
             "^javascript:",
             
-            # Anchor-only links
-            "^#",
-            
             # All GitHub URLs - checked separately in dedicated steps
             "^https://github\\.com/"
           ]

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -360,6 +360,7 @@ jobs:
             --max-retries 3
             --retry-wait-time 10
             --max-concurrency 20
+            --include-fragments
             --files-from urls.txt
           output: ./lychee-raw-main.md
           format: markdown

--- a/fern/products/api-def/pages/overrides.mdx
+++ b/fern/products/api-def/pages/overrides.mdx
@@ -59,7 +59,7 @@ api:
       overrides: ./overrides.yml
 ```
 
-You can also specify [multiple override files](#multiple-override-files).
+You can also specify [multiple override files](#managing-overrides-across-apis).
 
 </Step>
 <Step title="Fern combines your spec and overrides">


### PR DESCRIPTION
## Description

Fixes a broken same-page anchor link in the overrides docs page, and updates the scheduled link checker to catch this class of bug going forward.

The link `[multiple override files](#multiple-override-files)` pointed to a heading that doesn't exist — the correct anchor is `#managing-overrides-across-apis`. The scheduled `check-links.yml` workflow didn't catch this because it explicitly excluded anchor-only links (`^#`) and didn't validate HTML fragment targets.

Context: The `^#` exclusion and lack of `--include-fragments` were part of the original lychee setup in #2581, likely to avoid noise from fragments that couldn't be validated via HTTP. With `--include-fragments`, lychee now fetches each page and verifies that anchor targets exist as `id` attributes in the rendered HTML.

## Changes Made

- **overrides.mdx**: Fix broken anchor `#multiple-override-files` → `#managing-overrides-across-apis`
- **check-links.yml**: Remove `^#` exclusion so anchor links are no longer skipped
- **check-links.yml**: Add `--include-fragments` flag so lychee validates that anchor targets actually exist in rendered pages

## Testing

- [ ] Trigger `check-links.yml` manually via `workflow_dispatch` to verify anchor validation works
- [ ] Confirm no false positives from the new fragment checking