### PR TITLE
Require Node.js 22+ for the Fern CLI

### DIFF
--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -12,17 +12,13 @@ The Fern CLI lets you initialize projects, validate API definitions, preview cha
 <Steps>
 <Step title="Check prerequisites">
 
-The Fern CLI requires [Node.js](https://nodejs.org/) version 18 or higher and npm version 8.6.0 or higher (ships with Node.js 18).
+The Fern CLI requires [Node.js](https://nodejs.org/) version 22 or higher and npm version 10.0.0 or higher (ships with Node.js 22).
 
 ```bash
-node -v  # Must be v18.0.0 or higher
+node -v  # Must be v22.0.0 or higher
 ```
 
 If your version is below the minimum, [download the latest Node.js LTS](https://nodejs.org/) which includes a compatible npm version.
-
-<Warning title="`fern docs dev` requires Node.js 22+">
-  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by [`fern docs dev`](/learn/cli-api-reference/cli-reference/commands#fern-docs-dev) runs Next.js 16 and requires **Node.js 22 or higher** (the active [long-term support (LTS) release](https://nodejs.org/en/about/previous-releases)).
-</Warning>
 
 </Step>
 

--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -20,8 +20,8 @@ node -v  # Must be v18.0.0 or higher
 
 If your version is below the minimum, [download the latest Node.js LTS](https://nodejs.org/) which includes a compatible npm version.
 
-<Warning title="`fern docs dev` requires Node.js 20+">
-  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by [`fern docs dev`](/learn/cli-api-reference/cli-reference/commands#fern-docs-dev) runs Next.js 16 and requires **Node.js 20.9 or higher**. If you plan to preview docs locally, use an actively maintained [Node.js long-term support (LTS) release](https://nodejs.org/en/about/previous-releases).
+<Warning title="`fern docs dev` needs a current Node.js LTS">
+  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by [`fern docs dev`](/learn/cli-api-reference/cli-reference/commands#fern-docs-dev) runs Next.js 16. If you plan to preview docs locally, use a currently supported [Node.js long-term support (LTS) release](https://nodejs.org/en/about/previous-releases) (Node.js 22 or higher as of this writing).
 </Warning>
 
 </Step>

--- a/fern/products/cli-api-reference/pages/cli-get-started.mdx
+++ b/fern/products/cli-api-reference/pages/cli-get-started.mdx
@@ -20,8 +20,8 @@ node -v  # Must be v18.0.0 or higher
 
 If your version is below the minimum, [download the latest Node.js LTS](https://nodejs.org/) which includes a compatible npm version.
 
-<Warning title="`fern docs dev` needs a current Node.js LTS">
-  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by [`fern docs dev`](/learn/cli-api-reference/cli-reference/commands#fern-docs-dev) runs Next.js 16. If you plan to preview docs locally, use a currently supported [Node.js long-term support (LTS) release](https://nodejs.org/en/about/previous-releases) (Node.js 22 or higher as of this writing).
+<Warning title="`fern docs dev` requires Node.js 22+">
+  While the rest of the Fern CLI runs on Node.js 18+, the local docs preview server started by [`fern docs dev`](/learn/cli-api-reference/cli-reference/commands#fern-docs-dev) runs Next.js 16 and requires **Node.js 22 or higher** (the active [long-term support (LTS) release](https://nodejs.org/en/about/previous-releases)).
 </Warning>
 
 </Step>

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -457,7 +457,7 @@ hideOnThisPage: true
     </CodeBlock>
 
     <Warning title="`fern docs dev` requirements">
-    `fern docs dev` runs Next.js 16 locally and requires a currently supported [Node.js long-term support (LTS) release](https://nodejs.org/en/about/previous-releases) (Node.js 22 or higher as of this writing), even though [the rest of the Fern CLI supports Node.js 18+](/learn/cli-api-reference/cli-reference/overview#check-prerequisites).
+    `fern docs dev` runs Next.js 16 locally and requires **Node.js 22 or higher** (the active [long-term support (LTS) release](https://nodejs.org/en/about/previous-releases)), even though [the rest of the Fern CLI supports Node.js 18+](/learn/cli-api-reference/cli-reference/overview#check-prerequisites).
 
     On Windows, `fern docs dev` also requires [long path support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later) to be enabled.
 

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -457,7 +457,7 @@ hideOnThisPage: true
     </CodeBlock>
 
     <Warning title="`fern docs dev` requirements">
-    `fern docs dev` runs Next.js 16 locally and requires **Node.js 20.9 or higher**, even though [the rest of the Fern CLI supports Node.js 18+](/learn/cli-api-reference/cli-reference/overview#check-prerequisites).
+    `fern docs dev` runs Next.js 16 locally and requires a currently supported [Node.js long-term support (LTS) release](https://nodejs.org/en/about/previous-releases) (Node.js 22 or higher as of this writing), even though [the rest of the Fern CLI supports Node.js 18+](/learn/cli-api-reference/cli-reference/overview#check-prerequisites).
 
     On Windows, `fern docs dev` also requires [long path support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later) to be enabled.
 

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -456,10 +456,8 @@ hideOnThisPage: true
     ```
     </CodeBlock>
 
-    <Warning title="`fern docs dev` requirements">
-    `fern docs dev` runs Next.js 16 locally and requires **Node.js 22 or higher** (the active [long-term support (LTS) release](https://nodejs.org/en/about/previous-releases)), even though [the rest of the Fern CLI supports Node.js 18+](/learn/cli-api-reference/cli-reference/overview#check-prerequisites).
-
-    On Windows, `fern docs dev` also requires [long path support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later) to be enabled.
+    <Warning title="Windows: enable long path support">
+    On Windows, `fern docs dev` requires [long path support](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later) to be enabled.
 
     To enable long path support, run the following command in an elevated PowerShell prompt, then restart your terminal:
 


### PR DESCRIPTION
## Summary

Follow-up to #5024. Bumps the documented Node.js requirement for the entire Fern CLI to Node.js 22+ instead of differentiating between `fern docs dev` and the rest of the CLI.

Changes:
- `cli-get-started.mdx` "Check prerequisites": Node.js 18 → 22, npm 8.6.0 → 10.0.0, `node -v` check updated to `v22.0.0`. Removed the separate `fern docs dev` Node version warning.
- `commands.mdx` `fern docs dev` section: Removed the Node version line from the Warning; retitled it "Windows: enable long path support" since that's the only remaining requirement it covers.

Motivation: Node.js 20 reaches end-of-life on 2026-04-30 and Fern is dropping official support for Node 20 shortly after. Stating a single Node.js 22+ requirement across the CLI is simpler for users than differentiating between commands.

## Review & Testing Checklist for Human

- [ ] Confirm you're comfortable documenting Node.js 22+ as the CLI-wide requirement (i.e. the CLI itself, not just `fern docs dev`, now effectively requires Node 22+).
- [ ] Verify the updated prerequisites step and the slimmed-down Windows-only warning render correctly on the preview.

### Notes

- Files touched:
  - `fern/products/cli-api-reference/pages/cli-get-started.mdx`
  - `fern/products/cli-api-reference/pages/commands.mdx`
- npm 10.x ships with Node.js 22 ([release notes](https://nodejs.org/en/blog/release/v22.0.0)).

Link to Devin session: https://app.devin.ai/sessions/1f5f5152296445e99301dc29bbd6d747
Requested by: @Ryan-Amirthan