### PR TITLE
docs: restore #custom-files anchor on llms-txt overview page

### DIFF
--- a/fern/products/docs/pages/ai/llms-txt/overview.mdx
+++ b/fern/products/docs/pages/ai/llms-txt/overview.mdx
@@ -27,6 +27,18 @@ Both files are available at any level of your documentation hierarchy (`/llms.tx
 
 Examples: [Eleven Labs llms.txt](https://elevenlabs.io/docs/llms.txt), [Cash App llms-full.txt](https://developers.cash.app/llms-full.txt).
 
+## Custom files
+
+To serve your own `llms.txt` or `llms-full.txt` instead of the auto-generated versions, point to your files under the [`agents` key in `docs.yml`](/learn/docs/configuration/site-level-settings#agents-configuration):
+
+```yaml docs.yml
+agents:
+  llms-txt: ./path/to/llms.txt
+  llms-full-txt: ./path/to/llms-full.txt
+```
+
+Custom files are served at the root-level `/llms.txt` and `/llms-full.txt` endpoints. Any file you don't specify falls back to the auto-generated version. See [Serve custom files](/learn/docs/ai-features/customize-llm-output#serve-custom-files) for the full reference.
+
 ## Page descriptions
 
 Both files include page descriptions pulled from [frontmatter](/learn/docs/configuration/page-level-settings). Fern uses the `description` field if present, otherwise falls back to `subtitle`.


### PR DESCRIPTION
## Summary

When [#4966](https://github.com/fern-api/docs/pull/4966) broke the single `llms-txt.mdx` page into multiple pages, the "Custom files" section moved to `/learn/docs/ai-features/customize-llm-output#serve-custom-files`. This left `/learn/docs/ai-features/llms-txt#custom-files` (which customers and any external references relied on) without a target.

Restores a short "Custom files" section on the `llms-txt` overview page. The H2 regenerates the `#custom-files` anchor so existing links resolve, and the section points readers to `customize-llm-output` for the full reference to avoid duplicating content.

Triggered by an external report that a bookmarked link to the old anchor was no longer landing on the relevant content.

## Review & Testing Checklist for Human

- [ ] Preview `/learn/docs/ai-features/llms-txt#custom-files` and confirm the page scrolls to the new "Custom files" section.
- [ ] Confirm the link from the new section to `/learn/docs/ai-features/customize-llm-output#serve-custom-files` resolves.

### Notes

Only `fern/products/docs/pages/ai/llms-txt/overview.mdx` changes. No nav/config change; the new H2 reuses the existing overview page.

Link to Devin session: https://app.devin.ai/sessions/62f0a408a7384ad1b2635f91e1a2343c
Requested by: @cdonel707