### PR TITLE
Improve self-hosted docs based on user feedback

### DIFF
--- a/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
@@ -21,7 +21,7 @@ Password authentication protects your docs behind a simple password prompt. User
 Add the following environment variables to your Dockerfile:
 
 ```dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 COPY fern/ /fern/
 
@@ -52,7 +52,7 @@ Basic token verification uses JWTs (JSON Web Tokens) to authenticate users. This
 Add the following environment variables to your Dockerfile:
 
 ```dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 COPY fern/ /fern/
 
@@ -231,7 +231,7 @@ The self-hosted container includes a built-in test login page that you can enabl
 Add the following environment variables to your Dockerfile:
 
 ```dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 COPY fern/ /fern/
 
@@ -278,7 +278,7 @@ You can enable [API key injection](/learn/docs/authentication/features/api-key-i
 Add `FERN_API_KEY_INJECTION_ENABLED` to your Dockerfile alongside the basic token verification variables:
 
 ```dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 COPY fern/ /fern/
 

--- a/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-authentication.mdx
@@ -21,7 +21,7 @@ Password authentication protects your docs behind a simple password prompt. User
 Add the following environment variables to your Dockerfile:
 
 ```dockerfile
-FROM fernapi/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 
@@ -52,7 +52,7 @@ Basic token verification uses JWTs (JSON Web Tokens) to authenticate users. This
 Add the following environment variables to your Dockerfile:
 
 ```dockerfile
-FROM fernapi/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 
@@ -231,7 +231,7 @@ The self-hosted container includes a built-in test login page that you can enabl
 Add the following environment variables to your Dockerfile:
 
 ```dockerfile
-FROM fernapi/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 
@@ -278,7 +278,7 @@ You can enable [API key injection](/learn/docs/authentication/features/api-key-i
 Add `FERN_API_KEY_INJECTION_ENABLED` to your Dockerfile alongside the basic token verification variables:
 
 ```dockerfile
-FROM fernapi/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 

--- a/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
@@ -21,7 +21,7 @@ Before setting up self-hosted documentation, ensure you have:
 
 The self-hosted documentation runs on a private Docker image: `fernenterprise/fern-self-hosted`
 
-**Contact Fern Support** to receive a Docker Hub organization access token (OAT) and the latest image tag.
+**Contact Fern Support** to receive a Docker Hub organization access token (OAT).
 
 Log in to Docker Hub using the token provided by Fern:
 
@@ -34,17 +34,11 @@ When prompted for a password, enter the OAT provided by the Fern team.
 </Step>
 <Step title="Download the Docker image">
 
-Pull the image using the tag provided by Fern:
+Pull the image:
 
 ```bash
-docker pull fernenterprise/fern-self-hosted:<latest-tag>
+docker pull fernenterprise/fern-self-hosted:latest
 ```
-
-Replace `<latest-tag>` with the specific tag provided by Fern.
-
-<Warning>
-Don't use `fernenterprise/fern-self-hosted:latest` as it may not contain the most recent version. Always use the specific tag provided by Fern.
-</Warning>
 
 Verify the image is available in your Docker daemon:
 
@@ -69,14 +63,12 @@ your-project/
 Add the following content to the `Dockerfile`:
 
 ```dockerfile Dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 COPY fern/ /fern/
 
 RUN fern-generate
 ```
-
-Replace `<latest-tag>` with the tag from the previous step.
 
 <Info>
 `fern-generate` is a command available inside the Docker image that processes your documentation at build time, enabling faster container startup, air-gapped deployment, and a smaller attack surface. It's not a command you run on your host machine. You can alternatively [defer generation to runtime](#runtime-generation).
@@ -94,15 +86,13 @@ docker build -t self-hosted-docs .
 </Step>
 <Step title="Run the documentation">
 
-Start your self-hosted documentation on port 8080:
+Start your self-hosted documentation:
 
 ```bash
-docker run -p 8080:3000 self-hosted-docs
+docker run -p 3000:3000 self-hosted-docs
 ```
 
