### PR TITLE
fix: remove existing digests from self-hosted changelog

### DIFF
--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-04.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-04.mdx
@@ -4,7 +4,6 @@
 FROM fernenterprise/fern-self-hosted:0.114.28
 ```
 
-Digest: `sha256:dd797d3deb1c76a525a06152bf55af6a1e454d9592b8c2fa9606806399b83c53`
 
 ### v0.114.29
 
@@ -12,4 +11,3 @@ Digest: `sha256:dd797d3deb1c76a525a06152bf55af6a1e454d9592b8c2fa9606806399b83c53
 FROM fernenterprise/fern-self-hosted:0.114.29
 ```
 
-Digest: `sha256:b87a00aaf47c8fa5d2d765be1d47c2a2131c3065fc2d6af6f518bdb64f5395d3`

--- a/fern/products/docs/pages/self-hosted/changelog/2026-05-05.mdx
+++ b/fern/products/docs/pages/self-hosted/changelog/2026-05-05.mdx
@@ -4,4 +4,3 @@
 FROM fernenterprise/fern-self-hosted:0.114.30
 ```
 
-Digest: `sha256:9a6efaec08dd1456be5004d88ac7c377d0204fd0ce46a5d6f85ca20d0a1a01c7`


### PR DESCRIPTION
## Summary
Removes the 3 existing SHA256 digests from the self-hosted changelog entries (v0.114.28, v0.114.29, v0.114.30). A companion PR in `fern-api/fern-platform` updates the publish workflow to automatically backfill all missing digests from Docker Hub on each run, so these will be re-populated with verified correct digests the next time a self-hosted version is published.

## Review & Testing Checklist for Human
- [ ] Merge the companion workflow PR in fern-platform first: fetch digests from Docker Hub + auto-backfill
- [ ] After both are merged, trigger a self-hosted release and verify the changelog entries get correct digests

### Notes
Companion PR: fern-api/fern-platform (fetch digests from Docker Hub and auto-backfill)

Link to Devin session: https://app.devin.ai/sessions/4603930dbd584afda978a29cf5338a7f
Requested by: @thesandlord