### PR TITLE
Fix SDK config docs: correct field names, defaults, and add missing flags

### DIFF
--- a/fern/products/sdks/generators/csharp/configuration.mdx
+++ b/fern/products/sdks/generators/csharp/configuration.mdx
@@ -64,8 +64,23 @@ When enabled, includes built-in exception handling utilities in the generated SD
 When enabled, path parameters are included as properties in the request object instead of being passed as separate method parameters. This creates a more unified request structure where all parameters are grouped together.
 </ParamField>
 
+<ParamField path="maxRetries" type="number" required={false} toc={true}>
+The default number of retries for failed requests. When not set, the generated SDK uses its own built-in default. SDK users can still override this per-request via request options.
+</ParamField>
+
 <ParamField path="namespace" type="string" required={false} toc={true}>
 Specifies the root namespace for all generated .NET code. This determines the namespace hierarchy that users will import when using the SDK.
+</ParamField>
+
+<ParamField path="offset-semantics" type="'item-index' | 'page-index'" required={false} toc={true}>
+Controls how the offset parameter is interpreted for [auto-paginated](/learn/sdks/deep-dives/auto-pagination) endpoints.
+
+*    `item-index`: The offset counts individual items (e.g., offset 20 skips the first 20 items).
+*    `page-index`: The offset counts pages (e.g., offset 3 skips to page 3).
+</ParamField>
+
+<ParamField path="omit-fern-headers" type="boolean" default="false" required={false} toc={true}>
+When enabled, the generated SDK omits the `X-Fern-Language`, `X-Fern-SDK-Name`, and `X-Fern-SDK-Version` headers from HTTP requests.
 </ParamField>
 
 <ParamField path="package-id" type="string" required={false} toc={true}>

