### PR TITLE
Configure dynamic OG image with background and hidden overlays

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -24,10 +24,11 @@ ai-search:
 
 metadata:
   og:dynamic: true
-  og:image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image-compressed.png
-  twitter:image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image-compressed.png
+  og:dynamic:show-url: false
+  og:dynamic:show-gradient: false
+  og:dynamic:show-logo: false
+  og:dynamic:background-image: https://fern-docs.s3.us-east-2.amazonaws.com/fern-docs-og_image.png
   canonical-host: buildwithfern.com
-  og:description: Build better developer experiences. Generate SDKs in TypeScript, Python, Go, Java, C#, PHP, Ruby, Swift & Rust. Create interactive API docs with AI search.
 
 
 products:


### PR DESCRIPTION
## Summary

Configures dynamic Open Graph image generation for social sharing previews:

- `og:dynamic:background-image` — Fern docs screenshot as the OG card background
- `og:dynamic:show-url: false` — hides the URL overlay
- `og:dynamic:show-gradient: false` — removes the gradient overlay
- `og:dynamic:show-logo: false` — hides the logo (already baked into the background image)

Removes static `og:image`, `twitter:image`, and `og:description` fallbacks in favour of the dynamic configuration.

## Test plan
- [ ] Share a docs page on Slack/Twitter/LinkedIn and verify the OG card renders correctly with the background image and no overlays