### PR TITLE
Add self-hosted changelog with automated version updates

### DIFF
--- a/.github/workflows/update-self-hosted-changelog.yml
+++ b/.github/workflows/update-self-hosted-changelog.yml
@@ -1,0 +1,66 @@
+name: Update Self-Hosted Changelog
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+jobs:
+  update-self-hosted-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+      - name: Sync self-hosted releases from fern-platform
+        env:
+          GH_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DIR="fern/products/docs/pages/self-hosted/changelog"
+          mkdir -p "$DIR"
+
+          gh api -H "Accept: application/vnd.github+json" \
+            "repos/fern-api/fern-platform/releases?per_page=50" \
+            --jq '.[] | select(.tag_name | startswith("docs@")) | "\(.tag_name)\t\(.published_at)"' \
+            | sort -k2 \
+            > /tmp/releases.tsv
+
+          while IFS=$'\t' read -r tag published; do
+            version="${tag#docs@}"
+            date="${published%%T*}"
+            file="$DIR/$date.mdx"
+            version_escaped="${version//./\\.}"
+
+            if grep -rqE "^### v${version_escaped}$" "$DIR" 2>/dev/null; then
+              continue
+            fi
+
+            if [ -s "$file" ]; then
+              printf '\n### v%s\n\n```dockerfile\nFROM fernenterprise/fern-self-hosted:%s\n```\n' "$version" "$version" >> "$file"
+            else
+              printf '### v%s\n\n```dockerfile\nFROM fernenterprise/fern-self-hosted:%s\n```\n' "$version" "$version" > "$file"
+            fi
+          done < /tmp/releases.tsv
+      - name: create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "update self-hosted changelog from fern-platform releases"
+          title: "Update self-hosted changelog"
+          branch: update-self-hosted-changelog
+          base: main
+          delete-branch: true
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash
+      - name: Approving PR
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
+        run: |
+          echo "Approving PR"
+          gh pr review ${{ steps.cpr.outputs.pull-request-number }} --approve

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -393,6 +393,8 @@ navigation:
         slug: previews
       - page: Health check endpoints
         path: ./pages/self-hosted/health-check-endpoints.mdx
+      - changelog: ./pages/self-hosted/changelog
+        title: Changelog
   - section: Analytics & integrations
     slug: integrations
     collapsed: true

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -394,7 +394,7 @@ navigation:
       - page: Health check endpoints
         path: ./pages/self-hosted/health-check-endpoints.mdx
       - changelog: ./pages/self-hosted/changelog
-        title: Changelog
+        title: Releases
   - section: Analytics & integrations
     slug: integrations
     collapsed: true

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-15.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-15.mdx
@@ -1,0 +1,5 @@
+### v0.114.1
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.1
+```

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-17.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-17.mdx
@@ -1,0 +1,17 @@
+### v0.114.2
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.2
+```
+
+### v0.114.3
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.3
+```
+
+### v0.114.4
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.4
+```

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-20.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-20.mdx
@@ -1,0 +1,11 @@
+### v0.114.5
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.5
+```
+
+### v0.114.6
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.6
+```

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-21.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-21.mdx
@@ -1,0 +1,11 @@
+### v0.114.7
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.7
+```
+
+### v0.114.8
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.8
+```

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-22.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-22.mdx
@@ -1,0 +1,23 @@
+### v0.114.9
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.9
+```
+
+### v0.114.10
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.10
+```
+
+### v0.114.11
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.11
+```
+
+### v0.114.12
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.12
+```

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-23.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-23.mdx
@@ -1,0 +1,5 @@
+### v0.114.13
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.13
+```

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-24.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-24.mdx
@@ -1,0 +1,17 @@
+### v0.114.14
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.14
+```
+
+### v0.114.15
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.15
+```
+
+### v0.114.16
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.16
+```

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-27.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-27.mdx
@@ -1,0 +1,17 @@
+### v0.114.17
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.17
+```
+
+### v0.114.18
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.18
+```
+
+### v0.114.19
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.19
+```

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-28.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-28.mdx
@@ -1,0 +1,11 @@
+### v0.114.20
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.20
+```
+
+### v0.114.21
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.21
+```

--- a/fern/products/docs/pages/self-hosted/changelog/overview.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/overview.mdx
@@ -1,0 +1,8 @@
+Release history for the Fern self-hosted Docker image. Each entry shows the `FROM` line for that release.
+
+To upgrade:
+
+- On `:latest` — rebuild and redeploy your image to pick up the new base.
+- Pinning a version — copy the `FROM` line from the release below into your Dockerfile, then rebuild and redeploy.
+
+See the [self-hosted setup guide](/learn/docs/self-hosted/set-up) for the full flow.

--- a/fern/products/docs/pages/self-hosted/self-hosted-set-up.mdx
+++ b/fern/products/docs/pages/self-hosted/self-hosted-set-up.mdx
@@ -79,6 +79,10 @@ RUN fern-generate
 `fern-generate` is a command available inside the Docker image that processes your documentation at build time, enabling faster container startup, air-gapped deployment, and a smaller attack surface. It's not a command you run on your host machine. You can alternatively [defer generation to runtime](#runtime-generation).
 </Info>
 
+<Tip>
+See [recent releases](/learn/docs/self-hosted/releases) to pin to a specific version instead of `:latest`.
+</Tip>
+
 </Step>
 <Step title="Build your Docker image">
 

--- a/fern/products/docs/pages/self-hosted/self-hosted.mdx
+++ b/fern/products/docs/pages/self-hosted/self-hosted.mdx
@@ -78,7 +78,7 @@ Fern provides your documentation site as a ready-to-run Docker container that yo
 1. **Upload your fern folder** - Add your documentation source files to the container
 1. **Run the container** - Start your local server using standard Docker commands
 1. **Deploy** - Set up your server environment and publish the documentation
-1. **Receive updated Docker images** - Fern releases new versions of the Docker image that your team can evaluate and deploy when ready.
+1. **Receive updated Docker images** - Fern [releases new versions of the Docker image](/learn/docs/self-hosted/releases) that your team can evaluate and deploy when ready. 
 
 ### Architecture diagram
 


### PR DESCRIPTION
## Summary

- Adds a self-hosted changelog wired into the docs nav (`fern/products/docs/pages/self-hosted/changelog/`), with an `overview.mdx` explaining the upgrade flow and a dated `.mdx` per release date listing each version's `FROM` line for `fernenterprise/fern-self-hosted`.
- Adds `.github/workflows/update-self-hosted-changelog.yml` — hourly cron that polls `fern-api/fern-platform` for new `docs@` release tags, appends an entry to the corresponding date file, and opens an auto-merging PR. Idempotent: skips versions already recorded.
- Backfills the last ~3 weeks of `docs@` releases (21 versions, Apr 15 → Apr 28).

## Test plan

- [ ] Verify the changelog renders in `fern docs dev` — overview + 9 dated entries with copy-pasteable `FROM` code blocks.
- [ ] Confirm the workflow has access to `secrets.FERN_GITHUB_TOKEN` (needed because `fern-api/fern-platform` is private).
- [ ] After merge, manually trigger via `gh workflow run update-self-hosted-changelog.yml` to confirm a no-op run produces no PR (everything backfilled).
- [ ] Wait for the next `docs@` release on fern-platform and confirm an auto-PR opens with the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
