### PR TITLE
docs: expand GitLab PAT scopes for Fern Editor setup

### DIFF
--- a/fern/products/docs/pages/component-library/writing-content/visual-editor.mdx
+++ b/fern/products/docs/pages/component-library/writing-content/visual-editor.mdx
@@ -53,7 +53,7 @@ Install the [Fern GitHub app](https://github.com/apps/fern-api), then [connect y
 <Tab title="GitLab">
 GitLab requires manual setup:
 
-1. [Create a personal access token](https://gitlab.com/-/user_settings/personal_access_tokens) in GitLab with the following scopes: `api`, `read_repository`, `write_repository`. Set the expiration date far into the future to avoid disrupting your Editor experience — you can revoke the token at any time.
+1. [Create a personal access token](https://gitlab.com/-/user_settings/personal_access_tokens) in GitLab with the following scopes: `read_user`, `api`, `write_repository`, `read_repository`, `read_api`. Set the expiration date far into the future to avoid disrupting your Editor experience — you can revoke the token at any time.
 2. Contact Fern support via Slack or [email](mailto:support@buildwithfern.com) with your access token and GitLab repository URL.
 3. Once Fern configures the connection, [connect your repository](/learn/dashboard/configuration/github-repo) in the [Dashboard](https://dashboard.buildwithfern.com/).
 </Tab>


### PR DESCRIPTION
## Summary

Updates the GitLab personal access token scope list on the Fern Editor getting-started page to include all 5 required scopes: `read_user`, `api`, `write_repository`, `read_repository`, `read_api` (previously only listed `api`, `read_repository`, `write_repository`).

Per user request in [Slack thread](https://buildwithfern.slack.com/archives/C09RZ3ZA04A/p1776969677937169?thread_ts=1776969677.937169&cid=C09RZ3ZA04A).

Affected page: https://buildwithfern.com/learn/docs/writing-content/fern-editor#getting-started

## Review & Testing Checklist for Human

- [ ] Confirm the 5 scopes listed are the correct set GitLab PATs need for Fern Editor (the 2 additions are `read_user` and `read_api`).
- [ ] Verify the preview renders the scope list correctly.

### Notes

Single-line edit to `fern/products/docs/pages/component-library/writing-content/visual-editor.mdx`.


Link to Devin session: https://app.devin.ai/sessions/1839a535396b4d19a54ff2885d8d2068
Requested by: @Ryan-Amirthan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
