### PR TITLE
docs(sdks): document csharp default-timeout-in-seconds config option

### DIFF
--- a/fern/products/sdks/deep-dives/generated-sdk.mdx
+++ b/fern/products/sdks/deep-dives/generated-sdk.mdx
@@ -57,7 +57,7 @@ Your SDK users can configure individual requests using language-specific options
 
 | Option | Description | Availability |
 |--------|-------------|--------------|
-| Timeouts | Configure request timeouts (default: 30 seconds for C# and PHP, 60 seconds for all other languages) | All languages |
+| Timeouts | Configure request timeouts (default: 30 seconds for [C#](/learn/sdks/generators/csharp/configuration#default-timeout-in-seconds) and PHP, 60 seconds for all other languages) | All languages |
 | [Retries](/sdks/deep-dives/retries-with-backoff) | Configure maximum retries (default: 2 with exponential backoff for 408, 429, and 5xx responses) | All languages except Ruby and Swift |
 | Custom HTTP client | Override the default HTTP client for unsupported environments or custom requirements | TypeScript, Python, Java, PHP, and Swift |
 | [aiohttp transport](/learn/sdks/generators/python/aiohttp-support) | Opt into `aiohttp` as the async HTTP transport to resolve DNS concurrency bottlenecks | Python only |

--- a/fern/products/sdks/generators/csharp/configuration.mdx
+++ b/fern/products/sdks/generators/csharp/configuration.mdx
@@ -33,7 +33,7 @@ Customizes the name of the pagination helper class used for handling paginated A
 </ParamField>
 
 <ParamField path="default-timeout-in-seconds" type="number | 'infinity'" default="30" required={false} toc={true}>
-The default timeout for network requests, in seconds. Set to `infinity` to disable the default timeout. SDK users can still override this per-request via `RequestOptions.Timeout`.
+The default timeout for network requests, in seconds. Set to `infinity` to disable the default timeout. SDK users can still [override this per request](/learn/sdks/deep-dives/sdk-user-features#customization-options) by passing `RequestOptions.Timeout`.
 </ParamField>
 
 <ParamField path="enable-forward-compatible-enums" type="boolean" required={false} toc={true}>

--- a/fern/products/sdks/generators/csharp/configuration.mdx
+++ b/fern/products/sdks/generators/csharp/configuration.mdx
@@ -32,6 +32,10 @@ Sets the name of the generated API client class. This determines the primary cli
 Customizes the name of the pagination helper class used for handling paginated API responses. This allows you to specify a custom name that fits your naming conventions.
 </ParamField>
 
+<ParamField path="default-timeout-in-seconds" type="number | 'infinity'" default="30" required={false} toc={true}>
+The default timeout for network requests, in seconds. Set to `infinity` to disable the default timeout. SDK users can still override this per-request via `RequestOptions.Timeout`.
+</ParamField>
+
 <ParamField path="enable-forward-compatible-enums" type="boolean" required={false} toc={true}>
 When enabled, generates enum types that can handle unknown values. This allows the SDK to process new enum values that may be added to the API without breaking existing client code, improving forward compatibility.
 </ParamField>


### PR DESCRIPTION
## Summary

Documents the new `default-timeout-in-seconds` option on the C# SDK generator configuration page. Adds a single `<ParamField>` entry between `custom-pager-name` and `enable-forward-compatible-enums`.

The option itself is implemented in [fern-api/fern#15801](https://github.com/fern-api/fern/pull/15801) — this PR just adds the corresponding reference docs.

Behavior documented:
- Type: `number | 'infinity'`
- Default: `30` (preserves existing C# generator behavior)
- `'infinity'` disables the default timeout
- Users can still override per-request via `RequestOptions.Timeout`

## Review & Testing Checklist for Human

- [ ] Confirm the documented behavior matches the implementation in the paired fern PR (default `30`, accepts a positive number or the literal string `"infinity"`, per-request override via `RequestOptions.Timeout`).
- [ ] Skim the rendered preview to confirm the new `<ParamField>` shows up in the right place in the C# configuration page TOC and is styled consistently with surrounding entries.

### Notes

Docs-only change, no logic. The paired generator PR is what actually wires the config through to `ClientOptions.Timeout`.

Link to Devin session: https://app.devin.ai/sessions/1ad0d89c7aed4cf499de2fb8e324eac1
Requested by: @fern-support