--- a/fern/products/sdks/generators/go/configuration.mdx
+++ b/fern/products/sdks/generators/go/configuration.mdx
@@ -19,7 +19,7 @@ groups:
           path: ../generated/go
 ```
 
-<ParamField path="alwaysSendRequiredProperties" type="boolean" required={false} toc={true}>
+<ParamField path="alwaysSendRequiredProperties" type="boolean" default="true" required={false} toc={true}>
 When enabled, ensures that all required properties are always included in API requests, even if they have default values or are otherwise optional in the implementation.
 </ParamField>
 
@@ -35,7 +35,22 @@ Specifies the name of the generated client struct. This determines the primary c
 Sets the name of the exported client that will be used in code snippets and documentation examples. This is useful for customizing how the client appears in generated documentation.
 </ParamField>
 
-<ParamField path="enableWireTests" type="string" default="true" required={false} toc={true}>
+<ParamField path="maxRetries" type="number" required={false} toc={true}>
+The default number of retries for failed requests. When not set, the generated SDK uses its own built-in default. SDK users can still override this per-request via request options.
+</ParamField>
+
+<ParamField path="offsetSemantics" type="'item-index' | 'page-index'" required={false} toc={true}>
+Controls how the offset parameter is interpreted for [auto-paginated](/learn/sdks/deep-dives/auto-pagination) endpoints.
+
+*    `item-index`: The offset counts individual items (e.g., offset 20 skips the first 20 items).
+*    `page-index`: The offset counts pages (e.g., offset 3 skips to page 3).
+</ParamField>
+
+<ParamField path="omitFernHeaders" type="boolean" default="false" required={false} toc={true}>
+When enabled, the generated SDK omits the `X-Fern-Language`, `X-Fern-SDK-Name`, and `X-Fern-SDK-Version` headers from HTTP requests.
+</ParamField>
+
+<ParamField path="enableWireTests" type="boolean" default="true" required={false} toc={true}>
 Generates [mock server (wire) tests](/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends the correct HTTP requests and correctly handles responses per the API spec. When enabled, Docker is required as a runtime dependency to run the generated tests.
 </ParamField>
 
@@ -69,11 +84,11 @@ with the relevant elements in your `go.mod` path. In this case, the generated Go
 When enabled, includes legacy client options for backward compatibility with older versions of the SDK. This is useful for maintaining compatibility when upgrading SDK versions.
 </ParamField>
 
-<ParamField path="inlineFileProperties" type="boolean" required={false} toc={true}>
+<ParamField path="inlineFileProperties" type="boolean" default="true" required={false} toc={true}>
 Controls whether file upload properties are generated as inline request properties instead of separate parameters. When enabled, file upload fields become part of the request struct rather than being passed as individual function parameters.
 </ParamField>
 
-<ParamField path="inlinePathParameters" type="boolean" required={false} toc={true}>
+<ParamField path="inlinePathParameters" type="boolean" default="true" required={false} toc={true}>
 When enabled, path parameters are inlined into request types rather than being passed as separate function parameters. This creates a more unified request structure where path parameters are included in the request object.
 </ParamField>
 
@@ -135,18 +150,14 @@ replace "github.com/your/sdk" v0.0.0 => "path/to/generated/sdk"
 
 </ParamField>
 
-<ParamField path="packageLayout" type="'flat' | 'nested'" required={false} toc={true}>
-Controls the organization of the generated package structure. Choose 'flat' for a flatter package structure with fewer nested directories, or 'nested' for a more hierarchical organization that mirrors your API structure.
-</ParamField>
-
 <ParamField path="packageName" type="string" required={false} toc={true}>
 Specifies the package name for the generated Go code. This determines the package declaration that will appear at the top of generated Go files and affects how users import the SDK.
 </ParamField>
 
-<ParamField path="union" type="'v0' | 'v1'" required={false} toc={true}>
+<ParamField path="union" type="'v0' | 'v1'" default="v1" required={false} toc={true}>
 Controls the union type generation strategy. Use 'v0' for the legacy union implementation or 'v1' for the newer, more robust union handling approach that provides better type safety and discriminated union support.
 </ParamField>
 
-<ParamField path="useReaderForBytesRequest" type="boolean" required={false} toc={true}>
+<ParamField path="useReaderForBytesRequest" type="boolean" default="true" required={false} toc={true}>
 When enabled, uses `io.Reader` interface for handling byte request bodies instead of byte slices. This is more memory-efficient for large payloads and follows Go best practices for streaming data.
 </ParamField>

--- a/fern/products/sdks/generators/java/configuration.mdx
+++ b/fern/products/sdks/generators/java/configuration.mdx
@@ -86,8 +86,23 @@ Controls whether file upload properties are generated as inline request properti
 When enabled, path parameters are included as properties in the request object instead of being passed as separate method parameters. This creates a more unified request structure where all parameters are grouped together.
 </ParamField>
 
+<ParamField path="maxRetries" type="number" required={false} toc={true}>
+The default number of retries for failed requests. When not set, the generated SDK uses its own built-in default. SDK users can still override this per-request via request options.
+</ParamField>
+
 <ParamField path="json-include" type="'non-empty' | 'non-absent'" default="non-absent" required={false} toc={true}>
 Controls Jackson's JSON serialization behavior for optional fields. Use 'non-empty' to exclude null and empty values, or 'non-absent' to only exclude null values while preserving empty collections and strings.
+</ParamField>
+
+<ParamField path="offset-semantics" type="'item-index' | 'page-index'" required={false} toc={true}>
+Controls how the offset parameter is interpreted for [auto-paginated](/learn/sdks/deep-dives/auto-pagination) endpoints.
+
+*    `item-index`: The offset counts individual items (e.g., offset 20 skips the first 20 items).
+*    `page-index`: The offset counts pages (e.g., offset 3 skips to page 3).
+</ParamField>
+
+<ParamField path="omit-fern-headers" type="boolean" default="false" required={false} toc={true}>
+When enabled, the generated SDK omits the `X-Fern-Language`, `X-Fern-SDK-Name`, and `X-Fern-SDK-Version` headers from HTTP requests.
 </ParamField>
 
 <ParamField path="package-layout" type="'nested' | 'flat'" default="nested" required={false} toc={true}>

--- a/fern/products/sdks/generators/java/configuration.mdx
+++ b/fern/products/sdks/generators/java/configuration.mdx
@@ -86,12 +86,12 @@ Controls whether file upload properties are generated as inline request properti
 When enabled, path parameters are included as properties in the request object instead of being passed as separate method parameters. This creates a more unified request structure where all parameters are grouped together.
 </ParamField>
 
-<ParamField path="maxRetries" type="number" required={false} toc={true}>
-The default number of retries for failed requests. When not set, the generated SDK uses its own built-in default. SDK users can still override this per-request via request options.
-</ParamField>
-
 <ParamField path="json-include" type="'non-empty' | 'non-absent'" default="non-absent" required={false} toc={true}>
 Controls Jackson's JSON serialization behavior for optional fields. Use 'non-empty' to exclude null and empty values, or 'non-absent' to only exclude null values while preserving empty collections and strings.
+</ParamField>
+
+<ParamField path="maxRetries" type="number" required={false} toc={true}>
+The default number of retries for failed requests. When not set, the generated SDK uses its own built-in default. SDK users can still override this per-request via request options.
 </ParamField>
 
 <ParamField path="offset-semantics" type="'item-index' | 'page-index'" required={false} toc={true}>

--- a/fern/products/sdks/generators/php/configuration.mdx
+++ b/fern/products/sdks/generators/php/configuration.mdx
@@ -34,8 +34,23 @@ When enabled, generates [mock server (wire) tests](/sdks/deep-dives/testing#mock
 When enabled, path parameters are included as properties in the request class instead of being passed as separate method parameters. This creates a more unified request structure where all parameters are grouped together in the request object.
 </ParamField>
 
+<ParamField path="maxRetries" type="number" required={false} toc={true}>
+The default number of retries for failed requests. When not set, the generated SDK uses its own built-in default. SDK users can still override this per-request via request options.
+</ParamField>
+
 <ParamField path="namespace" type="string" required={false} toc={true}>
 Specifies the PHP namespace for all generated code. This determines the namespace hierarchy that users will use when importing and using the SDK classes.
+</ParamField>
+
+<ParamField path="offsetSemantics" type="'item-index' | 'page-index'" required={false} toc={true}>
+Controls how the offset parameter is interpreted for [auto-paginated](/learn/sdks/deep-dives/auto-pagination) endpoints.
+
+*    `item-index`: The offset counts individual items (e.g., offset 20 skips the first 20 items).
+*    `page-index`: The offset counts pages (e.g., offset 3 skips to page 3).
+</ParamField>
+
+<ParamField path="omitFernHeaders" type="boolean" default="false" required={false} toc={true}>
+When enabled, the generated SDK omits the `X-Fern-Language`, `X-Fern-SDK-Name`, and `X-Fern-SDK-Version` headers from HTTP requests.
 </ParamField>
 
 <ParamField path="packageName" type="string" required={false} toc={true}>

--- a/fern/products/sdks/generators/python/configuration.mdx
+++ b/fern/products/sdks/generators/python/configuration.mdx
@@ -61,6 +61,10 @@ The name of the generated client class. Must be PascalCase. For example, setting
   The chunk size to use (if any) when processing a response bytes stream within `iter_bytes` or `aiter_bytes` results in: `for chunk in response.iter_bytes(chunk_size=<default_bytes_stream_chunk_size>):`
 </ParamField>
 
+<ParamField path="default_max_retries" type="number" default="2" required={false} toc={true}>
+The default number of retries for failed requests in the generated SDK. Set to `0` to disable retries by default. SDK users can still override this per-request via request options.
+</ParamField>
+
 <ParamField path="enable_wire_tests" type="bool" default="false" required={false} toc={true}>
 When enabled, generates [mock server (wire) tests](/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
 </ParamField>
@@ -145,7 +149,7 @@ When enabled, generates utility methods for working with union types, including 
   Feature flag that removes the usage of request objects, and instead uses parameters in function signatures where possible.
 </ParamField>
 
-<ParamField path="lazy_import" type="bool" default="true" required={false} toc={true}>
+<ParamField path="lazy_imports" type="bool" default="true" required={false} toc={true}>
   Enables lazy loading of client imports. When enabled, modules and classes are imported only when first accessed rather than at package initialization. This reduces memory footprint when using a small portion of a large API, at the cost of a latency penalty when first accessing a client. 
   
   Set to `false` to restore eager loading behavior.
@@ -161,7 +165,18 @@ For example, setting `package_name: "my_custom_package"` enables users to use
 
 </ParamField>
 
-<ParamField path="pyproject_python_version" type="string" default="^3.8" required={false} toc={true}>
+<ParamField path="offset_semantics" type="'item-index' | 'page-index'" default="item-index" required={false} toc={true}>
+Controls how the offset parameter is interpreted for [auto-paginated](/learn/sdks/deep-dives/auto-pagination) endpoints.
+
+*    `item-index`: The offset counts individual items (e.g., offset 20 skips the first 20 items).
+*    `page-index`: The offset counts pages (e.g., offset 3 skips to page 3).
+</ParamField>
+
+<ParamField path="omit_fern_headers" type="bool" default="false" required={false} toc={true}>
+When enabled, the generated SDK omits the `X-Fern-Language`, `X-Fern-SDK-Name`, and `X-Fern-SDK-Version` headers from HTTP requests.
+</ParamField>
+
+<ParamField path="pyproject_python_version" type="string" default="^3.10" required={false} toc={true}>
   <Warning>This changes your declared python dependency, which is not meant to be done often if at all. This is a last resort if any dependencies force you to change your version requirements.</Warning>
 </ParamField>
 

--- a/fern/products/sdks/generators/ruby/configuration.mdx
+++ b/fern/products/sdks/generators/ruby/configuration.mdx
@@ -13,7 +13,7 @@ groups:
       - name: fernapi/fern-ruby-sdk
         version: <Markdown src="/snippets/version-number-ruby.mdx"/>
         config:
-          module: YourModuleName
+          moduleName: YourModuleName
           enableWireTests: true
           extraDependencies:
             faraday: "~> 2.0"
@@ -62,12 +62,16 @@ Specify additional dependencies to include in the generated SDK's gemspec. This 
 Specify additional development dependencies to include in the generated SDK's Gemfile. These are dependencies used for development and testing but not required by end users.
 </ParamField>
 
-<ParamField path="module" type="string" required={false} toc={true}>
+<ParamField path="maxRetries" type="number" required={false} toc={true}>
+The default number of retries for failed requests. When not set, the generated SDK uses its own built-in default. SDK users can still override this per-request via request options.
+</ParamField>
+
+<ParamField path="moduleName" type="string" required={false} toc={true}>
 Custom module name for the generated SDK. This sets the top-level Ruby module that wraps all generated code. By default, the module name is derived from the package name in your publish configuration or your organization name.
 
 ```yaml
 config:
