### PR TITLE
ci: handle <sitemapindex> in check-links workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -81,8 +81,50 @@ jobs:
 
       - name: Fetch sitemap and extract URLs
         run: |
-          curl -s https://buildwithfern.com/learn/sitemap.xml | grep -oP '(?<=<loc>)[^<]+' > urls.txt
-          echo "Found $(wc -l < urls.txt) URLs in sitemap"
+          # The sitemap may be either a regular <urlset> or a <sitemapindex>
+          # that points to per-language sub-sitemaps (e.g. sitemap-en.xml,
+          # sitemap-zh.xml). Handle both shapes by recursively expanding any
+          # sitemapindex into its child sitemaps before extracting page URLs.
+          set -euo pipefail
+          ROOT_SITEMAP="https://buildwithfern.com/learn/sitemap.xml"
+
+          fetch_sitemap_urls() {
+            local sitemap_url="$1"
+            local body
+            body=$(curl -fsSL "$sitemap_url") || {
+              echo "Warning: failed to fetch $sitemap_url" >&2
+              return 0
+            }
+
+            local locs
+            locs=$(echo "$body" | grep -oP '(?<=<loc>)[^<]+' || true)
+
+            if echo "$body" | grep -q '<sitemapindex'; then
+              # Recursively expand each child sitemap.
+              while IFS= read -r child; do
+                if [ -n "$child" ]; then
+                  fetch_sitemap_urls "$child"
+                fi
+              done <<< "$locs"
+            else
+              # Regular <urlset> — emit page URLs directly.
+              if [ -n "$locs" ]; then
+                echo "$locs"
+              fi
+            fi
+          }
+
+          fetch_sitemap_urls "$ROOT_SITEMAP" | sort -u > urls.txt
+
+          total=$(wc -l < urls.txt | tr -d ' ')
+          echo "Found $total URLs in sitemap"
+
+          if [ "$total" -eq 0 ]; then
+            echo "::error::No URLs were extracted from the sitemap. The link checker has nothing to scan."
+            echo "Root sitemap response:"
+            curl -fsSL "$ROOT_SITEMAP" || true
+            exit 1
+          fi
 
       - name: Extract and verify GitHub blob/tree/tag URLs locally
         id: verify_github


### PR DESCRIPTION
## Summary

The `Check Links` workflow ([runs](https://github.com/fern-api/docs/actions/workflows/check-links.yml)) has been failing since 2026-05-04 with:

```
No links were found. This usually indicates a configuration error.
```

**Root cause:** `https://buildwithfern.com/learn/sitemap.xml` recently changed shape from a flat `<urlset>` to a `<sitemapindex>` that points to per-language sub-sitemaps:

```xml
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap><loc>https://buildwithfern.com/learn/sitemap-en.xml</loc></sitemap>
  <sitemap><loc>https://buildwithfern.com/learn/sitemap-zh.xml</loc></sitemap>
</sitemapindex>
```

The previous step extracted `<loc>` entries directly, so `urls.txt` ended up containing only the two child-sitemap URLs (XML files), not the actual page URLs. lychee then fetched those XML files, found 0 HTML links, and bailed out with `failIfEmpty`.

**Fix:** Recursively expand `<sitemapindex>` entries into their child sitemaps' `<loc>` URLs before writing `urls.txt`. Behaviour is unchanged for the legacy flat-`<urlset>` shape, so this is forward-compatible whether the platform serves an index or a flat sitemap.

Verified locally — the new logic produces 325 URLs from the current sitemapindex (vs. 2 before), and exits with a clear error if the sitemap is genuinely empty instead of silently producing an empty `urls.txt`.

## Review & Testing Checklist for Human

- [ ] Trigger the workflow manually via `workflow_dispatch` on this branch and confirm it gets past the `Check non-GitHub links` step (i.e. lychee's "Total" is non-zero).
- [ ] Confirm the run completes without the `failIfEmpty` error.

### Notes

While diagnosing this, I noticed a separate issue worth flagging: `https://buildwithfern.com/learn/sitemap-en.xml` is currently returning an **empty** `<urlset>`, while `sitemap-zh.xml` correctly contains 325 URLs. With this PR's fix, the workflow will exercise the Chinese pages (which still cover the same docs structure), but English pages won't be exercised until the platform is fixed. Worth investigating in `fern-platform` separately — likely related to the same change that introduced the sitemapindex.


Link to Devin session: https://app.devin.ai/sessions/f71d9cbb5efc401799576519b960ef05
Requested by: @davidkonigsberg