### PR TITLE
ci: add zizmor GitHub Actions security analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Configures Dependabot to keep our GitHub Actions pinned references up to date.
+# Other ecosystems are intentionally not enabled here.
+#
+# Pair with the `unpinned-uses` policy enforced by `.github/workflows/zizmor.yml`:
+# zizmor requires actions to be pinned to a full-length commit SHA with the
+# version tag as a trailing comment. Dependabot will keep both in sync.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/auto-merge-on-docs-release.yml
+++ b/.github/workflows/auto-merge-on-docs-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find and merge dependent PRs
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const version = context.payload.client_payload.version;

--- a/.github/workflows/check-devin-pr-assignee.yml
+++ b/.github/workflows/check-devin-pr-assignee.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'devin-ai-integration[bot]' }}
     steps:
       - name: Auto-assign requester from PR description
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Create lychee config
         run: |
@@ -380,7 +382,7 @@ jobs:
 
 
       - name: Upload URLs (early, for debugging)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: urls
           path: |
@@ -392,7 +394,7 @@ jobs:
       - name: Check GitHub links (very low concurrency to avoid 503 rate limiting)
         id: lychee_github
         if: steps.extract_github_http.outputs.github_http_count != '0'
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: >-
             --no-progress
@@ -408,7 +410,7 @@ jobs:
 
       - name: Check non-GitHub links (high concurrency)
         id: lychee_main
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: >-
             --config lychee.toml
@@ -600,15 +602,15 @@ jobs:
           broken_count=$(wc -l < broken-links.txt | tr -d ' ')
           
           # Get rate limit stats
-          rate_limited="${{ steps.retry429.outputs.rate_limited_count }}"
+          rate_limited="${STEPS_RETRY429_OUTPUTS_RATE_LIMITED_COUNT}"
           rate_limited=${rate_limited:-0}
-          still_failing_429="${{ steps.retry429.outputs.still_failing_429 }}"
+          still_failing_429="${STEPS_RETRY429_OUTPUTS_STILL_FAILING_429}"
           still_failing_429=${still_failing_429:-0}
           
           # Get GitHub local verification stats
-          github_verified="${{ steps.verify_github.outputs.verified_count }}"
+          github_verified="${STEPS_VERIFY_GITHUB_OUTPUTS_VERIFIED_COUNT}"
           github_verified=${github_verified:-0}
-          github_missing="${{ steps.verify_github.outputs.missing_count }}"
+          github_missing="${STEPS_VERIFY_GITHUB_OUTPUTS_MISSING_COUNT}"
           github_missing=${github_missing:-0}
           
           # Build clean errors-only report
@@ -682,9 +684,9 @@ jobs:
           cat lychee-summary-table.md
           echo ""
           # Get repo-internal GitHub URL counts
-          verified_locally="${{ steps.retry429.outputs.verified_locally }}"
+          verified_locally="${STEPS_RETRY429_OUTPUTS_VERIFIED_LOCALLY}"
           verified_locally=${verified_locally:-0}
-          missing_locally="${{ steps.retry429.outputs.missing_locally }}"
+          missing_locally="${STEPS_RETRY429_OUTPUTS_MISSING_LOCALLY}"
           missing_locally=${missing_locally:-0}
           
           echo "Recovery Info:"
@@ -763,10 +765,17 @@ jobs:
             
             echo ""
           } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          STEPS_RETRY429_OUTPUTS_RATE_LIMITED_COUNT: ${{ steps.retry429.outputs.rate_limited_count }}
