### PR TITLE
docs: update PR preview workflow examples with branded comment design

### DIFF
--- a/fern/products/docs/pages/preview-publish/preview-changes-locally.mdx
+++ b/fern/products/docs/pages/preview-publish/preview-changes-locally.mdx
@@ -194,13 +194,29 @@ jobs:
 
       - name: Create comment content
         run: |
-          echo ":herb: **Preview your docs:** <${{ steps.generate-docs.outputs.preview_url }}>" > comment.md
+          PREVIEW_URL="${{ steps.generate-docs.outputs.preview_url }}"
+          cat > comment.md << EOF
+          <div align="center">
+          <a href="https://buildwithfern.com"><img src="https://raw.githubusercontent.com/fern-api/docs-starter/main/fern/docs/assets/fern-logo-primary.svg" height="30" alt="Fern" /></a>
+          <h3>✅ Preview Ready</h3>
+          <strong><a href="$PREVIEW_URL">Visit Preview →</a></strong>
+          </div>
+
+          ---
+          EOF
 
           if [ -n "${{ steps.page-links.outputs.page_links }}" ]; then
             echo "" >> comment.md
-            echo "Here are the markdown pages you've updated:" >> comment.md
+            echo "<details>" >> comment.md
+            echo "<summary>📄 <strong>Changed pages</strong></summary>" >> comment.md
+            echo "" >> comment.md
             echo "${{ steps.page-links.outputs.page_links }}" >> comment.md
+            echo "" >> comment.md
+            echo "</details>" >> comment.md
+            echo "" >> comment.md
           fi
+
+          echo '<sub>🌿 Deployed with <a href="https://buildwithfern.com">Fern</a></sub>' >> comment.md
 
       - name: Post PR comment
         uses: thollander/actions-comment-pull-request@v2.4.3
@@ -287,13 +303,29 @@ jobs:
 
       - name: Create comment content
         run: |
-          echo ":herb: **Preview your docs:** <${{ steps.generate-docs.outputs.preview_url }}>" > comment.md
+          PREVIEW_URL="${{ steps.generate-docs.outputs.preview_url }}"
+          cat > comment.md << EOF
+          <div align="center">
+          <a href="https://buildwithfern.com"><img src="https://raw.githubusercontent.com/fern-api/docs-starter/main/fern/docs/assets/fern-logo-primary.svg" height="30" alt="Fern" /></a>
+          <h3>✅ Preview Ready</h3>
+          <strong><a href="$PREVIEW_URL">Visit Preview →</a></strong>
+          </div>
+
+          ---
+          EOF
 
           if [ -n "${{ steps.page-links.outputs.page_links }}" ]; then
             echo "" >> comment.md
-            echo "Here are the markdown pages you've updated:" >> comment.md
+            echo "<details>" >> comment.md
+            echo "<summary>📄 <strong>Changed pages</strong></summary>" >> comment.md
+            echo "" >> comment.md
             echo "${{ steps.page-links.outputs.page_links }}" >> comment.md
+            echo "" >> comment.md
+            echo "</details>" >> comment.md
+            echo "" >> comment.md
           fi
+
+          echo '<sub>🌿 Deployed with <a href="https://buildwithfern.com">Fern</a></sub>' >> comment.md
 
       - name: Post PR comment
         uses: thollander/actions-comment-pull-request@v2.4.3


### PR DESCRIPTION
## Summary

Updates both workflow examples on the PR previews documentation page to use the new branded comment design. Both the standard and fork-compatible workflow examples now generate a centered HTML comment with the Fern logo, status heading, prominent preview link, collapsible changed pages section, and Fern branding footer.

## Review & Testing Checklist for Human
- [ ] Verify the YAML code blocks in the rendered docs page are syntactically correct and readable
- [ ] Confirm the documentation accurately reflects the updated `docs-starter` workflow

### Notes
Companion PR to `fern-api/docs-starter#115` which updates the actual workflow file.

Link to Devin session: https://app.devin.ai/sessions/064c68649dc6458d8c73fad00c829285
Requested by: @Ryan-Amirthan