### PR TITLE
fix: backfill self-hosted changelog digests and add missing releases

### DIFF
--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-15.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-15.mdx
@@ -3,3 +3,5 @@
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.1
 ```
+
+Digest: `sha256:4f9a80af3f95bc757ea3295ecedbbde225362f71273533e128741dbc99202e5c`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-17.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-17.mdx
@@ -4,14 +4,18 @@
 FROM fernenterprise/fern-self-hosted:0.114.2
 ```
 
+Digest: `sha256:1ae5e2859d1f24df1fe5aa01b3154a329ee44e52725f2a597ecec90a6b4234fe`
 ### v0.114.3
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.3
 ```
 
+Digest: `sha256:45b120b80fcdb50ac4ff9c5b18ed764c16b9c9d20ae93f10cb7321bf865264d8`
 ### v0.114.4
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.4
 ```
+
+Digest: `sha256:ce8b34be169049c6c82125397c6f0521ee6ebda5b33e6fcb6778bcbd1acfed9e`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-20.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-20.mdx
@@ -4,8 +4,11 @@
 FROM fernenterprise/fern-self-hosted:0.114.5
 ```
 
+Digest: `sha256:aab5bbdaf05cb56900c7e5b7190d6302255f09ab8ea787a52f53ddd648679919`
 ### v0.114.6
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.6
 ```
+
+Digest: `sha256:ee4df49686d0301c20b125be9814b13420505448aae33fc118e2b74ed5800729`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-21.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-21.mdx
@@ -4,8 +4,11 @@
 FROM fernenterprise/fern-self-hosted:0.114.7
 ```
 
+Digest: `sha256:94c3ff8467e73307c56b5a369e911b67f4705b0800ef8c8564681098576421e2`
 ### v0.114.8
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.8
 ```
+
+Digest: `sha256:fe3987bc3174e7c9cdc5105907d433e35178dee14be514f05da3420ddfb75b43`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-22.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-22.mdx
@@ -4,20 +4,11 @@
 FROM fernenterprise/fern-self-hosted:0.114.9
 ```
 
+Digest: `sha256:eac94f2f0e29c38ec8216ff012b6cba50b490eaebac221e8736e595e38d3739e`
 ### v0.114.10
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.10
 ```
 
-### v0.114.11
-
-```dockerfile
-FROM fernenterprise/fern-self-hosted:0.114.11
-```
-
-### v0.114.12
-
-```dockerfile
-FROM fernenterprise/fern-self-hosted:0.114.12
-```
+Digest: `sha256:ed32808b3a93c74c67c807d45914ddda98d7f00be5baca6cb3895d41162fb7cc`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-23.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-23.mdx
@@ -1,5 +1,0 @@
-### v0.114.13
-
-```dockerfile
-FROM fernenterprise/fern-self-hosted:0.114.13
-```

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-24.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-24.mdx
@@ -4,14 +4,18 @@
 FROM fernenterprise/fern-self-hosted:0.114.14
 ```
 
+Digest: `sha256:b0dffc646ddce5c582d6092d12aed29484c1bfee5b84f050c4c4561de55273aa`
 ### v0.114.15
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.15
 ```
 
+Digest: `sha256:15194eca6189ebc105062d2627f8504d20ebc36ffdd3e93152b6986dc98fc069`
 ### v0.114.16
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.16
 ```
+
+Digest: `sha256:e6c7f04b322c8610a13fa4396b184c094fa5ac3d6f7ce3233435aea5385b3623`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-27.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-27.mdx
@@ -4,14 +4,11 @@
 FROM fernenterprise/fern-self-hosted:0.114.17
 ```
 
-### v0.114.18
-
-```dockerfile
-FROM fernenterprise/fern-self-hosted:0.114.18
-```
-
+Digest: `sha256:a8544061e07873dab3344deeb7c35f723eba090ca6b56b2d687f88a03b031378`
 ### v0.114.19
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.19
 ```
+
+Digest: `sha256:64f5fa8ad31f568d275645087de8aac02780b09b61b9e5d3fa7a5fb581555e6c`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-28.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-28.mdx
@@ -4,8 +4,11 @@
 FROM fernenterprise/fern-self-hosted:0.114.20
 ```
 
+Digest: `sha256:e6cc86bd2559868986c4c9f1928b1ea3739db00933fe729ab0c1b59e48ba294d`
 ### v0.114.21
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.21
 ```
+
+Digest: `sha256:debc54667bda85589b48da806d7914ae64839411f44fc7ba1a448ecf408e47d8`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-04-29.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-04-29.mdx
@@ -3,3 +3,5 @@
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.22
 ```
