### PR TITLE
chore: backfill SHA256 digests for v0.114.28–v0.114.30

### DIFF
--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-04.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-04.mdx
@@ -4,8 +4,12 @@
 FROM fernenterprise/fern-self-hosted:0.114.28
 ```
 
+Digest: `sha256:dd797d3deb1c76a525a06152bf55af6a1e454d9592b8c2fa9606806399b83c53`
+
 ### v0.114.29
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.29
 ```
+
+Digest: `sha256:b87a00aaf47c8fa5d2d765be1d47c2a2131c3065fc2d6af6f518bdb64f5395d3`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-05.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-05.mdx
@@ -3,3 +3,5 @@
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.30
 ```
+
+Digest: `sha256:9a6efaec08dd1456be5004d88ac7c377d0204fd0ce46a5d6f85ca20d0a1a01c7`


### PR DESCRIPTION
## Summary

Backfills SHA256 digests for the three most recent self-hosted releases:

- `v0.114.28` → `sha256:dd797d3deb1c76a525a06152bf55af6a1e454d9592b8c2fa9606806399b83c53`
- `v0.114.29` → `sha256:b87a00aaf47c8fa5d2d765be1d47c2a2131c3065fc2d6af6f518bdb64f5395d3`
- `v0.114.30` → `sha256:9a6efaec08dd1456be5004d88ac7c377d0204fd0ce46a5d6f85ca20d0a1a01c7`

Future releases will include digests automatically via the new automation in fern-platform (https://github.com/fern-api/fern-platform/pull/10555).

## Review & Testing Checklist for Human

- [ ] Verify the digest values match the actual DockerHub images

Link to Devin session: https://app.devin.ai/sessions/e9529cdd7cd74121858220a6c457b077
Requested by: @thesandlord