### PR TITLE
docs: add alpha, beta, preview, legacy availability values

### DIFF
--- a/fern/products/api-def/ferndef/availability.mdx
+++ b/fern/products/api-def/ferndef/availability.mdx
@@ -9,10 +9,13 @@ You can add `availability` to an endpoint, type, or property within your Fern De
 ## Endpoints, types, and properties
 
 Availability can be:
+- `alpha` which means it is an early experimental release; will show an `Alpha` tag
 - `in-development` which means it is being worked on; will show a `Beta` tag
 - `pre-release` which means it is available; will show a `Beta` tag
-- `deprecated` which means it will be removed in the future; will show a `Deprecated` tag
+- `preview` which means it is feature-complete but subject to change; will show a `Preview` tag
 - `generally-available` which means it is stable and available for use; will show a `GA` tag
+- `deprecated` which means it will be removed in the future; will show a `Deprecated` tag
+- `legacy` which means it has been superseded but is still supported; will show a `Legacy` tag
 
 ### Endpoint 
 

--- a/fern/products/api-def/ferndef/availability.mdx
+++ b/fern/products/api-def/ferndef/availability.mdx
@@ -9,13 +9,16 @@ You can add `availability` to an endpoint, type, or property within your Fern De
 ## Endpoints, types, and properties
 
 Availability can be:
-- `alpha` which means it is an early experimental release; will show an `Alpha` tag
-- `in-development` which means it is being worked on; will show a `Beta` tag
-- `pre-release` which means it is available; will show a `Beta` tag
-- `preview` which means it is feature-complete but subject to change; will show a `Preview` tag
-- `generally-available` which means it is stable and available for use; will show a `GA` tag
-- `deprecated` which means it will be removed in the future; will show a `Deprecated` tag
-- `legacy` which means it has been superseded but is still supported; will show a `Legacy` tag
+
+| Value | Description | Tag |
+| --- | --- | --- |
+| `alpha` | Early experimental release | `Alpha` |
+| `in-development` | Being worked on | `Beta` |
+| `pre-release` | Available | `Beta` |
+| `preview` | Feature-complete but subject to change | `Preview` |
+| `generally-available` | Stable and available for use | `GA` |
+| `deprecated` | Will be removed in the future | `Deprecated` |
+| `legacy` | Superseded but still supported | `Legacy` |
 
 ### Endpoint 
 

--- a/fern/products/api-def/ferndef/availability.mdx
+++ b/fern/products/api-def/ferndef/availability.mdx
@@ -14,6 +14,7 @@ Availability can be:
 | --- | --- | --- |
 | `alpha` | Early experimental release | `Alpha` |
 | `in-development` | Being worked on | `Beta` |
+| `beta` | Available but may change | `Beta` |
 | `pre-release` | Available | `Beta` |
 | `preview` | Feature-complete but subject to change | `Preview` |
 | `generally-available` | Stable and available for use | `GA` |

--- a/fern/products/api-def/openapi/extensions/availability.mdx
+++ b/fern/products/api-def/openapi/extensions/availability.mdx
@@ -13,12 +13,14 @@ You can configure the `availability` of sections in your API Reference documenta
 
 The options are:
 
-- `alpha` — early experimental stage; shows an `Alpha` tag
-- `beta` — stable enough for early adopters; shows a `Beta` tag
-- `preview` — feature-complete but subject to change; shows a `Preview` tag
-- `generally-available` — stable and ready for production; shows a `GA` tag
-- `deprecated` — no longer recommended for new use; shows a `Deprecated` tag
-- `legacy` — superseded but still supported; shows a `Legacy` tag
+| Value | Description | Tag |
+| --- | --- | --- |
+| `alpha` | Early experimental stage | `Alpha` |
+| `beta` | Stable enough for early adopters | `Beta` |
+| `preview` | Feature-complete but subject to change | `Preview` |
+| `generally-available` | Stable and ready for production | `GA` |
+| `deprecated` | No longer recommended for new use | `Deprecated` |
+| `legacy` | Superseded but still supported | `Legacy` |
 
 The example below marks that the `POST /pet` endpoint is `deprecated`.
 

--- a/fern/products/api-def/openapi/extensions/availability.mdx
+++ b/fern/products/api-def/openapi/extensions/availability.mdx
@@ -13,9 +13,12 @@ You can configure the `availability` of sections in your API Reference documenta
 
 The options are:
 
-- `beta`
-- `generally-available`
-- `deprecated`
+- `alpha` — early experimental stage; shows an `Alpha` tag
+- `beta` — stable enough for early adopters; shows a `Beta` tag
+- `preview` — feature-complete but subject to change; shows a `Preview` tag
+- `generally-available` — stable and ready for production; shows a `GA` tag
+- `deprecated` — no longer recommended for new use; shows a `Deprecated` tag
+- `legacy` — superseded but still supported; shows a `Legacy` tag
 
 The example below marks that the `POST /pet` endpoint is `deprecated`.
 

--- a/fern/products/api-def/snippets/availability.mdx
+++ b/fern/products/api-def/snippets/availability.mdx
@@ -1,4 +1,4 @@
-You can set the availability for the entire API reference or for specific sections in your `docs.yml` configuration. Options are: `stable`, `generally-available`, `in-development`, `pre-release`, `deprecated`, or `beta`. 
+You can set the availability for the entire API reference or for specific sections in your `docs.yml` configuration. Options are: `stable`, `generally-available`, `in-development`, `pre-release`, `deprecated`, `alpha`, `beta`, `preview`, or `legacy`. 
 
 When you set the availability of a section, all of the endpoints in that section are automatically marked with that availability unless explicitly set otherwise. 
 


### PR DESCRIPTION
## Summary

Documents `alpha`, `beta`, `preview`, and `legacy` as valid `x-fern-availability` / `availability` values, alongside the existing `in-development`, `pre-release`, `generally-available`, and `deprecated`. Also promotes `beta` from an OpenAPI-only alias for `pre-release` to a first-class value usable in Fern Definitions (matching the change in [fern#15320](https://github.com/fern-api/fern/pull/15320)).

The pages at `/learn/api-definitions/openapi/extensions/availability` and `/learn/api-definitions/fern-definition/availability` now list these values with brief descriptions of each lifecycle stage and the badge they render as.

## Review & Testing Checklist for Human

- [ ] Skim the rendered preview to confirm the table layouts match the rest of the API definitions section.
- [ ] Sanity-check that the badge labels described here (`Alpha`, `Beta`, `Preview`, `Legacy`) match what fern-platform actually renders once [fern-platform#10027](https://github.com/fern-api/fern-platform/pull/10027) and [fern#15320](https://github.com/fern-api/fern/pull/15320) ship.

### Notes

This PR is purely docs — no functional code changes. The runtime support comes from [fern#15320](https://github.com/fern-api/fern/pull/15320) (CLI / IR / parsers) and [fern-platform#10027](https://github.com/fern-api/fern-platform/pull/10027) (FDR schema + UI). Until those merge, customers writing `availability: alpha|preview|legacy` in a Fern Definition or `x-fern-availability: alpha|preview|legacy` in OpenAPI will be rejected by validation.

Link to Devin session: https://app.devin.ai/sessions/dfd46458269a401d82862980e905e9a2
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
