### PR TITLE
fix: replace PR_BOT_GH_PAT with FERN_GITHUB_TOKEN in update-versions workflow

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Approving PR
         if: steps.cpr.outputs.pull-request-operation == 'created'
         env:
-          GH_TOKEN: ${{ secrets.PR_BOT_GH_PAT }}
+          GH_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
         run: |
           echo "Approving PR"
           gh pr review ${{ steps.cpr.outputs.pull-request-number }} --approve


### PR DESCRIPTION
## Summary

Replaces `PR_BOT_GH_PAT` with `FERN_GITHUB_TOKEN` in the "Approving PR" step of the `update-versions.yml` workflow. This aligns the docs repo with the standardized token used across other fern-api repos (venus, fern, fern-platform).

The `PR_BOT_GH_PAT` token was found to lack the required scopes (e.g. `security_events`) in other repos, causing CI failures. `FERN_GITHUB_TOKEN` is the canonical PAT with the correct permissions.

## Review & Testing Checklist for Human

- [ ] Verify that the `FERN_GITHUB_TOKEN` secret is configured in the `fern-api/docs` repo (Settings → Secrets and variables → Actions). If it's missing, the auto-approve step will fail.
- [ ] After merging, monitor the next automated "Update versions from docker hub" PR to confirm the approval step succeeds.

### Notes
- Also fixes a missing trailing newline at end of file.
- Related PRs: similar changes in `fern-api/venus`, `fern-api/fern`, and `fern-api/fern-platform`.

Link to Devin session: https://app.devin.ai/sessions/facba5dbb3fb4869a94c949db5085817
Requested by: @davidkonigsberg