-The `-p 8080:3000` flag maps port 8080 on your machine to port 3000 inside the container. The documentation will be available at [localhost:8080](http://localhost:8080).
-
-You can replace `8080` with any available port on your machine.
+The documentation will be available at [localhost:3000](http://localhost:3000).
 
 </Step>
 <Step title="Deploy the documentation">
@@ -127,7 +117,7 @@ instances:
 To override the domain at runtime (for example, when the actual hostname differs from the `custom-domain` in `docs.yml`), set the `CUSTOM_DOMAIN` environment variable:
 
 ```bash
-docker run -p 8080:3000 -e CUSTOM_DOMAIN=docs.plantstore.dev self-hosted-docs
+docker run -p 3000:3000 -e CUSTOM_DOMAIN=docs.plantstore.dev self-hosted-docs
 ```
 
 See [Environment variables](#environment-variables) for details.
@@ -241,7 +231,7 @@ The value must start with `/` and must not end with a trailing slash.
 Set `NEXT_PUBLIC_BASE_PATH` in your Dockerfile before running `fern-generate`. This patches the base path into the bundle at build time, so the container can run with a read-only filesystem.
 
 ```dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 COPY fern/ /fern/
 
@@ -256,7 +246,7 @@ RUN fern-generate
 Pass `NEXT_PUBLIC_BASE_PATH` when starting the container. The base path is patched into the bundle at container startup.
 
 ```bash
-docker run -p 8080:3000 -e NEXT_PUBLIC_BASE_PATH=/docs self-hosted-docs
+docker run -p 3000:3000 -e NEXT_PUBLIC_BASE_PATH=/docs self-hosted-docs
 ```
 
 <Warning>
@@ -266,7 +256,7 @@ Runtime patching modifies files inside the container on startup, so it is not co
 </Tab>
 </Tabs>
 
-With `NEXT_PUBLIC_BASE_PATH=/docs`, the documentation is accessible at `http://localhost:8080/docs` instead of `http://localhost:8080/`.
+With `NEXT_PUBLIC_BASE_PATH=/docs`, the documentation is accessible at `http://localhost:3000/docs` instead of `http://localhost:3000/`.
 
 <Info>
 A single Docker image built **without** `NEXT_PUBLIC_BASE_PATH` can be configured at runtime to serve from any path. This lets you reuse one image across environments that may need different base paths.
@@ -282,7 +272,7 @@ By default, `fern-generate` runs at Docker build time. Defer generation to runti
 Use the `--only-deps` flag to defer generation to runtime:
 
 ```dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 COPY fern/ /fern/
 
@@ -335,7 +325,7 @@ If there's no `deps` or `dependencies` section (or only local paths), you can sk
 Run `fern-generate` at build time when network access is available:
 
 ```dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 COPY fern/ /fern/
 
@@ -351,7 +341,7 @@ Use this option when you don't have all the information at build time and need t
 To generate at runtime in an air-gapped environment, vendor buf dependencies locally:
 
 ```dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 # Install buf CLI for dependency caching
 RUN npm install -g @bufbuild/buf
@@ -400,7 +390,7 @@ api:
 This approach works with both build-time and runtime generation:
 
 ```dockerfile
-FROM fernenterprise/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:latest
 
 COPY fern/ /fern/
 

--- a/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
@@ -17,80 +17,98 @@ Before setting up self-hosted documentation, ensure you have:
 ## Setup instructions
 
 <Steps>
-<Step title="Request Access to the Docker Image">
+<Step title="Request access to the Docker image">
 
-The self-hosted documentation runs on a private Docker image: `fernapi/fern-self-hosted`
+The self-hosted documentation runs on a private Docker image: `fernenterprise/fern-self-hosted`
 
 **Contact Fern Support** and provide your Docker Hub username to the Fern team. Fern will allowlist your account to download the private image, and provide you with the latest tag.
 
 </Step>
-<Step title="Download the Docker Image">    
+<Step title="Download the Docker image">
 
 Once your account is allowlisted, download the latest image:
 
 ```bash
-docker pull fernapi/fern-self-hosted:<latest-tag>
+docker pull fernenterprise/fern-self-hosted:<latest-tag>
 ```
 
+Replace `<latest-tag>` with the specific tag provided by Fern.
+
 <Warning>
-Do not use `fernapi/fern-self-hosted:latest` as it may not contain the most recent version. Always use the specific latest tag provided by Fern.
+Do not use `fernenterprise/fern-self-hosted:latest` as it may not contain the most recent version. Always use the specific tag provided by Fern.
 </Warning>
 
 You can verify the image is available in your Docker daemon:
 
 ```bash
-docker images | grep fernapi/fern-self-hosted
+docker images | grep fernenterprise/fern-self-hosted
 ```
 
 </Step>
 <Step title="Create a Dockerfile">
 
-In the directory containing your `fern/` folder, create a new `Dockerfile` with the following content:
+In the same directory that contains your `fern/` folder, create a file named `Dockerfile`:
 
-```dockerfile <your-docker-file-name>
-FROM fernapi/fern-self-hosted:<latest-tag>
+```
+your-project/
+├── Dockerfile
+└── fern/
+    ├── fern.config.json
+    ├── docs.yml
+    └── ...
+```
+
+Add the following content to the `Dockerfile`:
+
+```dockerfile Dockerfile
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 
 RUN fern-generate
 ```
 
-Replace `<latest-tag>` with the actual tag used in the previous step.
+Replace `<latest-tag>` with the tag from the previous step.
 
 <Info>
-  `fern-generate` processes your documentation at build time, enabling faster container startup, air-gapped deployment, and a smaller attack surface. You can alternatively [defer generation to runtime](#runtime-generation).
-  </Info>
+`fern-generate` is a command available inside the Docker image that processes your documentation at build time, enabling faster container startup, air-gapped deployment, and a smaller attack surface. It's not a command you run on your host machine. You can alternatively [defer generation to runtime](#runtime-generation).
+</Info>
 
 </Step>
-<Step title="Build Your Custom Docker Image">
+<Step title="Build your Docker image">
 
-Build your custom Docker image using the Dockerfile:
+From the directory containing your `Dockerfile` and `fern/` folder, build the image:
 
 ```bash
-docker build -f <your-docker-file-name> -t <your-image-name> <path-to-dockerfile>
-```
-
-Example:
-  
-```bash
-docker build -f Dockerfile -t self-hosted-docs .
+docker build -t self-hosted-docs .
 ```
 
 </Step>
-<Step title="Run the Documentation">
+<Step title="Run the documentation">
 
-Start your self-hosted documentation:
+Start your self-hosted documentation on port 8080:
 
 ```bash
-docker run -p <port-number>:3000 <your-image-name>
+docker run -p 8080:3000 self-hosted-docs
 ```
 
-The documentation will be available at `localhost:<port-number>`.
+The `-p 8080:3000` flag maps port 8080 on your machine to port 3000 inside the container. The documentation will be available at [localhost:8080](http://localhost:8080).
+
+You can replace `8080` with any available port on your machine.
 
 </Step>
-<Step title="Configure Custom Domain">
+<Step title="Deploy the documentation">
 
-Your documentation will be published to the domain specified in your `docs.yml` file. For example:
+You can now deploy the image to your own infrastructure, allowing you to host the documentation on your own domain.
+
+Once deployed, you can set up [preview environments](/learn/docs/self-hosted/previews) to preview documentation changes on every pull request.
+
+</Step>
+</Steps>
+
+## Custom domain
+
+Your documentation uses the domain specified in your `docs.yml` file. For example:
 
 ```yaml
 instances:
@@ -101,20 +119,10 @@ instances:
 To override the domain at runtime (for example, when the actual hostname differs from the `custom-domain` in `docs.yml`), set the `CUSTOM_DOMAIN` environment variable:
 
 ```bash
-docker run -p 3000:3000 -e CUSTOM_DOMAIN=docs.plantstore.dev <your-image-name>
+docker run -p 8080:3000 -e CUSTOM_DOMAIN=docs.plantstore.dev self-hosted-docs
 ```
 
 See [Environment variables](#environment-variables) for details.
-
-</Step>
-<Step title="Deploy the Documentation">
-
-You can now deploy the image to your own infrastructure, allowing you to host the documentation on your own domain.
-
-Once deployed, you can set up [preview environments](/learn/docs/self-hosted/previews) to preview documentation changes on every pull request.
-
-</Step>
-</Steps>
 
 ## Environment variables
 
@@ -225,7 +233,7 @@ The value must start with `/` and must not end with a trailing slash.
 Set `NEXT_PUBLIC_BASE_PATH` in your Dockerfile before running `fern-generate`. This patches the base path into the bundle at build time, so the container can run with a read-only filesystem.
 
 ```dockerfile
-FROM fernapi/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 
@@ -240,7 +248,7 @@ RUN fern-generate
 Pass `NEXT_PUBLIC_BASE_PATH` when starting the container. The base path is patched into the bundle at container startup.
 
 ```bash
-docker run -p 3000:3000 -e NEXT_PUBLIC_BASE_PATH=/docs <your-image-name>
+docker run -p 8080:3000 -e NEXT_PUBLIC_BASE_PATH=/docs self-hosted-docs
 ```
 
 <Warning>
@@ -250,7 +258,7 @@ Runtime patching modifies files inside the container on startup, so it is not co
 </Tab>
 </Tabs>
 
-With `NEXT_PUBLIC_BASE_PATH=/docs`, the documentation is accessible at `http://localhost:3000/docs` instead of `http://localhost:3000/`.
+With `NEXT_PUBLIC_BASE_PATH=/docs`, the documentation is accessible at `http://localhost:8080/docs` instead of `http://localhost:8080/`.
 
 <Info>
 A single Docker image built **without** `NEXT_PUBLIC_BASE_PATH` can be configured at runtime to serve from any path. This lets you reuse one image across environments that may need different base paths.
@@ -266,7 +274,7 @@ By default, `fern-generate` runs at Docker build time. Defer generation to runti
 Use the `--only-deps` flag to defer generation to runtime:
 
 ```dockerfile
-FROM fernapi/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 
@@ -319,7 +327,7 @@ If there's no `deps` or `dependencies` section (or only local paths), you can sk
 Run `fern-generate` at build time when network access is available:
 
 ```dockerfile
-FROM fernapi/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 
@@ -335,7 +343,7 @@ Use this option when you don't have all the information at build time and need t
 To generate at runtime in an air-gapped environment, vendor buf dependencies locally:
 
 ```dockerfile
-FROM fernapi/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 # Install buf CLI for dependency caching
 RUN npm install -g @bufbuild/buf
@@ -384,7 +392,7 @@ api:
 This approach works with both build-time and runtime generation:
 
 ```dockerfile
-FROM fernapi/fern-self-hosted:<latest-tag>
+FROM fernenterprise/fern-self-hosted:<latest-tag>
 
 COPY fern/ /fern/
 
@@ -405,6 +413,13 @@ The container parses all `generators.yml` files in your fern directory, finds pr
 ### Kubernetes deployment
 
 Here is a sample Deployment and Service configuration. Replace `your-registry/fern-docs:latest` with your image name.
+
+Apply the configuration:
+
+```bash
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml
+```
 
 **deployment.yaml:**
 

--- a/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
@@ -31,6 +31,12 @@ docker login --username fernenterprise
 
 When prompted for a password, enter the OAT provided by the Fern team.
 
+In CI, pass the token via the `DOCKERHUB_OAT` environment variable:
+
+```bash
+echo "$DOCKERHUB_OAT" | docker login --username fernenterprise --password-stdin
+```
+
 </Step>
 <Step title="Download the Docker image">
 

--- a/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted-set-up.mdx
@@ -12,21 +12,29 @@ description: Learn how to set up self-hosted documentation on your own infrastru
 Before setting up self-hosted documentation, ensure you have:
 - Docker installed on your system
 - Access to your Fern project's `fern/` directory
-- A Docker Hub account (for accessing the private image)
+- A Docker Hub organization access token (OAT) from Fern (for pulling the private image)
 
 ## Setup instructions
 
 <Steps>
-<Step title="Request access to the Docker image">
+<Step title="Authenticate with Docker Hub">
 
 The self-hosted documentation runs on a private Docker image: `fernenterprise/fern-self-hosted`
 
-**Contact Fern Support** and provide your Docker Hub username to the Fern team. Fern will allowlist your account to download the private image, and provide you with the latest tag.
+**Contact Fern Support** to receive a Docker Hub organization access token (OAT) and the latest image tag.
+
+Log in to Docker Hub using the token provided by Fern:
+
+```bash
+docker login --username fernenterprise
+```
+
+When prompted for a password, enter the OAT provided by the Fern team.
 
 </Step>
 <Step title="Download the Docker image">
 
-Once your account is allowlisted, download the latest image:
+Pull the image using the tag provided by Fern:
 
 ```bash
 docker pull fernenterprise/fern-self-hosted:<latest-tag>
@@ -35,10 +43,10 @@ docker pull fernenterprise/fern-self-hosted:<latest-tag>
 Replace `<latest-tag>` with the specific tag provided by Fern.
 
 <Warning>
-Do not use `fernenterprise/fern-self-hosted:latest` as it may not contain the most recent version. Always use the specific tag provided by Fern.
+Don't use `fernenterprise/fern-self-hosted:latest` as it may not contain the most recent version. Always use the specific tag provided by Fern.
 </Warning>
 
-You can verify the image is available in your Docker daemon:
+Verify the image is available in your Docker daemon:
 
 ```bash
 docker images | grep fernenterprise/fern-self-hosted

--- a/fern/products/docs/pages/enterprise/self-hosted.mdx
+++ b/fern/products/docs/pages/enterprise/self-hosted.mdx
@@ -74,10 +74,11 @@ PDF export and **offline AI chat functionality** for self-hosted deployments are
 
 Fern provides your documentation site as a ready-to-run Docker container that you can deploy on your own infrastructure. For detailed instructions, see [Set up self-hosted documentation](/learn/docs/self-hosted/set-up).
 
-1. **Download the Docker image** - Fern provides the location of the most up-to-date Docker image containing the documentation frontend
+1. **Authenticate with Docker Hub** - Use the organization access token (OAT) provided by Fern to log in
+1. **Download the Docker image** - Pull the `fernenterprise/fern-self-hosted` image
 1. **Upload your fern folder** - Add your documentation source files to the container
-1. **Run the container** - Spin up your local server using standard Docker commands
-1. **Configure hosting** - Set up your server environment and decide how to publish/share the documentation
+1. **Run the container** - Start your local server using standard Docker commands
+1. **Deploy** - Set up your server environment and publish the documentation
 1. **Receive updated Docker images** - Fern releases new versions of the Docker image that your team can evaluate and deploy when ready.
 
 ### Architecture diagram
@@ -100,7 +101,7 @@ sequenceDiagram
 
 ## Monitoring and health checks
 
-The self-hosted container includes [health check endpoints](./health-check-endpoints) on port 8081 for Kubernetes and Helm deployments.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+The self-hosted container includes [health check endpoints](./health-check-endpoints) on port 8081 for Kubernetes and Helm deployments.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
 
 
 


### PR DESCRIPTION
## Summary

Updates self-hosted documentation based on feedback from the docker bug bash / walkthrough thread. Three files changed: `self-hosted-set-up.mdx`, `self-hosted-authentication.mdx`, and `self-hosted.mdx`.

**Docker org rename**: All Docker image references changed from `fernapi/fern-self-hosted` to `fernenterprise/fern-self-hosted` across all files.

**Authentication flow update**: Replaced the old allowlisting workflow (provide Docker Hub username → get allowlisted) with Docker Hub Organization Access Tokens (OATs). New step 1 is "Authenticate with Docker Hub" with `docker login --username fernenterprise`. Includes a CI example using `--password-stdin` with a `DOCKERHUB_OAT` environment variable.

**Image tag simplification**: All `<latest-tag>` placeholders replaced with `:latest`. The previous warning against using `:latest` has been removed.

**Setup step improvements** (in `self-hosted-set-up.mdx`):
- Removed confusing placeholder variables (`<your-docker-file-name>`, `<your-image-name>`, `<port-number>`) and replaced with concrete defaults (`Dockerfile`, `self-hosted-docs`, `3000`)
- Simplified `docker build` command — removed `-f` flag, single copy-paste command
- Port mapping simplified to `-p 3000:3000`
- Added directory tree showing where `Dockerfile` should live relative to `fern/`
- Clarified that `fern-generate` runs inside the Docker container, not on the host machine
- Moved "Configure Custom Domain" out of the numbered setup steps into its own `## Custom domain` section (it's optional, not the logical next step after running the container)
- Added `kubectl apply` commands to the Kubernetes deployment section
- Step titles now use sentence case

**Overview page update** (`self-hosted.mdx`):
- Setup process steps updated to reflect new auth-first flow and concrete image name

## Review & Testing Checklist for Human
- [ ] Verify `docker login --username fernenterprise` is the correct OAT login flow — is the username literally `fernenterprise`, or does Docker Hub OAT auth use a different username?
- [ ] Confirm `:latest` is kept up to date on Docker Hub — the old docs explicitly warned against using it
- [ ] Check the CI login example (`echo "$DOCKERHUB_OAT" | docker login --username fernenterprise --password-stdin`) works as expected with a real OAT
- [ ] Preview the rendered pages to confirm the directory tree, restructured steps, and new auth instructions read well

Recommended test plan: Follow the setup instructions end-to-end on a fresh machine using a real OAT to confirm the happy path works as documented.

### Notes
- SDK generator references (`fernapi/fern-python-sdk`, etc.) in other docs were intentionally left unchanged — only the self-hosted Docker image org was updated.
- Pre-existing Vale warnings (e.g., "latest" time-relative terms) were not addressed since they existed before this PR and are inherent to the content's subject matter.
- The `DOCKERHUB_OAT` env var name in the CI example is a suggested convention, not a requirement — customers can name it whatever they like.

Link to Devin session: https://app.devin.ai/sessions/9567f0ff03294d2fa2a8b6425a47c228
Requested by: @thesandlord
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/4682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
