### PR TITLE
docs(csharp): document user-agent-name-from-package config flag

### DIFF
--- a/fern/products/sdks/generators/csharp/configuration.mdx
+++ b/fern/products/sdks/generators/csharp/configuration.mdx
@@ -110,5 +110,5 @@ When enabled, generates discriminated union types for API responses that can con
 <ParamField path="user-agent-name-from-package" type="boolean" default="false" required={false} toc={true}>
 When enabled, the generated SDK sends a `User-Agent: <NuGetPackageId>/<version>` header on every request when the API definition does not specify an explicit `User-Agent`. This mirrors other generators' `<package-name>/<version>` fallback.
 
-The prefix is taken from the cascade `package-id` → `namespace` → `PascalCase(<organization>_<api-name>)`, so it matches whatever name the SDK ships under on NuGet. Defaults to `false`.
+The prefix is taken from the cascade `package-id` → `namespace` → `PascalCase(<organization>_<api-name>)`, so it matches whatever name the SDK ships under on NuGet.
 </ParamField>

--- a/fern/products/sdks/generators/csharp/configuration.mdx
+++ b/fern/products/sdks/generators/csharp/configuration.mdx
@@ -108,7 +108,7 @@ When enabled, generates discriminated union types for API responses that can con
 </ParamField>
 
 <ParamField path="user-agent-name-from-package" type="boolean" default="false" required={false} toc={true}>
-When enabled, the generated SDK sends a `User-Agent: <NuGetPackageId>/<version>` header on every request when the API definition does not specify an explicit `User-Agent`. This mirrors the TypeScript generator's `<npm-package-name>/<version>` fallback and is useful for SDKs imported from OpenAPI, where the IR carries no `platformHeaders.userAgent`.
+When enabled, the generated SDK sends a `User-Agent: <NuGetPackageId>/<version>` header on every request when the API definition does not specify an explicit `User-Agent`. This mirrors other generators' `<package-name>/<version>` fallback.
 
-The prefix is taken from the cascade `package-id` → `namespace` → `PascalCase(<organization>_<api-name>)`, so it matches whatever name the SDK ships under on NuGet. Defaults to `false` to preserve the existing behavior of emitting no `User-Agent` header for OpenAPI-imported SDKs.
+The prefix is taken from the cascade `package-id` → `namespace` → `PascalCase(<organization>_<api-name>)`, so it matches whatever name the SDK ships under on NuGet. Defaults to `false`.
 </ParamField>

--- a/fern/products/sdks/generators/csharp/configuration.mdx
+++ b/fern/products/sdks/generators/csharp/configuration.mdx
@@ -106,3 +106,9 @@ When enabled, places core SDK classes (like base client classes and utilities) i
 <ParamField path="use-discriminated-unions" type="boolean" required={false} toc={true}>
 When enabled, generates discriminated union types for API responses that can contain multiple different object types. This provides type-safe handling of polymorphic responses.
 </ParamField>
+
+<ParamField path="user-agent-name-from-package" type="boolean" default="false" required={false} toc={true}>
+When enabled, the generated SDK sends a `User-Agent: <NuGetPackageId>/<version>` header on every request when the API definition does not specify an explicit `User-Agent`. This mirrors the TypeScript generator's `<npm-package-name>/<version>` fallback and is useful for SDKs imported from OpenAPI, where the IR carries no `platformHeaders.userAgent`.
+
+The prefix is taken from the cascade `package-id` → `namespace` → `PascalCase(<organization>_<api-name>)`, so it matches whatever name the SDK ships under on NuGet. Defaults to `false` to preserve the existing behavior of emitting no `User-Agent` header for OpenAPI-imported SDKs.
+</ParamField>


### PR DESCRIPTION
## Summary

Adds a `<ParamField>` entry to the C# SDK generator configuration reference (`fern/products/sdks/generators/csharp/configuration.mdx`) documenting the new opt-in `user-agent-name-from-package` boolean flag. When enabled, the generated C# SDK falls back to `User-Agent: <NuGetPackageId>/<version>` when the IR carries no explicit `platformHeaders.userAgent` — the C# parity for the TypeScript generator's `<npm-package-name>/<version>` fallback.

The new entry is placed alphabetically after `use-discriminated-unions` and explains:
- What the flag does and when it fires (no IR-supplied `User-Agent`, e.g. OpenAPI imports).
- That the prefix resolves through the cascade `package-id` → `namespace` → `PascalCase(<organization>_<api-name>)`, so the User-Agent always matches the package the SDK ships under on NuGet.
- That it defaults to `false` to preserve the existing "no User-Agent header" behavior.

The flag itself ships in [fern-api/fern#15802](https://github.com/fern-api/fern/pull/15802) (C# generator).

## Review & Testing Checklist for Human

- [ ] Don't merge this before [fern-api/fern#15802](https://github.com/fern-api/fern/pull/15802) is released — until the C# generator change ships, this page documents a config key that doesn't exist in any published version.
- [ ] Verify the cascade description (`package-id` → `namespace` → `PascalCase(<organization>_<api-name>)`) reads accurately for the C# audience and matches how `package-id` is described elsewhere on this page.
- [ ] Open the Vercel preview for the configuration page and confirm the new `<ParamField>` renders correctly (default badge, anchor, TOC entry) and that ordering against the surrounding entries looks right.

### Notes

The wording uses `NuGetPackageId` as the prefix shorthand, which matches the language already used on the page in the `package-id` entry and in the C# generator's source. No other docs pages currently reference this flag, so no cross-page link updates are needed.

Link to Devin session: https://app.devin.ai/sessions/02d3233caaac4616b6f38488ff08ef1a
Requested by: @fern-support