+
+Digest: `sha256:48900638c4d5e0899671532fdebf28d8bf809a650f8037a99eeee41c3d5a4dc6`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-01.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-01.mdx
@@ -4,8 +4,11 @@
 FROM fernenterprise/fern-self-hosted:0.114.24
 ```
 
+Digest: `sha256:ed7ebd789e9dc4c186b14ad6b3ba09c037a41bf043cc0371fbb877aeb64e4b2d`
 ### v0.114.25
 
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.25
 ```
+
+Digest: `sha256:ec0c1d0dab16b209da1085e2e922ff87b5f76cdf7f93702e974933a6389d9932`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-02.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-02.mdx
@@ -3,3 +3,5 @@
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.26
 ```
+
+Digest: `sha256:3e7ffd77b36f5e02c4640c355d6a0aa1e80f4eb57f35df1d4eba0ba84f117146`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-03.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-03.mdx
@@ -3,3 +3,5 @@
 ```dockerfile
 FROM fernenterprise/fern-self-hosted:0.114.27
 ```
+
+Digest: `sha256:b50e00dadcd018841798a15fa1f25ad4f0f1f4cb1e283e303f39f167140a8ada`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-04.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-04.mdx
@@ -5,7 +5,6 @@ FROM fernenterprise/fern-self-hosted:0.114.28
 ```
 
 Digest: `sha256:dd797d3deb1c76a525a06152bf55af6a1e454d9592b8c2fa9606806399b83c53`
-
 ### v0.114.29
 
 ```dockerfile

--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-05.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-05.mdx
@@ -5,3 +5,18 @@ FROM fernenterprise/fern-self-hosted:0.114.30
 ```
 
 Digest: `sha256:9a6efaec08dd1456be5004d88ac7c377d0204fd0ce46a5d6f85ca20d0a1a01c7`
+
+### v0.114.31
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.31
+```
+
+Digest: `sha256:46f38fb7e93b8251921fe5069bef3b18ec03f530e0a9f1033fd68179a810fb01`
+### v0.114.32
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.32
+```
+
+Digest: `sha256:903892260ea84f12269d21c4b29c139c6fe8b55cc92027a4cd5cd3a18751861e`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-06.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-06.mdx
@@ -1,0 +1,35 @@
+### v0.114.33
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.33
+```
+
+Digest: `sha256:ef97be68de1a89fb4cfd744a06a9ea0cf347a98d63075937b5c841b7008d4735`
+### v0.114.34
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.34
+```
+
+Digest: `sha256:980ad0c99795f4e929ac62a6191adeac30b6faf82330e66da903e2d558143061`
+### v0.114.35
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.35
+```
+
+Digest: `sha256:885e0ac18f80b5c4813d8847f2a8a2a4db533854f169970dc03062886cef1ba3`
+### v0.114.36
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.36
+```
+
+Digest: `sha256:f86aa23a81e6fc6bad7398ff66e1ea27c7a6a1697c6f07d8303bef1d93c8406f`
+### v0.114.37
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.37
+```
+
+Digest: `sha256:df14d2d70ad0dc68e5c5e41c14666c768903e299680c03b67e048fe933d1b8f7`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-07.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-07.mdx
@@ -1,0 +1,14 @@
+### v0.114.38
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.38
+```
+
+Digest: `sha256:d9396ba5c4f9b175cdf8008201a99a7161da463654d7a06ec9753c52e66b8f02`
+### v0.114.39
+
+```dockerfile
+FROM fernenterprise/fern-self-hosted:0.114.39
+```
+
+Digest: `sha256:509ca3cb6c61b461935451e3e25a34f0f1ebf74aad67f0de01b0f4bf806348f2`


### PR DESCRIPTION
## Summary

Backfills SHA256 digests for all self-hosted Docker image releases and adds missing changelog entries for v0.114.31–v0.114.39.

## Review & Testing Checklist for Human

- [ ] Verify the digests match Docker Hub — spot check a few versions with `docker buildx imagetools inspect fernenterprise/fern-self-hosted:<version>`
- [ ] Confirm the removed entries (v0.114.11, v0.114.12, v0.114.13, v0.114.18) are indeed not on Docker Hub
- [ ] Check the releases page renders correctly after merge: https://buildwithfern.com/learn/docs/self-hosted/releases

### Changes

- **Added SHA256 digests** to all entries v0.114.1 through v0.114.27 (verified against Docker Hub via `docker buildx imagetools inspect`)
- **Removed phantom entries** for v0.114.11, v0.114.12, v0.114.13, v0.114.18 — these were never published to Docker Hub
- **Added missing entries** for v0.114.31 through v0.114.39 (released May 5–7) with correct digests
- **Deleted empty file** `2026-04-23.mdx` (its only entry, v0.114.13, was a phantom)

### Notes

A companion PR in `fern-api/fern-platform` fixes the workflow that was causing entries to be lost when multiple releases happened before the auto-merge PR was merged.

Link to Devin session: https://app.devin.ai/sessions/4603930dbd584afda978a29cf5338a7f
Requested by: @thesandlord