### PR TITLE
Note Node.js 20+ requirement for `fern docs dev`

### DIFF
--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -21,7 +21,7 @@ node -v  # Must be v18.0.0 or higher
 If your version is below the minimum, [download the latest Node.js LTS](https://nodejs.org/) which includes a compatible npm version.
 
 <Warning title="`fern docs dev` requires Node.js 20+">
-  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by `fern docs dev` runs Next.js 16 and requires **Node.js 20.9 or higher**. If you plan to preview docs locally, use an actively maintained [Node.js long-term support (LTS) release](https://nodejs.org/en/about/previous-releases).
+  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by [`fern docs dev`](/learn/cli-api-reference/cli-reference/commands#fern-docs-dev) runs Next.js 16 and requires **Node.js 20.9 or higher**. If you plan to preview docs locally, use an actively maintained [Node.js long-term support (LTS) release](https://nodejs.org/en/about/previous-releases).
 </Warning>
 
 </Step>

--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -21,7 +21,7 @@ node -v  # Must be v18.0.0 or higher
 If your version is below the minimum, [download the latest Node.js LTS](https://nodejs.org/) which includes a compatible npm version.
 
 <Note title="`fern docs dev` requires Node.js 20+">
-  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by `fern docs dev` runs Next.js 16 and requires **Node.js 20.9 or higher**. We recommend using a [current Node.js LTS release](https://nodejs.org/en/about/previous-releases) if you plan to preview docs locally.
+  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by `fern docs dev` runs Next.js 16 and requires **Node.js 20.9 or higher**. If you plan to preview docs locally, use an actively maintained [Node.js long-term support (LTS) release](https://nodejs.org/en/about/previous-releases).
 </Note>
 
 </Step>

--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -20,6 +20,10 @@ node -v  # Must be v18.0.0 or higher
 
 If your version is below the minimum, [download the latest Node.js LTS](https://nodejs.org/) which includes a compatible npm version.
 
+<Note title="`fern docs dev` requires Node.js 20+">
+  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by `fern docs dev` runs Next.js 16 and requires **Node.js 20.9 or higher**. We recommend using a [current Node.js LTS release](https://nodejs.org/en/about/previous-releases) if you plan to preview docs locally.
+</Note>
+
 </Step>
 
 <Step title="Install the Fern CLI">

--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -20,9 +20,9 @@ node -v  # Must be v18.0.0 or higher
 
 If your version is below the minimum, [download the latest Node.js LTS](https://nodejs.org/) which includes a compatible npm version.
 
-<Note title="`fern docs dev` requires Node.js 20+">
+<Warning title="`fern docs dev` requires Node.js 20+">
   While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by `fern docs dev` runs Next.js 16 and requires **Node.js 20.9 or higher**. If you plan to preview docs locally, use an actively maintained [Node.js long-term support (LTS) release](https://nodejs.org/en/about/previous-releases).
-</Note>
+</Warning>
 
 </Step>
 

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -456,12 +456,10 @@ hideOnThisPage: true
     ```
     </CodeBlock>
 
-    <Warning>
-    `fern docs dev` runs Next.js 16 locally and requires **Node.js 20.9 or higher**, even though the rest of the Fern CLI supports Node.js 18+. See the [CLI prerequisites](/learn/cli-api-reference/cli-reference/overview#check-prerequisites) for details.
-    </Warning>
+    <Warning title="`fern docs dev` requirements">
+    `fern docs dev` runs Next.js 16 locally and requires **Node.js 20.9 or higher**, even though [the rest of the Fern CLI supports Node.js 18+](/learn/cli-api-reference/cli-reference/overview#check-prerequisites).
 
-    <Warning>
-    On Windows, `fern docs dev` requires [long path support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later) to be enabled.
+    On Windows, `fern docs dev` also requires [long path support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later) to be enabled.
 
     To enable long path support, run the following command in an elevated PowerShell prompt, then restart your terminal:
 

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -457,6 +457,10 @@ hideOnThisPage: true
     </CodeBlock>
 
     <Warning>
+    `fern docs dev` runs Next.js 16 locally and requires **Node.js 20.9 or higher**, even though the rest of the Fern CLI supports Node.js 18+. See the [CLI prerequisites](/learn/cli-api-reference/cli-reference/overview#check-prerequisites) for details.
+    </Warning>
+
+    <Warning>
     On Windows, `fern docs dev` requires [long path support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later) to be enabled.
 
     To enable long path support, run the following command in an elevated PowerShell prompt, then restart your terminal:


### PR DESCRIPTION
## Summary

Adds a callout on the [CLI Overview → Check prerequisites](https://buildwithfern.com/learn/cli-api-reference/cli-reference/overview#check-prerequisites) step explaining that while the Fern CLI as a whole still requires Node.js 18+, running `fern docs dev` needs Node.js 20.9+ because the local docs preview server runs Next.js 16 ([Next.js 16 system requirements](https://nextjs.org/docs/app/getting-started/installation#system-requirements)).

The prior text only mentioned Node 18+, which is misleading for anyone trying to preview docs locally on Node 18.

## Review & Testing Checklist for Human

- [ ] Confirm the wording of the `<Note>` matches how we want to communicate the `fern docs dev` vs. rest-of-CLI split (Node 20.9 vs. Node 18+)
- [ ] Verify the callout renders correctly on the CLI Overview preview

### Notes

- Node version sources:
  - Fern CLI source explicitly says `The Fern CLI requires Node 18+ or above.` and the published `fern-api` package is built with a `node18` tsup target.
  - The fern-platform docs bundle downloaded and run by `fern docs dev` depends on Next.js 16, which requires Node 20.9+.
- The recommendation to use a current [Node.js LTS release](https://nodejs.org/en/about/previous-releases) matches the link the user asked us to point to.

Link to Devin session: https://app.devin.ai/sessions/1f5f5152296445e99301dc29bbd6d747
Requested by: @Ryan-Amirthan