### PR TITLE
Add dynamic OG image background for social sharing

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -23,6 +23,9 @@ ai-search:
       title: Fern pricing
 
 metadata:
+  og:dynamic: true
+  og:dynamic:show-url: false
+  og:dynamic:background-image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image.png
   og:image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image-compressed.png
   twitter:image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image-compressed.png
   canonical-host: buildwithfern.com


### PR DESCRIPTION
## Summary

- Enables `og:dynamic: true` to generate dynamic Open Graph images for social sharing
- Sets the Fern docs screenshot as the `og:dynamic:background-image` so each page's OG card uses it as a backdrop
- Adds `og:dynamic:show-url: false` to hide the URL overlay on generated images

## Test plan
- [ ] Preview a docs page link on Slack/Twitter/LinkedIn and verify the OG card renders with the background image