### PR TITLE
docs: document data-fern-logo attribute on Fern.Logo anchor

### DIFF
--- a/fern/products/docs/pages/changelog/2026-04-21.mdx
+++ b/fern/products/docs/pages/changelog/2026-04-21.mdx
@@ -4,6 +4,6 @@ tags: ["customization", "components"]
 
 ## Target the logo from custom scripts
 
-You can now target `<Fern.Logo />` from custom scripts with `document.querySelector('#fern-header [data-fern-logo]')`.
+`<Fern.Logo />` now renders with a `data-fern-logo` attribute so custom scripts can target the logo with `document.querySelector('#fern-header [data-fern-logo]')`. Use this to rewrite the logo's `href` on certain pages or modify other behavior.
 
 <Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/customization/header-and-footer">Read the docs</Button>

--- a/fern/products/docs/pages/changelog/2026-04-21.mdx
+++ b/fern/products/docs/pages/changelog/2026-04-21.mdx
@@ -1,0 +1,9 @@
+---
+tags: ["customization", "components"]
+---
+
+## `data-fern-logo` hook on the logo anchor
+
+The anchor rendered by `<Fern.Logo />` now carries a `data-fern-logo` attribute, giving custom JavaScript a stable selector for the site logo. Target it with `#fern-header [data-fern-logo]` instead of brittle heuristics like `a:has(img)`.
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/customization/header-and-footer">Read the docs</Button>

--- a/fern/products/docs/pages/changelog/2026-04-21.mdx
+++ b/fern/products/docs/pages/changelog/2026-04-21.mdx
@@ -2,8 +2,8 @@
 tags: ["customization", "components"]
 ---
 
-## `data-fern-logo` hook on the logo anchor
+## Target the logo from custom scripts
 
-The anchor rendered by `<Fern.Logo />` now carries a `data-fern-logo` attribute, giving custom JavaScript a stable selector for the site logo. Target it with `#fern-header [data-fern-logo]` instead of brittle heuristics like `a:has(img)`.
+You can now target `<Fern.Logo />` from custom scripts with `document.querySelector('#fern-header [data-fern-logo]')`.
 
 <Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/customization/header-and-footer">Read the docs</Button>

--- a/fern/products/docs/pages/customization/custom-header-footer.mdx
+++ b/fern/products/docs/pages/customization/custom-header-footer.mdx
@@ -94,7 +94,7 @@ The following components are available on the `Fern` prop:
 
 | Component | Description |
 | --- | --- |
-| `<Fern.Logo />` | Your site [logo](/docs/configuration/site-level-settings#logo-configuration) as configured in `docs.yml`. Links to the homepage. The rendered anchor carries a `data-fern-logo` attribute so custom scripts can target it stably (e.g. `document.querySelector('#fern-header [data-fern-logo]')`) without resorting to brittle selectors like `a:has(img)`. |
+| `<Fern.Logo />` | Your site [logo](/docs/configuration/site-level-settings#logo-configuration) as configured in `docs.yml`. Links to the homepage. You can target this component with `document.querySelector('#fern-header [data-fern-logo]')`. |
 | `<Fern.Search />` | The [search](/docs/customization/search) bar, including the AI search trigger if enabled. |
 | `<Fern.ProductSwitcher />` | Dropdown to switch between [products](/docs/configuration/products). |
 | `<Fern.VersionSwitcher />` | Dropdown to switch between [versions](/docs/configuration/versions). |

--- a/fern/products/docs/pages/customization/custom-header-footer.mdx
+++ b/fern/products/docs/pages/customization/custom-header-footer.mdx
@@ -94,7 +94,7 @@ The following components are available on the `Fern` prop:
 
 | Component | Description |
 | --- | --- |
-| `<Fern.Logo />` | Your site [logo](/docs/configuration/site-level-settings#logo-configuration) as configured in `docs.yml`. Links to the homepage. |
+| `<Fern.Logo />` | Your site [logo](/docs/configuration/site-level-settings#logo-configuration) as configured in `docs.yml`. Links to the homepage. The rendered anchor carries a `data-fern-logo` attribute so custom scripts can target it stably (e.g. `document.querySelector('#fern-header [data-fern-logo]')`) without resorting to brittle selectors like `a:has(img)`. |
 | `<Fern.Search />` | The [search](/docs/customization/search) bar, including the AI search trigger if enabled. |
 | `<Fern.ProductSwitcher />` | Dropdown to switch between [products](/docs/configuration/products). |
 | `<Fern.VersionSwitcher />` | Dropdown to switch between [versions](/docs/configuration/versions). |


### PR DESCRIPTION
## Summary

Documents the new `data-fern-logo` attribute on the anchor rendered by `<Fern.Logo />` (shipped in fern-api/fern-platform#9923). Customers writing custom JavaScript against the docs can now target the logo anchor via `#fern-header [data-fern-logo]` instead of brittle heuristics like `a:has(img)`, which in turn was stomping unrelated anchors that happened to wrap images.

Two small changes:
- `fern/products/docs/pages/customization/custom-header-footer.mdx` — extends the `<Fern.Logo />` row in the built-in-components table with a sentence about the new attribute.
- `fern/products/docs/pages/changelog/2026-04-21.mdx` — new changelog entry announcing the hook and linking back to the header-and-footer page.

## Review & Testing Checklist for Human

- [ ] Read the updated `<Fern.Logo />` table row in context — confirm it reads well alongside the other rows and doesn't overwhelm the table.
- [ ] Confirm the changelog entry phrasing fits the "you can now…" style used in recent entries.
- [ ] Spot-check the rendered Markdown on the preview: the inline code samples (`#fern-header [data-fern-logo]`, `a:has(img)`) render correctly inside a table cell and inside a paragraph.

### Notes
No code paths change; this is purely documentation of an attribute that already exists on `main` of fern-platform. Internal links use the same `/docs/...` style as the rest of the file.


Link to Devin session: https://app.devin.ai/sessions/8a9ddf02630549fbbc0ae25aebb02c23
Requested by: @thesandlord
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
