### PR TITLE
Revert dynamic OG image background configuration

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -24,11 +24,10 @@ ai-search:
 
 metadata:
   og:dynamic: true
-  og:dynamic:show-url: false
-  og:dynamic:show-gradient: false
-  og:dynamic:show-logo: false
-  og:dynamic:background-image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image.png
+  og:image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image-compressed.png
+  twitter:image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image-compressed.png
   canonical-host: buildwithfern.com
+  og:description: Build better developer experiences. Generate SDKs in TypeScript, Python, Go, Java, C#, PHP, Ruby, Swift & Rust. Create interactive API docs with AI search.
 
 
 products:


### PR DESCRIPTION
## Summary

Reverts the dynamic OG image settings introduced in #5404 and #5405 due to an issue with the configuration.

**Changes:**
- Removes `og:dynamic:background-image`
- Removes `og:dynamic:show-url: false`
- Removes `og:dynamic:show-gradient: false`
- Removes `og:dynamic:show-logo: false`
- Restores `og:image` and `twitter:image` static fallback images
- Restores `og:description`

Keeps `og:dynamic: true` as it was already present before these changes.

## Test plan
- [ ] Verify OG cards on social platforms render with the static image again