### PR TITLE
Add dynamic OG image background for social sharing

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -25,11 +25,10 @@ ai-search:
 metadata:
   og:dynamic: true
   og:dynamic:show-url: false
+  og:dynamic:show-gradient: false
+  og:dynamic:show-logo: false
   og:dynamic:background-image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image.png
-  og:image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image-compressed.png
-  twitter:image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image-compressed.png
   canonical-host: buildwithfern.com
-  og:description: Build better developer experiences. Generate SDKs in TypeScript, Python, Go, Java, C#, PHP, Ruby, Swift & Rust. Create interactive API docs with AI search.
 
 
 products:


### PR DESCRIPTION
## Summary

Configures dynamic Open Graph image generation in `docs.yml` for richer social sharing previews:

- `og:dynamic:background-image` — uses the Fern docs screenshot as the OG card background
- `og:dynamic:show-url: false` — hides the URL overlay
- `og:dynamic:show-gradient: false` — removes the gradient overlay for a cleaner look
- `og:dynamic:show-logo: false` — hides the logo overlay (logo is already baked into the background image)

Also includes `fern/apis/fai/ai_examples_override.yml` (new file).

## Test plan
- [ ] Share a docs page URL on Slack/Twitter/LinkedIn and verify the OG card renders with the background image and no overlays