### PR TITLE
Fix product switcher layout: hide spec subtitles and update stale selectors

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -171,17 +171,9 @@ h1, h2, h3 {
       left: 0.5rem;
     }
 
-    > a[href*="openapi"],
-    > a[href*="asyncapi"],
-    > a[href*="openrpc"],
-    > a[href*="grpc"],
-    > a[href*="ferndef"] {
+    > a[href*="openapi"] {
       grid-column: 3;
       grid-row: 1;
-      position: absolute;
-      left: 66.66%;
-      right: 0;
-      margin: 0 -0.75rem;
 
       .fern-selection-item-icon {
         width: 1.5rem;
@@ -189,11 +181,49 @@ h1, h2, h3 {
       }
     }
 
-    > a[href*="openapi"] { top: 1.25rem; }
-    > a[href*="asyncapi"] { top: calc(1.25rem + (248px - 2.5rem) / 5 * 1); }
-    > a[href*="openrpc"] { top: calc(1.25rem + (248px - 2.5rem) / 5 * 2); }
-    > a[href*="grpc"] { top: calc(1.25rem + (248px - 2.5rem) / 5 * 3); }
-    > a[href*="ferndef"] { top: calc(1.25rem + (248px - 2.5rem) / 5 * 4); }
+    > a[href*="asyncapi"] {
+      grid-column: 3;
+      grid-row: 2;
+      transform: translateY(-32px);
+
+      .fern-selection-item-icon {
+        width: 1.5rem;
+        height: 1.5rem;
+      }
+    }
+
+    > a[href*="openrpc"] {
+      grid-column: 3;
+      grid-row: 3;
+      transform: translateY(-64px);
+
+      .fern-selection-item-icon {
+        width: 1.5rem;
+        height: 1.5rem;
+      }
+    }
+
+    > a[href*="grpc"] {
+      grid-column: 3;
+      grid-row: 4;
+      transform: translateY(-96px);
+
+      .fern-selection-item-icon {
+        width: 1.5rem;
+        height: 1.5rem;
+      }
+    }
+
+    > a[href*="ferndef"] {
+      grid-column: 3;
+      grid-row: 5;
+      transform: translateY(-108px);
+
+      .fern-selection-item-icon {
+        width: 1.5rem;
+        height: 1.5rem;
+      }
+    }
 
     > a[href="/learn/api-definitions"] {
       display: none;

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -217,7 +217,7 @@ h1, h2, h3 {
     > a[href*="ferndef"] {
       grid-column: 3;
       grid-row: 5;
-      transform: translateY(-96px);
+      transform: translateY(-128px);
       
       .fern-selection-item-icon {
         width: 1.5rem;

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -126,7 +126,7 @@ h1, h2, h3 {
     grid-template-columns: repeat(3, 1fr);
     gap: 1.5rem;
     padding: 1.25rem;
-    height: 248px;
+    height: 280px;
     
     > a {
       max-width: 320px;
@@ -153,7 +153,7 @@ h1, h2, h3 {
       grid-row: 2;
     }
 
-    > a[href*="ask-fern"] {
+    > a[href*="dashboard"] {
       grid-column: 2;
       grid-row: 2;
     }
@@ -184,7 +184,7 @@ h1, h2, h3 {
     > a[href*="asyncapi"] {
       grid-column: 3;
       grid-row: 2;
-      transform: translateY(-32px);
+      transform: translateY(-24px);
 
       .fern-selection-item-icon {
         width: 1.5rem;
@@ -195,7 +195,7 @@ h1, h2, h3 {
     > a[href*="openrpc"] {
       grid-column: 3;
       grid-row: 3;
-      transform: translateY(-64px);
+      transform: translateY(-48px);
 
       .fern-selection-item-icon {
         width: 1.5rem;
@@ -206,7 +206,7 @@ h1, h2, h3 {
     > a[href*="grpc"] {
       grid-column: 3;
       grid-row: 4;
-      transform: translateY(-96px);
+      transform: translateY(-72px);
 
       .fern-selection-item-icon {
         width: 1.5rem;
@@ -255,10 +255,6 @@ h1, h2, h3 {
 
 :is(.dark) .fern-product-selector-radio-group a[href*="docs"] img {
   content: url("https://fern-docs.s3.us-east-2.amazonaws.com/product-switcher/product-switcher-docs-dark.png") !important;
-}
-
-:is(.dark) .fern-product-selector-radio-group a[href*="ask-fern"] img {
-  content: url("https://fern-docs.s3.us-east-2.amazonaws.com/product-switcher/product-switcher-askfern-dark.png") !important;
 }
 
 :is(.dark) .fern-product-selector-radio-group a[href*="cli-api-reference"] img {

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -95,7 +95,6 @@ h1, h2, h3 {
 @media (min-width: 1024px) {
   div[data-testid="product-dropdown-content"] {
     border-radius: 1.5rem !important;
-    min-width: 820px !important;
   }
 
   .product-dropdown-trigger {
@@ -130,7 +129,7 @@ h1, h2, h3 {
     height: 248px;
     
     > a {
-      max-width: 320px;
+      max-width: 340px;
       margin: -0.75rem;
       position: relative;
 

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -171,59 +171,29 @@ h1, h2, h3 {
       left: 0.5rem;
     }
 
-    > a[href*="openapi"] {
-      grid-column: 3;
-      grid-row: 1;
-
-      .fern-selection-item-icon {
-        width: 1.5rem;
-        height: 1.5rem;
-      }
-    }
-
-    > a[href*="asyncapi"] {
-      grid-column: 3;
-      grid-row: 2;
-      transform: translateY(-32px);
-
-      .fern-selection-item-icon {
-        width: 1.5rem;
-        height: 1.5rem;
-      }
-    }
-
-    > a[href*="openrpc"] {
-      grid-column: 3;
-      grid-row: 3;
-      transform: translateY(-64px);
-
-      .fern-selection-item-icon {
-        width: 1.5rem;
-        height: 1.5rem;
-      }
-    }
-
-    > a[href*="grpc"] {
-      grid-column: 3;
-      grid-row: 4;
-      transform: translateY(-96px);
-
-      .fern-selection-item-icon {
-        width: 1.5rem;
-        height: 1.5rem;
-      }
-    }
-
+    > a[href*="openapi"],
+    > a[href*="asyncapi"],
+    > a[href*="openrpc"],
+    > a[href*="grpc"],
     > a[href*="ferndef"] {
       grid-column: 3;
-      grid-row: 5;
-      transform: translateY(-128px);
-      
+      grid-row: 1;
+      position: absolute;
+      left: 66.66%;
+      right: 0;
+      margin: 0 -0.75rem;
+
       .fern-selection-item-icon {
         width: 1.5rem;
         height: 1.5rem;
       }
     }
+
+    > a[href*="openapi"] { top: 1.25rem; }
+    > a[href*="asyncapi"] { top: calc(1.25rem + (248px - 2.5rem) / 5 * 1); }
+    > a[href*="openrpc"] { top: calc(1.25rem + (248px - 2.5rem) / 5 * 2); }
+    > a[href*="grpc"] { top: calc(1.25rem + (248px - 2.5rem) / 5 * 3); }
+    > a[href*="ferndef"] { top: calc(1.25rem + (248px - 2.5rem) / 5 * 4); }
 
     > a[href="/learn/api-definitions"] {
       display: none;

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -217,7 +217,7 @@ h1, h2, h3 {
     > a[href*="ferndef"] {
       grid-column: 3;
       grid-row: 5;
-      transform: translateY(-108px);
+      transform: translateY(-100px);
 
       .fern-selection-item-icon {
         width: 1.5rem;

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -95,6 +95,7 @@ h1, h2, h3 {
 @media (min-width: 1024px) {
   div[data-testid="product-dropdown-content"] {
     border-radius: 1.5rem !important;
+    min-width: 820px !important;
   }
 
   .product-dropdown-trigger {
@@ -126,7 +127,7 @@ h1, h2, h3 {
     grid-template-columns: repeat(3, 1fr);
     gap: 1.5rem;
     padding: 1.25rem;
-    height: 280px;
+    height: 248px;
     
     > a {
       max-width: 320px;
@@ -184,7 +185,7 @@ h1, h2, h3 {
     > a[href*="asyncapi"] {
       grid-column: 3;
       grid-row: 2;
-      transform: translateY(-24px);
+      transform: translateY(-32px);
 
       .fern-selection-item-icon {
         width: 1.5rem;
@@ -195,7 +196,7 @@ h1, h2, h3 {
     > a[href*="openrpc"] {
       grid-column: 3;
       grid-row: 3;
-      transform: translateY(-48px);
+      transform: translateY(-64px);
 
       .fern-selection-item-icon {
         width: 1.5rem;
@@ -206,7 +207,7 @@ h1, h2, h3 {
     > a[href*="grpc"] {
       grid-column: 3;
       grid-row: 4;
-      transform: translateY(-72px);
+      transform: translateY(-96px);
 
       .fern-selection-item-icon {
         width: 1.5rem;

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -137,9 +137,6 @@ h1, h2, h3 {
         border-radius: 1rem;
       }
 
-      .fern-selection-item-subtitle {
-        display: none;
-      }
     }
 
     > a[href*="home"] {
@@ -173,6 +170,16 @@ h1, h2, h3 {
       position: absolute;
       top: -2rem;
       left: 0.5rem;
+    }
+
+    > a[href*="openapi"],
+    > a[href*="asyncapi"],
+    > a[href*="openrpc"],
+    > a[href*="grpc"],
+    > a[href*="ferndef"] {
+      .fern-selection-item-subtitle {
+        display: none;
+      }
     }
 
     > a[href*="openapi"] {

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -129,12 +129,16 @@ h1, h2, h3 {
     height: 248px;
     
     > a {
-      max-width: 340px;
+      max-width: 320px;
       margin: -0.75rem;
       position: relative;
 
       .fern-selection-item{
         border-radius: 1rem;
+      }
+
+      .fern-selection-item-subtitle {
+        display: none;
       }
     }
 
@@ -217,7 +221,7 @@ h1, h2, h3 {
     > a[href*="ferndef"] {
       grid-column: 3;
       grid-row: 5;
-      transform: translateY(-100px);
+      transform: translateY(-96px);
 
       .fern-selection-item-icon {
         width: 1.5rem;


### PR DESCRIPTION
## Summary

The product switcher dropdown layout broke after subtitles were added to the API spec items in #4652. The new subtitle text caused text wrapping and uneven spacing in the right-column spec items (OpenAPI, AsyncAPI, etc.).

Rather than adjusting widths and offsets to accommodate the subtitles, we hide them in the product switcher since they were added primarily for `llms.txt` rather than the visual dropdown UI. Subtitles on the main product items (Home, SDKs, Docs, Dashboard, CLI Reference) are left visible.

This PR makes three changes:

1. **Hide spec subtitles**: Added `display: none` on `.fern-selection-item-subtitle` scoped to the 5 spec items (OpenAPI, AsyncAPI, OpenRPC, gRPC, Fern Definition), restoring the original compact layout for the right column.
2. **Stale grid selector**: Updated `a[href*="ask-fern"]` → `a[href*="dashboard"]` so Dashboard is correctly placed at column 2, row 2.
3. **Stale dark-mode rule**: Removed the orphaned dark-mode image rule for `ask-fern` (Dashboard already has its own rule).

## Review & Testing Checklist for Human

- [ ] **Verify subtitles are hidden only for spec items** — the `display: none` rule targets items matching `openapi`, `asyncapi`, `openrpc`, `grpc`, and `ferndef` by href. Confirm that main product items (Home, SDKs, Docs, Dashboard, CLI Reference) still show their subtitles.
- [ ] **Check spec item spacing** — the original `translateY` offsets (-32px, -64px, -96px, -96px) were designed for items without subtitles. With subtitles hidden, spacing should look correct again, but verify visually that the 5 spec items have consistent vertical gaps.
- [ ] **Verify Dashboard positioning** — confirm Dashboard appears in column 2, row 2 (next to Docs) and not auto-placed elsewhere.
- [ ] **Check dark mode** — confirm the dropdown looks correct in dark mode after the stale ask-fern image rule removal.

Recommended test: open the product switcher on desktop in both light and dark mode. Confirm spec items show no subtitles while main products do, all items are correctly positioned, and clicking each item navigates correctly.

### Notes

- Changes are scoped to `@media (min-width: 1024px)` so mobile layout is unaffected.
- The subtitles added in #4652 are still present in the `docs.yml` config and will continue to appear in `llms.txt` and any other context that reads them — they are only hidden visually in the product switcher dropdown.
- The subtitle hiding uses `a[href*="..."]` selectors, so if spec product URLs change, the rules will need updating.

Link to Devin session: https://app.devin.ai/sessions/326d9358f7e541a79356825a0b2c9e41
Requested by: @Ryan-Amirthan