### PR TITLE
docs: add AsyncAPI spec download documentation

### DIFF
--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -415,6 +415,9 @@ navigation:
       - page: Download OpenAPI spec
         path: ./pages/ai/openapi-spec.mdx
         slug: openapi-spec
+      - page: Download AsyncAPI spec
+        path: ./pages/ai/asyncapi-spec.mdx
+        slug: asyncapi-spec
   - section: Resources
     collapsed: true
     hidden: true

--- a/fern/products/docs/pages/ai/asyncapi-spec.mdx
+++ b/fern/products/docs/pages/ai/asyncapi-spec.mdx
@@ -1,0 +1,40 @@
+---
+title: Download AsyncAPI spec
+description: Fern serves your AsyncAPI 2.6.0 spec from your docs site so AI tools and LLMs can discover and interact with your WebSocket API programmatically.
+---
+
+
+Fern docs sites automatically serve your raw AsyncAPI 2.6.0 specification for WebSocket channels, so anyone — or any tool — can download it for client generation, contract testing, or importing into tools that support AsyncAPI.
+
+The spec is also linked from your site's [`llms.txt`](/learn/docs/ai-features/llms-txt), so AI coding assistants like Cursor, Copilot, and Claude can discover and use it to generate accurate WebSocket integrations.
+
+## Available endpoints
+
+Every Fern docs site with WebSocket channels exposes the AsyncAPI specification at these paths:
+
+| Endpoint | Format | Content-Type |
+|----------|--------|--------------|
+| `/asyncapi.json` | JSON | `application/json` |
+| `/asyncapi.yaml` | YAML | `application/x-yaml` |
+| `/asyncapi.yml` | YAML | `application/x-yaml` |
+
+The spec includes all WebSocket channels with publish/subscribe messages, path parameters, query parameters, headers as WebSocket bindings, authentication schemes, type definitions as component schemas, and server URLs from your environment configuration. It's generated from the same API definition that powers your docs, so it's always up to date.
+
+## Usage
+
+Append the endpoint to your docs URL to download the spec:
+
+```bash
+# Download as JSON
+curl https://your-docs-site.com/asyncapi.json
+
+# Download as YAML
+curl https://your-docs-site.com/asyncapi.yaml
+```
+
+If your docs site includes multiple API definitions with WebSocket channels, the endpoint returns a listing of available APIs. Use the `api` query parameter to select a specific one:
+
+```bash
+# Get a specific API's spec
+curl https://your-docs-site.com/asyncapi.json?api=my-api-id
+```

--- a/fern/products/docs/pages/ai/llms-txt.mdx
+++ b/fern/products/docs/pages/ai/llms-txt.mdx
@@ -20,7 +20,7 @@ Fern also serves [clean Markdown instead of HTML](https://developer.mozilla.org/
 
 Fern generates two files for LLMs:
 
-- **`llms.txt`** contains a lightweight summary of your documentation site with each page distilled into a one-sentence description and URL. For sites with API endpoints, it also links to your [OpenAPI specification](/learn/docs/developer-tools/openapi-spec) as a standalone, machine-readable file so AI tools can parse your full API schema directly.
+- **`llms.txt`** contains a lightweight summary of your documentation site with each page distilled into a one-sentence description and URL. For sites with API endpoints, it also links to your [OpenAPI specification](/learn/docs/developer-tools/openapi-spec) as a standalone, machine-readable file so AI tools can parse your full API schema directly. For sites with WebSocket channels, it also links to your [AsyncAPI specification](/learn/docs/developer-tools/asyncapi-spec).
 
 - **`llms-full.txt`** contains complete documentation content including the full text of all pages. For API documentation, this includes your complete API Reference with resolved OpenAPI specifications and SDK code examples for enabled languages.
 

--- a/fern/products/docs/pages/changelog/2026-04-11.mdx
+++ b/fern/products/docs/pages/changelog/2026-04-11.mdx
@@ -1,0 +1,9 @@
+---
+tags: ["api-reference", "ai"]
+---
+
+## AsyncAPI spec endpoints
+
+Your Fern docs site now serves your raw AsyncAPI 2.6.0 specification at `/asyncapi.json` and `/asyncapi.yaml` for sites with WebSocket channels. Download it for client generation, contract testing, or importing into AsyncAPI-compatible tools. The spec is also linked from your site's `llms.txt`, so AI coding assistants can discover and use it automatically.
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/developer-tools/asyncapi-spec">Read the docs</Button>

--- a/fern/products/docs/pages/changelog/2026-04-11.mdx
+++ b/fern/products/docs/pages/changelog/2026-04-11.mdx
@@ -4,6 +4,6 @@ tags: ["api-reference", "ai"]
 
 ## AsyncAPI spec endpoints
 
-Your Fern docs site now serves your raw AsyncAPI 2.6.0 specification at `/asyncapi.json` and `/asyncapi.yaml` for sites with WebSocket channels. Download it for client generation, contract testing, or importing into AsyncAPI-compatible tools. The spec is also linked from your site's `llms.txt`, so AI coding assistants can discover and use it automatically.
+Fern docs sites serve your raw AsyncAPI 2.6.0 specification at `/asyncapi.json` and `/asyncapi.yaml` for sites with WebSocket channels. Download it for client generation, contract testing, or importing into AsyncAPI-compatible tools. The spec is also linked from your site's `llms.txt`, so AI coding assistants can discover and use it automatically.
 
 <Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/developer-tools/asyncapi-spec">Read the docs</Button>


### PR DESCRIPTION
## Summary

Documents the new AsyncAPI spec download feature (`/asyncapi.json`, `/asyncapi.yaml`, `/asyncapi.yml`) for Fern docs sites with WebSocket channels. This is the docs counterpart to the platform implementation in fern-api/fern-platform#9674.

**Changes:**
- New page `asyncapi-spec.mdx` under Developer tools, mirroring the existing [Download OpenAPI spec](/learn/docs/developer-tools/openapi-spec) page structure
- Updated `llms-txt.mdx` to mention AsyncAPI spec links alongside OpenAPI
- Added changelog entry for 2026-04-11
- Added navigation entry in `docs.yml`

## Review & Testing Checklist for Human

- [ ] **Verify fern-api/fern-platform#9674 is merged** before or alongside this PR — the documented endpoints (`/asyncapi.json`, `/asyncapi.yaml`) won't work until the platform change is live
- [ ] **Check that links resolve correctly** after deploy: `/learn/docs/developer-tools/asyncapi-spec` and the cross-link from the llms-txt page
- [ ] **Review content accuracy**: the page states AsyncAPI 2.6.0, describes publish/subscribe messages, WebSocket bindings, and `?api=` query parameter — confirm these match the actual platform implementation

**Suggested test plan:** After both PRs are deployed, visit a docs site with WebSocket channels (e.g. Deepgram) and verify that `/asyncapi.json` returns a valid spec, and that the new docs page renders correctly at the preview URL.

### Notes

- Page content and structure closely mirrors `openapi-spec.mdx` for consistency
- The changelog entry follows the same format as the OpenAPI spec changelog from 2026-02-26

Link to Devin session: https://app.devin.ai/sessions/ebc433e3d0764aa9adb93cd6916441b4
Requested by: @thesandlord