### PR TITLE
fix(ci): restrict preview-docs to same-repo PRs only

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   run:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # Only for commenting


### PR DESCRIPTION
## Summary

The `preview-docs.yml` workflow uses `pull_request_target` which makes secrets (like `FERN_TOKEN`) available even when checking out untrusted fork PR code. This is a known supply chain attack vector — a malicious fork PR could exfiltrate the token.

This PR adds a simple guard: `if: github.event.pull_request.head.repo.full_name == github.repository` — the job only runs when the PR originates from the same repository (i.e., from collaborators with push access). Fork PRs are skipped entirely.

## Review & Testing Checklist for Human

- [ ] Verify the `if` condition syntax is correct by opening a same-repo PR and confirming preview still generates
- [ ] Optionally test with a fork PR to confirm it is skipped (the job should show as "skipped" in the Actions tab)

### Notes

This is the minimal fix (Option A). If you later want fork PRs to also get previews, the workflow would need to be split into a two-step `pull_request` + `workflow_run` pattern.

Link to Devin session: https://app.devin.ai/sessions/4bb4632bdfe145d29582a1fae0ef3f2b
Requested by: @broady