### PR TITLE
Remove Cohere as an available model from Ask Fern docs

### DIFF
--- a/fern/products/docs/pages/resources/stainless-comparison.mdx
+++ b/fern/products/docs/pages/resources/stainless-comparison.mdx
@@ -76,7 +76,7 @@ Stainless offers RAG-based search. Fern provides additional AI features includin
 
 | Feature | Fern Docs | Stainless Docs |
 |---------|-----------|----------------|
-| **AI chatbot** | ✅ [Ask Fern](/learn/docs/ai-features/ask-fern/overview) with Claude/Cohere, [guidance documents](/learn/docs/ai-features/ask-fern/guidance), and custom knowledge sources | ✅ RAG-based Q&A |
+| **AI chatbot** | ✅ [Ask Fern](/learn/docs/ai-features/ask-fern/overview) with Claude, [guidance documents](/learn/docs/ai-features/ask-fern/guidance), and custom knowledge sources | ✅ RAG-based Q&A |
 | **AI analytics** | ✅ [Content gap identification](/learn/docs/ai-features/ask-fern/overview) and insights | ❌ None |
 | **Search** | ✅ Vector search with faceting by language, product, version | ⚠️ Metadata-driven with basic faceting |
 | **LLM-friendly format** | ✅ [/llms.txt and /llms-full.txt](/learn/docs/ai-features/llms-txt) | ✅ .md extension on URLs |
@@ -155,7 +155,7 @@ Both platforms support [customization](https://www.stainless.com/docs/docs-platf
 | **Storage** | S3 (AWS/MinIO) | Not applicable (static) |
 | **Search** | Algolia, MeiliSearch (self-hosted) | Metadata-driven indexing |
 | **Vector database** | TurboPuffer | None |
-| **AI** | Bedrock, Claude, Cohere | RAG with LLM (provider not specified) |
+| **AI** | Bedrock, Claude | RAG with LLM (provider not specified) |
 | **Authentication** | WorkOS | API keys (for Stainless service) |
 | **CDN** | Cloudflare + Vercel Edge | Cloudflare |
 | **Analytics** | PostHog | None |

--- a/fern/snippets/ask-fern-config.mdx
+++ b/fern/snippets/ask-fern-config.mdx
@@ -34,7 +34,6 @@ ai-search:
   The AI model to use for Ask Fern responses. Options:
   - `claude-3.7` - Claude 3.7 Sonnet (default)
   - `claude-4` - Claude 4 Sonnet
-  - `command-a` - Cohere Command A
   
   If not specified, Ask Fern uses `claude-3.7`.
 </ParamField>


### PR DESCRIPTION
## Summary

Removes all references to Cohere as an available AI model for Ask Fern across the public documentation:

- **`fern/snippets/ask-fern-config.mdx`**: Removed `command-a` (Cohere Command A) from the `ai-search.model` options list
- **`stainless-comparison.mdx`**: Removed "Cohere" from the AI chatbot feature row and the technology stack comparison table

References to Cohere as a _customer_ (SDK examples, PDF export demos) are intentionally unchanged.

## Review & Testing Checklist for Human

- [ ] Verify there are no other pages referencing Cohere as a model option for Ask Fern (a CLI changelog entry from 2025-03-27 mentioning Cohere Command R+ was intentionally kept as historical record)
- [ ] Confirm the preview deployment renders the config snippet and comparison tables correctly after the removal

Link to Devin session: https://app.devin.ai/sessions/96db9e98bc104770abe1d8aa45f9ceb4
Requested by: @paarthfern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
