### PR TITLE
docs: add custom robots.txt page

### DIFF
--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -351,6 +351,9 @@ navigation:
         path: ./pages/seo/configuring-slugs.mdx
       - page: Redirects
         path: ./pages/seo/redirects.mdx
+      - page: Custom robots.txt
+        path: ./pages/seo/robots-txt.mdx
+        slug: robots-txt
   - section: Authentication
     collapsed: true
     contents:

--- a/fern/products/docs/pages/changelog/2026-05-04.mdx
+++ b/fern/products/docs/pages/changelog/2026-05-04.mdx
@@ -1,6 +1,17 @@
 ---
-tags: ["configuration"]
+tags: ["configuration", "seo"]
 ---
+
+## Custom robots.txt
+
+You can now serve your own `robots.txt` at the root of your documentation site by pointing `agents.robots-txt` at a file in your repo. Fern serves your file verbatim and appends a managed block that disallows internal `/api/fern-docs/` routes, so you can opt in or out of specific AI crawlers, gate sensitive sections, or use the [Cloudflare Content Signals Policy](https://blog.cloudflare.com/content-signals-policy/) without losing route protection.
+
+```yaml docs.yml
+agents:
+  robots-txt: ./robots.txt
+```
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/seo/robots-txt">Read the docs</Button>
 
 ## Multi-source docs
 

--- a/fern/products/docs/pages/changelog/2026-05-04.mdx
+++ b/fern/products/docs/pages/changelog/2026-05-04.mdx
@@ -4,7 +4,7 @@ tags: ["configuration", "seo"]
 
 ## Custom robots.txt
 
-You can now serve your own `robots.txt` at the root of your documentation site by pointing `agents.robots-txt` at a file in your repo. Fern serves your file verbatim and appends a managed block that disallows internal `/api/fern-docs/` routes, so you can opt in or out of specific AI crawlers, gate sensitive sections, or use the [Cloudflare Content Signals Policy](https://blog.cloudflare.com/content-signals-policy/) without losing route protection.
+Serve your own `robots.txt` at the root of your documentation site by pointing `agents.robots-txt` at a file in your repo. Fern serves your file verbatim and appends a managed block that disallows internal `/api/fern-docs/` routes, so you can opt in or out of specific AI crawlers, gate sensitive sections, or use the [Cloudflare Content Signals Policy](https://blog.cloudflare.com/content-signals-policy/) without losing route protection.
 
 ```yaml docs.yml
 agents:

--- a/fern/products/docs/pages/changelog/2026-05-04.mdx
+++ b/fern/products/docs/pages/changelog/2026-05-04.mdx
@@ -4,7 +4,7 @@ tags: ["configuration", "seo"]
 
 ## Custom robots.txt
 
-Serve your own `robots.txt` at the root of your documentation site by pointing `agents.robots-txt` at a file in your repo. Fern serves your file verbatim and appends a managed block that disallows internal `/api/fern-docs/` routes, so you can opt in or out of specific AI crawlers, gate sensitive sections, or use the [Cloudflare Content Signals Policy](https://blog.cloudflare.com/content-signals-policy/) without losing route protection.
+Serve your own `robots.txt` at the root of your documentation site by pointing `agents.robots-txt` at a file in your repo.
 
 ```yaml docs.yml
 agents:

--- a/fern/products/docs/pages/navigation/site-level-settings.mdx
+++ b/fern/products/docs/pages/navigation/site-level-settings.mdx
@@ -1175,6 +1175,7 @@ agents:
   page-description-source: description
   llms-txt: ./path/to/llms.txt
   llms-full-txt: ./path/to/llms-full.txt
+  robots-txt: ./path/to/robots.txt
 ```
 
 <ParamField path="agents.page-directive" type="string" required={false} toc={true}>
@@ -1191,6 +1192,10 @@ agents:
 
 <ParamField path="agents.llms-full-txt" type="string" required={false} toc={true}>
   Path to a custom `llms-full.txt` file, relative to `docs.yml`. When set, this file is served at the root-level `/llms-full.txt` endpoint instead of the auto-generated version. Nested paths continue to use the auto-generated output.
+</ParamField>
+
+<ParamField path="agents.robots-txt" type="string" required={false} toc={true}>
+  Path to a custom `robots.txt` file, relative to `docs.yml`. When set, this file is served verbatim at `/robots.txt`. Fern appends a managed block disallowing `/api/fern-docs/` after your content. See [Custom robots.txt](/learn/docs/seo/robots-txt) for details.
 </ParamField>
 
 ## AI examples configuration

--- a/fern/products/docs/pages/navigation/site-level-settings.mdx
+++ b/fern/products/docs/pages/navigation/site-level-settings.mdx
@@ -1195,7 +1195,7 @@ agents:
 </ParamField>
 
 <ParamField path="agents.robots-txt" type="string" required={false} toc={true}>
-  Path to a custom `robots.txt` file, relative to `docs.yml`. When set, this file is served verbatim at `/robots.txt`. Fern appends a managed block disallowing `/api/fern-docs/` after your content. See [Custom robots.txt](/learn/docs/seo/robots-txt) for details.
+  Path to a custom `robots.txt` file, relative to `docs.yml`. When set, this file is served verbatim at `/robots.txt`. See [Custom robots.txt](/learn/docs/seo/robots-txt) for details.
 </ParamField>
 
 ## AI examples configuration

--- a/fern/products/docs/pages/seo/overview.mdx
+++ b/fern/products/docs/pages/seo/overview.mdx
@@ -36,7 +36,7 @@ The sitemap route fetches stored slug data, builds a URL-to-timestamp lookup, an
 
 When you want more control, you can configure:
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="SEO metadata" icon="fa-duotone fa-tags" href="/learn/docs/seo/setting-seo-metadata">
     Configure titles, descriptions, and social previews for search engines
   </Card>
@@ -45,5 +45,8 @@ When you want more control, you can configure:
   </Card>
   <Card title="Redirects" icon="fa-duotone fa-arrow-right-arrow-left" href="/learn/docs/seo/redirects">
     Set up redirects to preserve SEO equity when pages move
+  </Card>
+  <Card title="Custom robots.txt" icon="fa-duotone fa-robot" href="/learn/docs/seo/robots-txt">
+    Serve a custom `robots.txt` to control how search engines and AI crawlers access your content
   </Card>
 </CardGroup>

--- a/fern/products/docs/pages/seo/robots-txt.mdx
+++ b/fern/products/docs/pages/seo/robots-txt.mdx
@@ -36,8 +36,6 @@ User-Agent: *
 Disallow: /api/fern-docs/
 ```
 
-You don't need to include the `Disallow: /api/fern-docs/` block yourself — Fern always appends it after your content so internal routes stay protected even when your file allows everything.
-
 <Note>
   Crawler `User-Agent` groups in `robots.txt` are matched most-specific-first. Place named bots (e.g. `GPTBot`, `Googlebot`) before any wildcard `User-Agent: *` group so your overrides aren't shadowed by Fern's appended `User-Agent: *` block.
 </Note>

--- a/fern/products/docs/pages/seo/robots-txt.mdx
+++ b/fern/products/docs/pages/seo/robots-txt.mdx
@@ -1,0 +1,52 @@
+---
+title: Custom robots.txt
+description: Serve a custom robots.txt at the root of your documentation site to control how search engines and AI crawlers access your content.
+---
+
+By default, Fern serves an auto-generated `robots.txt` at the root of your documentation site that allows all crawlers and points to your `sitemap.xml`. Use the `agents.robots-txt` key in `docs.yml` to serve your own file instead — useful for opting in or out of specific AI crawlers, gating sensitive sections, or signaling preferences with the [Cloudflare Content Signals Policy](https://blog.cloudflare.com/content-signals-policy/).
+
+## Configuration
+
+Point `agents.robots-txt` at a file relative to your `docs.yml`:
+
+```yaml docs.yml
+agents:
+  robots-txt: ./robots.txt
+```
+
+Then write the file. For example:
+
+```txt robots.txt
+User-Agent: GPTBot
+Disallow: /private
+
+User-Agent: Googlebot
+Allow: /
+
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+Sitemap: https://docs.example.com/sitemap.xml
+```
+
+Your file is served verbatim at `/robots.txt`. Fern appends a managed block at the end that disallows internal API routes:
+
+```txt
+# Fern-managed routes — automatically disallowed
+User-Agent: *
+Disallow: /api/fern-docs/
+```
+
+You don't need to include the `Disallow: /api/fern-docs/` block yourself — Fern always appends it after your content so internal routes stay protected even when your file allows everything.
+
+<Note>
+  Crawler `User-Agent` groups in `robots.txt` are matched most-specific-first. Place named bots (e.g. `GPTBot`, `Googlebot`) before any wildcard `User-Agent: *` group so your overrides aren't shadowed by Fern's appended `User-Agent: *` block.
+</Note>
+
+<ParamField path="agents.robots-txt" type="string" required={false} toc={true}>
+  Path to a custom `robots.txt` file, relative to `docs.yml`. When set, this file is served at the root-level `/robots.txt` endpoint instead of the auto-generated default. Fern appends a managed block disallowing `/api/fern-docs/` after your content.
+</ParamField>
+
+## Related configuration
+
+- Per-page indexing is controlled with the [`noindex` frontmatter field](/learn/docs/seo/setting-seo-metadata#indexing).
+- AI-specific endpoints (`llms.txt`, `llms-full.txt`) are configured under [`agents.llms-txt` and `agents.llms-full-txt`](/learn/docs/ai-features/customize-llm-output#serve-custom-files).


### PR DESCRIPTION
## Summary

Documents the new `agents.robots-txt` config that ships with [fern-platform#10508](https://github.com/fern-api/fern-platform/pull/10508) + [fern#15674](https://github.com/fern-api/fern/pull/15674).

- New page: `Custom robots.txt` under SEO & GEO (`/learn/docs/seo/robots-txt`). Explains the default Fern-generated `robots.txt`, how to override it via `agents.robots-txt`, and the Fern-managed `Disallow: /api/fern-docs/` block that gets appended to your file.
- `seo/overview.mdx`: adds a `<Card>` for the new page (CardGroup grows from 3 to 4 cols=2).
- `navigation/site-level-settings.mdx`: adds an `agents.robots-txt` `<ParamField>` next to the existing `agents.llms-txt` / `agents.llms-full-txt` fields and updates the example `docs.yml` snippet.
- Changelog: appends a `## Custom robots.txt` section to `changelog/2026-05-04.mdx` (today's date) and adds the `seo` tag.

## Review & Testing Checklist for Human

- [ ] Verify the new page renders in the preview deployment with the correct nav placement under SEO & GEO and the example yaml/code blocks render cleanly.
- [ ] Sanity-check the cross-links work in the preview: `/learn/docs/seo/setting-seo-metadata#indexing`, `/learn/docs/ai-features/customize-llm-output#serve-custom-files`, and the changelog Button's `/learn/docs/seo/robots-txt`.
- [ ] Confirm the SEO overview cards lay out correctly at `cols={2}` with the new "Custom robots.txt" card.

### Notes

- Vale runs clean on the new page and on my edits to `seo/overview.mdx` (other warnings shown locally are pre-existing in `site-level-settings.mdx` and unrelated to my changes).
- I did not touch the Chinese translations under `fern/translations/zh/`. If the docs site auto-translates those on a separate workflow, the new page and the changelog addition will need to flow through that process.

Link to Devin session: https://app.devin.ai/sessions/bc75bd2352564431959460d665ebcc62
Requested by: @thesandlord