-  module: MyCustomModule
+  moduleName: MyCustomModule
 ```
 
 This generates code like:
@@ -79,6 +83,17 @@ module MyCustomModule
   end
 end
 ```
+</ParamField>
+
+<ParamField path="offsetSemantics" type="'item-index' | 'page-index'" required={false} toc={true}>
+Controls how the offset parameter is interpreted for [auto-paginated](/learn/sdks/deep-dives/auto-pagination) endpoints.
+
+*    `item-index`: The offset counts individual items (e.g., offset 20 skips the first 20 items).
+*    `page-index`: The offset counts pages (e.g., offset 3 skips to page 3).
+</ParamField>
+
+<ParamField path="omitFernHeaders" type="boolean" default="false" required={false} toc={true}>
+When enabled, the generated SDK omits the `X-Fern-Language`, `X-Fern-SDK-Name`, and `X-Fern-SDK-Version` headers from HTTP requests.
 </ParamField>
 
 <ParamField path="requirePaths" type="array of strings" required={false} toc={true}>

--- a/fern/products/sdks/generators/rust/configuration.mdx
+++ b/fern/products/sdks/generators/rust/configuration.mdx
@@ -58,6 +58,10 @@ When enabled, generates [mock server (wire) tests](/learn/sdks/deep-dives/testin
 When enabled, generates code examples in the README and reference documentation.
 </ParamField>
 
+<ParamField path="maxRetries" type="number" required={false} toc={true}>
+The default number of retries for failed requests. When not set, the generated SDK defaults to 3 retries. SDK users can still override this per-request via request options.
+</ParamField>
+
 ### Package metadata
 
 Configure metadata for publishing to crates.io:

--- a/fern/products/sdks/generators/swift/configuration.mdx
+++ b/fern/products/sdks/generators/swift/configuration.mdx
@@ -32,6 +32,10 @@ The name of the generated environment enum. This allows you to customize the enu
 The module name used in client code (e.g., `import MyCustomModule`). When provided, this name is used consistently across the library, product, and target.
 </ParamField>
 
+<ParamField path="maxRetries" type="number" required={false} toc={true}>
+The default number of retries for failed requests. When not set, the generated SDK uses its own built-in default. SDK users can still override this per-request via request options.
+</ParamField>
+
 <ParamField path="enableWireTests" type="boolean" default="true" required={false} toc={true}>
 Generates [mock server (wire) tests](/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends the correct HTTP requests and correctly handles responses per the API spec.
 </ParamField>

--- a/fern/products/sdks/generators/typescript/configuration.mdx
+++ b/fern/products/sdks/generators/typescript/configuration.mdx
@@ -168,7 +168,7 @@ Choose whether you want to support Node.js 16 and above (`Node16`), or Node.js 1
 *    `Node18` uses the native FormData API, and accepts a wider range of types for file uploads, such as `Buffer`, `File`, `Blob`, `Readable`, `ReadableStream`, `ArrayBuffer`, and `Uint8Array`
 </ParamField>
 
-<ParamField path="generateSubpackageExports" type="boolean" default="false" toc={true}>
+<ParamField path="generateSubpackageExports" type="boolean" default="true" toc={true}>
 Generates subpackage exports that allow users to import individual clients directly, rather than importing the entire SDK. This enables JavaScript bundlers to tree-shake unused code, significantly reducing bundle sizes.
 
 ```typescript
@@ -294,6 +294,10 @@ config:
 import { AcmePayments, AcmePaymentsClient } from "@acme/node";
 ```
 
+</ParamField>
+
+<ParamField path="maxRetries" type="number" required={false} toc={true}>
+The default number of retries for failed requests. When not set, the generated SDK uses its own built-in default. SDK users can still override this per-request via request options.
 </ParamField>
 
 <ParamField path="naming" type="string | object" toc={true}>


### PR DESCRIPTION
## Summary

Audit of all 9 SDK generator configuration pages against the source-of-truth config schemas in `fern-api/fern`. Fixes incorrect field names, wrong defaults, wrong types, and adds three previously undocumented cross-generator flags.

### Bug fixes
- **Python**: `lazy_import` → `lazy_imports` (wrong field name — would cause Pydantic validation error)
- **Python**: `pyproject_python_version` default `^3.8` → `^3.10` (wrong default)
- **Ruby**: `module` → `moduleName` (wrong field name for Ruby v2)
- **Go**: `enableWireTests` type `string` → `boolean` (wrong type)
- **TypeScript**: `generateSubpackageExports` default `false` → `true` (wrong default)
- **Go**: Added missing defaults for `alwaysSendRequiredProperties` (true), `inlinePathParameters` (true), `inlineFileProperties` (true), `useReaderForBytesRequest` (true), `union` ("v1")
- **Go**: Removed `packageLayout` (Go v1-only option, does not exist in v2)

### New documentation
- `maxRetries` — added to all 9 languages (TS, Python, Java, Go, C#, PHP, Ruby, Rust, Swift)
- `offsetSemantics` — added to Python, Java, Go, C#, PHP, Ruby (TS already had it)
- `omitFernHeaders` — added to Python, Java, Go, C#, PHP, Ruby (TS already had it)

## Review & Testing Checklist for Human
- [ ] Verify Python `lazy_imports` (plural) matches the actual Pydantic field name in `generators/python/src/fern_python/generators/sdk/custom_config.py`
- [ ] Verify Python `pyproject_python_version` default is indeed `^3.10` in latest generator
- [ ] Verify Ruby `moduleName` is the correct config key for Ruby v2 (`BaseRubyCustomConfigSchema.ts`)
- [ ] Spot-check that `maxRetries`, `offsetSemantics`, and `omitFernHeaders` use the correct casing per language (camelCase for Go/Ruby/PHP/TS, kebab-case for Java/C#, snake_case for Python)
- [ ] Preview the config pages to confirm ParamFields render correctly

### Notes
- Rust and Swift do not have `offsetSemantics` or `omitFernHeaders` in their schemas, so those flags were intentionally not added to those languages.
- For Rust, `maxRetries` defaults to 3 when unset (hardcoded in `ClientConfigGenerator.ts`); this is noted in the docs.
- Python uses `default_max_retries` (snake_case) as the config key, with `maxRetries` accepted as an alias via `parse_obj`.


Link to Devin session: https://app.devin.ai/sessions/e2be987659314cca813d1c2488e156b1
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
