### PR TITLE
docs: add note explaining why x-fern-default is used instead of plain default

### DIFF
--- a/fern/products/api-def/openapi/extensions/default.mdx
+++ b/fern/products/api-def/openapi/extensions/default.mdx
@@ -8,6 +8,8 @@ The `x-fern-default` extension lets you specify a client-side default value for 
 
 This is useful for pinning an API version header or a region path parameter while still allowing callers to override the value. `x-fern-default` is supported across all SDK languages.
 
+<Note>Fern uses `x-fern-default` instead of the standard OpenAPI `default` property because they have different semantics. The OpenAPI `default` on a schema describes the value the **server** assumes when the parameter is omitted — it's a documentation hint and doesn't affect client behavior. `x-fern-default` instructs the generated SDK to **actively send** the value in every request when the caller doesn't provide one, ensuring the parameter is always present on the wire.</Note>
+
 ## Path parameters
 
 In the example below, the SDK sends `us-east-1` for `region` when the caller doesn't specify one.


### PR DESCRIPTION
## Summary

Adds a `<Note>` callout to the [default values extension page](https://buildwithfern.com/learn/api-definitions/openapi/extensions/default-values) explaining why Fern uses `x-fern-default` instead of the standard OpenAPI `default` property.

The key distinction: OpenAPI `default` describes the value the server assumes when a parameter is omitted (a documentation hint), while `x-fern-default` instructs the SDK to actively send the value in every request, ensuring it's always present on the wire.

## Review & Testing Checklist for Human
- [ ] Verify the note renders correctly on the preview deployment
- [ ] Confirm the semantic explanation is technically accurate

### Notes
Low-risk, single-callout addition to an existing page.

Link to Devin session: https://app.devin.ai/sessions/8dbd9e9711624a8d8a8ef82cfcdd0134
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->