### PR TITLE
ci(check-links): exclude non-ASCII bytes when extracting GitHub URLs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -136,19 +136,29 @@ jobs:
           echo "Scanning repo for GitHub blob/tree/tag URLs..."
           start_time=$(date +%s)
           > github-urls.txt
-          
+
+          # Use byte-oriented matching so the URL terminator class can
+          # exclude all non-ASCII bytes. Without LC_ALL=C, grep's PCRE
+          # engine runs in UTF-8 mode and treats \x80-\xff differently.
+          export LC_ALL=C
+
           # Search the content directories for GitHub blob/tree URLs
           # Include fern/ (main docs) and README.md (root)
           # Exclude .git and any cloned repos
-          grep -RhoE 'https://github\.com/[^/]+/[^/]+/(blob|tree)/[^"'"'"')<>[:space:]]+' \
+          # The terminator class excludes ASCII whitespace, common markdown
+          # delimiters, and any non-ASCII byte (\x80-\xff). This prevents
+          # trailing CJK punctuation (e.g., U+FF09 FULLWIDTH RIGHT PAREN)
+          # from being absorbed into the URL when extracted from translated
+          # prose.
+          grep -RhoP 'https://github\.com/[^/]+/[^/]+/(blob|tree)/[^"'"'"')<>\s\x80-\xff]+' \
             fern/ \
             README.md \
             --exclude-dir=.git \
             --exclude-dir=.github-repos \
             >> github-urls.txt 2>/dev/null || true
-          
+
           # Also search for releases/tag URLs
-          grep -RhoE 'https://github\.com/[^/]+/[^/]+/releases/tag/[^"'"'"')<>[:space:]]+' \
+          grep -RhoP 'https://github\.com/[^/]+/[^/]+/releases/tag/[^"'"'"')<>\s\x80-\xff]+' \
             fern/ \
             README.md \
             --exclude-dir=.git \
@@ -323,33 +333,36 @@ jobs:
           
           echo "Scanning repo for GitHub URLs to check via HTTP..."
           > github-http-urls.txt
-          
+
+          # See note above about LC_ALL=C and the \x80-\xff terminator class.
+          export LC_ALL=C
+
           # Search for issues URLs
-          grep -RhoE 'https://github\.com/[^/]+/[^/]+/issues/[^"'"'"')<>[:space:]]+' \
+          grep -RhoP 'https://github\.com/[^/]+/[^/]+/issues/[^"'"'"')<>\s\x80-\xff]+' \
             fern/ README.md \
             --exclude-dir=.git --exclude-dir=.github-repos \
             >> github-http-urls.txt 2>/dev/null || true
-          
+
           # Search for compare URLs
-          grep -RhoE 'https://github\.com/[^/]+/[^/]+/compare/[^"'"'"')<>[:space:]]+' \
+          grep -RhoP 'https://github\.com/[^/]+/[^/]+/compare/[^"'"'"')<>\s\x80-\xff]+' \
             fern/ README.md \
             --exclude-dir=.git --exclude-dir=.github-repos \
             >> github-http-urls.txt 2>/dev/null || true
-          
+
           # Search for commit/commits URLs
-          grep -RhoE 'https://github\.com/[^/]+/[^/]+/commits?/[^"'"'"')<>[:space:]]+' \
+          grep -RhoP 'https://github\.com/[^/]+/[^/]+/commits?/[^"'"'"')<>\s\x80-\xff]+' \
             fern/ README.md \
             --exclude-dir=.git --exclude-dir=.github-repos \
             >> github-http-urls.txt 2>/dev/null || true
-          
+
           # Search for discussions URLs
-          grep -RhoE 'https://github\.com/[^/]+/[^/]+/discussions/[^"'"'"')<>[:space:]]+' \
+          grep -RhoP 'https://github\.com/[^/]+/[^/]+/discussions/[^"'"'"')<>\s\x80-\xff]+' \
             fern/ README.md \
             --exclude-dir=.git --exclude-dir=.github-repos \
             >> github-http-urls.txt 2>/dev/null || true
-          
+
           # Search for pull request URLs (excluding fern-api org - those are too slow to check)
-          grep -RhoE 'https://github\.com/[^/]+/[^/]+/pull/[^"'"'"')<>[:space:]]+' \
+          grep -RhoP 'https://github\.com/[^/]+/[^/]+/pull/[^"'"'"')<>\s\x80-\xff]+' \
             fern/ README.md \
             --exclude-dir=.git --exclude-dir=.github-repos \
             2>/dev/null | grep -v 'github\.com/fern-api/' \


### PR DESCRIPTION
## Summary

Follow-up to #5334. After the sitemap fix landed, the next [`Check Links` run](https://github.com/fern-api/docs/actions/workflows/check-links.yml) still failed — but for a different reason: the local GitHub URL verification step extracted

```
https://github.com/fern-api/protoc-gen-openapi/releases/tag/v0.1.7）
```

(note the trailing fullwidth Chinese right parenthesis, U+FF09, hex `EF BC 89`) from <ref_file file="/home/ubuntu/repos/docs/fern/translations/zh/products/sdks/generators/csharp/changelog/2026-03-13.mdx" />, then tried to verify that a tag literally named `v0.1.7）` exists in `fern-api/protoc-gen-openapi`, which of course it doesn't.

The URL terminator class in each `grep` was `[^"')<>[:space:]]+` — i.e. ASCII whitespace and a few markdown delimiters. The Chinese paren is none of those, so it was absorbed into the URL.

**Fix:** switch the URL extraction greps to `grep -P` (PCRE) with a terminator class that also excludes any non-ASCII byte (`\x80-\xff`), and `export LC_ALL=C` in those steps so PCRE runs in byte-oriented mode. URLs are pure ASCII per RFC 3986, so this is a tighter, correct constraint and is robust to any future CJK / accented punctuation that might land next to a bare URL in translated prose.

Verified locally on the current `main`:
- `releases/tag` extraction: 8 URLs before / 8 after — only difference is the previously-broken one is now extracted as `…/v0.1.7` instead of `…/v0.1.7）`.
- `blob/tree`, `issues`, `compare`, `commits?`, `discussions`, `pull` extractions: identical sets before/after.

## Review & Testing Checklist for Human

- [ ] Trigger the `Check Links` workflow manually via `workflow_dispatch` on this branch and confirm the job completes green (i.e. `GitHub URLs missing locally: 0`).

### Notes

This only fixes the URL extractor. If you'd prefer the source markdown to use ASCII parens (or, better, a real `[text](url)` link) in the zh translation, that's a separate change in <ref_file file="/home/ubuntu/repos/docs/fern/translations/zh/products/sdks/generators/csharp/changelog/2026-03-13.mdx" /> — happy to do that as a follow-up.

The earlier-flagged empty `sitemap-en.xml` issue (`buildwithfern.com/learn/sitemap-en.xml` returning an empty `<urlset>`) is unrelated to this PR and still worth investigating in `fern-platform`.


Link to Devin session: https://app.devin.ai/sessions/f71d9cbb5efc401799576519b960ef05
Requested by: @davidkonigsberg