+          STEPS_RETRY429_OUTPUTS_STILL_FAILING_429: ${{ steps.retry429.outputs.still_failing_429 }}
+          STEPS_VERIFY_GITHUB_OUTPUTS_VERIFIED_COUNT: ${{ steps.verify_github.outputs.verified_count }}
+          STEPS_VERIFY_GITHUB_OUTPUTS_MISSING_COUNT: ${{ steps.verify_github.outputs.missing_count }}
+          STEPS_RETRY429_OUTPUTS_VERIFIED_LOCALLY: ${{ steps.retry429.outputs.verified_locally }}
+          STEPS_RETRY429_OUTPUTS_MISSING_LOCALLY: ${{ steps.retry429.outputs.missing_locally }}
 
       - name: Upload errors-only report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: lychee-report
           path: ./lychee-report.md
@@ -774,7 +783,7 @@ jobs:
 
       - name: Upload lychee outputs and verification results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: lychee-outputs
           path: |
@@ -787,7 +796,7 @@ jobs:
       - name: Create PR for broken links
         id: create-pr
         if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_github.outputs.has_missing == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           DEVIN_PROMPT: |
             @devin-ai-integration Please fix the broken links detected by the scheduled link checker.
@@ -1042,7 +1051,7 @@ jobs:
 
       - name: Send Slack notification for broken links
         if: steps.create-pr.outputs.pr_created == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           SLACK_TOKEN: ${{ secrets.DEVIN_AI_PR_BOT_SLACK_TOKEN }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
@@ -1085,14 +1094,18 @@ jobs:
         if: steps.check_failures.outputs.has_other_failures == 'true' || steps.retry429.outputs.has_429_failures == 'true' || steps.verify_github.outputs.has_missing == 'true'
         run: |
           echo "Link check failed!"
-          if [ "${{ steps.check_failures.outputs.has_other_failures }}" == "true" ]; then
+          if [ "${STEPS_CHECK_FAILURES_OUTPUTS_HAS_OTHER_FAILURES}" == "true" ]; then
             echo "There are broken links (non-429 failures) in the report."
           fi
-          if [ "${{ steps.retry429.outputs.has_429_failures }}" == "true" ]; then
+          if [ "${STEPS_RETRY429_OUTPUTS_HAS_429_FAILURES}" == "true" ]; then
             echo "Some URLs still returned 429 after exponential backoff retry."
             echo "These URLs may need to be excluded or the rate limit needs more time to reset."
           fi
-          if [ "${{ steps.verify_github.outputs.has_missing }}" == "true" ]; then
+          if [ "${STEPS_VERIFY_GITHUB_OUTPUTS_HAS_MISSING}" == "true" ]; then
             echo "Some GitHub URLs point to paths that don't exist in the repos."
           fi
           exit 1
+        env:
+          STEPS_CHECK_FAILURES_OUTPUTS_HAS_OTHER_FAILURES: ${{ steps.check_failures.outputs.has_other_failures }}
+          STEPS_RETRY429_OUTPUTS_HAS_429_FAILURES: ${{ steps.retry429.outputs.has_429_failures }}
+          STEPS_VERIFY_GITHUB_OUTPUTS_HAS_MISSING: ${{ steps.verify_github.outputs.has_missing }}

--- a/.github/workflows/fern-scribe.yml
+++ b/.github/workflows/fern-scribe.yml
@@ -16,12 +16,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -62,7 +63,7 @@ jobs:
 
       - name: Comment on issue
         if: success()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.issues.createComment({
@@ -74,7 +75,7 @@ jobs:
 
       - name: Comment on failure
         if: failure()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,7 +1,7 @@
 name: Preview Docs
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, ready_for_review]
     branches:
       - main

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -15,9 +15,10 @@ jobs:
       contents: read # For checking out code
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0  # Fetch full history for git diff
+          persist-credentials: false
 
       - name: Checkout PR
         run: |
@@ -25,7 +26,7 @@ jobs:
           git checkout pr-${{ github.event.pull_request.number }}
 
       - name: Setup Fern CLI
-        uses: fern-api/setup-fern-cli@v1
+        uses: fern-api/setup-fern-cli@d07601425e9c9ede8745d71ca75c4c462d98755d # v1
 
       - name: Generate preview URL
         id: generate-docs
@@ -43,8 +44,9 @@ jobs:
         id: page-links
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          STEPS_GENERATE_DOCS_OUTPUTS_PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
         run: |
-          PREVIEW_URL="${{ steps.generate-docs.outputs.preview_url }}"
+          PREVIEW_URL="${STEPS_GENERATE_DOCS_OUTPUTS_PREVIEW_URL}"
           CHANGED_FILES=$(git diff --name-only origin/main...HEAD -- '*.mdx' 2>/dev/null || echo "")
           
           if [ -z "$CHANGED_FILES" ] || [ -z "$PREVIEW_URL" ]; then
@@ -69,16 +71,19 @@ jobs:
 
       - name: Create comment content
         run: |
-          echo ":herb: **Preview your docs:** <${{ steps.generate-docs.outputs.preview_url }}>" > comment.md
+          echo ":herb: **Preview your docs:** <${STEPS_GENERATE_DOCS_OUTPUTS_PREVIEW_URL}>" > comment.md
           
-          if [ -n "${{ steps.page-links.outputs.page_links }}" ]; then
+          if [ -n "${STEPS_PAGE_LINKS_OUTPUTS_PAGE_LINKS}" ]; then
             echo "" >> comment.md
             echo "Here are the markdown pages you've updated:" >> comment.md
-            echo "${{ steps.page-links.outputs.page_links }}" >> comment.md
+            echo "${STEPS_PAGE_LINKS_OUTPUTS_PAGE_LINKS}" >> comment.md
           fi
+        env:
+          STEPS_GENERATE_DOCS_OUTPUTS_PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
+          STEPS_PAGE_LINKS_OUTPUTS_PAGE_LINKS: ${{ steps.page-links.outputs.page_links }}
 
       - name: Post PR comment
-        uses: thollander/actions-comment-pull-request@v2.4.3
+        uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
         with:
           filePath: comment.md
           comment_tag: preview-docs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,10 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup Fern CLI
-        uses: fern-api/setup-fern-cli@v1
+        uses: fern-api/setup-fern-cli@d07601425e9c9ede8745d71ca75c4c462d98755d # v1
 
       - name: Publish Docs
         env:

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           stale-pr-message: 'This PR is stale because it has been open 25 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           close-pr-message: 'This PR was closed because it has been inactive for 5 days after being marked stale.'

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -9,9 +9,10 @@ jobs:
   update-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: main
+          persist-credentials: false
       - name: update-csharp-version
         run: curl -s "https://registry.hub.docker.com/v2/repositories/fernapi/fern-csharp-sdk/tags" | jq -r -j '[.results[] | select(.name != "latest" and .name != "AUTO")] | .[0].name' > fern/snippets/version-number-csharp.mdx
       - name: update-go-version
@@ -36,7 +37,7 @@ jobs:
         run: curl -s https://api.github.com/repos/fern-api/fern/releases/latest | jq -r -j '.tag_name' > fern/snippets/version-number-cli.mdx
       - name: create PR
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: "update versions from docker hub"
           title: "Update versions from docker hub"
@@ -45,7 +46,7 @@ jobs:
           delete-branch: true
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash
@@ -53,6 +54,7 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         env:
           GH_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
+          STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
           echo "Approving PR"
-          gh pr review ${{ steps.cpr.outputs.pull-request-number }} --approve
+          gh pr review ${STEPS_CPR_OUTPUTS_PULL_REQUEST_NUMBER} --approve

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -28,7 +28,7 @@ jobs:
             fern/**/*.mdx
           files_ignore: |
             **/changelog/**
-      - uses: errata-ai/vale-action@reviewdog
+      - uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
           files: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -15,11 +15,13 @@ jobs:
       github.event.pull_request.user.login != 'fern-support' &&
       github.event.pull_request.user.login != 'github-actions'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
           files: |
             fern/**/*.md

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required to upload SARIF results to code scanning.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary

Installs [zizmor](https://docs.zizmor.sh/) — a static analyzer for GitHub Actions workflows — and applies its safe auto-fixes across all existing workflows. Also adds a `github-actions`-only Dependabot config (7-day cooldown) so the SHA pins stay current.

### What's in this PR

1. **`.github/workflows/zizmor.yml`** — new workflow that runs zizmor on every push to `main` and every PR. Findings are uploaded as SARIF to **Security → Code scanning**.
2. **9 existing workflows auto-fixed by `zizmor --fix=all`** — SHA-pinned all `uses:` references (with `# vX.Y.Z` comments for Dependabot), added `persist-credentials: false` to `actions/checkout`, env-var-indirected `${{ ... }}` interpolations inside `run:` blocks.
3. **`.github/workflows/vale.yml`** — pinned `errata-ai/vale-action` from the `@reviewdog` branch to the latest stable tag `v2.1.1` (SHA `d89dee975228ae261d22c15adcd03578634d429c`). Dependabot will track this from here.
4. **`.github/workflows/preview-docs.yml`** — swapped trigger from `pull_request_target` to `pull_request`. The `pull_request_target` trigger was needed to grant secrets to fork PRs, but we explicitly *don't* want that (we already gate fork PRs out with `if: head.repo.full_name == github.repository`). `pull_request` is the right primitive: same-repo PRs still get secrets and `pull-requests: write`; fork PRs don't get secrets at all. The same-repo `if:` guard is retained as belt-and-braces.
5. **`.github/dependabot.yml`** — scoped to `github-actions` only (no other ecosystems enabled), `cooldown.default-days: 7` so upstream actions get a soak period before we bump pins.

### Findings: 51 → 4

`zizmor --fix=all` resolved 47 of 51 findings automatically. Manual fixes in this PR resolved 2 more (vale-action pin + preview-docs trigger). Remaining:

- **`excessive-permissions`** × 4 (all Medium): `auto-merge-on-docs-release.yml`, `publish-docs.yml`, `update-versions.yml`, `vale.yml`. These workflows have no top-level `permissions:` block, so the runner inherits the repo default. Fix is mechanical (add a minimal `permissions:` block) but mis-scoping silently breaks the workflows, so I'd rather do these in a separate, focused PR.

### How pinning + Dependabot works

zizmor's `unpinned-uses` policy (default since v1.20.0) requires every `uses:` to be a full-length commit SHA with the version tag as a trailing comment:

```yaml
uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
```

The SHA is the security boundary (immutable). The `# v6.0.2` comment is what Dependabot reads to find the next version. Dependabot updates both the SHA and the comment in lockstep.

The 7-day `cooldown.default-days` means a freshly published version sits for a week before Dependabot opens a bump PR — gives time for any "release-day" issues to surface upstream.

## Review & Testing Checklist for Human

- [ ] Verify the `Preview Docs` workflow runs correctly on this PR (the trigger change is the most behavior-affecting one — confirm the preview build/comment still happens).
- [ ] Confirm the `Vale` workflow still produces review comments on a PR that touches markdown content (pin moved from `@reviewdog` branch to `v2.1.1`).
- [ ] After merge, check **Security → Code scanning** to confirm zizmor's SARIF results are uploading and the 4 remaining `excessive-permissions` findings appear.
- [ ] Confirm Dependabot opens its first batch of `github-actions` PRs within a week, with `[dependencies, github-actions]` labels.

### Notes

The 4 remaining `excessive-permissions` findings (`auto-merge-on-docs-release.yml`, `publish-docs.yml`, `update-versions.yml`, `vale.yml`) are intentionally deferred to a focused follow-up PR — they need per-workflow analysis of minimal scopes, and mis-scoping is silently destructive.


Link to Devin session: https://app.devin.ai/sessions/45278f18466b470c9e50479b07dacfdd
Requested by: @broady