### PR TITLE
docs(cli-generator): add feature documentation for CLI SDK

### DIFF
--- a/fern/products/api-def/openapi/extensions/availability.mdx
+++ b/fern/products/api-def/openapi/extensions/availability.mdx
@@ -5,7 +5,7 @@ description: Mark API endpoint availability in OpenAPI with `x-fern-availability
 ---
 
 
-The `x-fern-availability` extension is used to mark the availability of an endpoint within your OpenAPI definition. The availability information propagates into the generated Fern Docs website as visual tags. 
+The `x-fern-availability` extension marks the availability of an endpoint within your OpenAPI definition. The availability information propagates into the generated Fern Docs website as visual tags and into [generated CLIs](/learn/cli-generator/get-started/openapi-extensions#availability-badges) as badges in `--help` output.
 
 You can configure the `availability` of sections in your API Reference documentation in your [`docs.yml` file](/learn/docs/configuration/site-level-settings). 
 

--- a/fern/products/api-def/openapi/extensions/availability.mdx
+++ b/fern/products/api-def/openapi/extensions/availability.mdx
@@ -5,7 +5,7 @@ description: Mark API endpoint availability in OpenAPI with `x-fern-availability
 ---
 
 
-The `x-fern-availability` extension marks the availability of an endpoint within your OpenAPI definition. The availability information propagates into generated Fern Docs as visual tags, into SDKs, and into [CLIs](/learn/cli-generator/get-started/openapi-extensions#availability-badges) as badges in `--help` output.
+The `x-fern-availability` extension is used to mark the availability of an endpoint within your OpenAPI definition. The availability information propagates into the generated Fern Docs website as visual tags, SDKs, and [CLIs](/learn/cli-generator/get-started/openapi-extensions#availability-badges).
 
 You can configure the `availability` of sections in your API Reference documentation in your [`docs.yml` file](/learn/docs/configuration/site-level-settings). 
 

--- a/fern/products/api-def/openapi/extensions/availability.mdx
+++ b/fern/products/api-def/openapi/extensions/availability.mdx
@@ -5,7 +5,7 @@ description: Mark API endpoint availability in OpenAPI with `x-fern-availability
 ---
 
 
-The `x-fern-availability` extension marks the availability of an endpoint within your OpenAPI definition. The availability information propagates into the generated Fern Docs website as visual tags and into [generated CLIs](/learn/cli-generator/get-started/openapi-extensions#availability-badges) as badges in `--help` output.
+The `x-fern-availability` extension marks the availability of an endpoint within your OpenAPI definition. The availability information propagates into generated Fern Docs as visual tags, into SDKs, and into [CLIs](/learn/cli-generator/get-started/openapi-extensions#availability-badges) as badges in `--help` output.
 
 You can configure the `availability` of sections in your API Reference documentation in your [`docs.yml` file](/learn/docs/configuration/site-level-settings). 
 

--- a/fern/products/api-def/openapi/extensions/ignore.mdx
+++ b/fern/products/api-def/openapi/extensions/ignore.mdx
@@ -5,7 +5,7 @@ description: Use x-fern-ignore to exclude endpoints, schemas, properties, or par
 ---
 
 
-If you want Fern to skip reading any endpoints, schemas, properties, or parameters, use the `x-fern-ignore` extension.
+If you want Fern to skip reading any endpoints, schemas, properties, or parameters, use the `x-fern-ignore` extension. Ignored operations and parameters are also excluded from [generated CLIs](/learn/cli-generator/get-started/openapi-extensions#filtering).
 
 ## Ignore an endpoint
 

--- a/fern/products/api-def/openapi/extensions/ignore.mdx
+++ b/fern/products/api-def/openapi/extensions/ignore.mdx
@@ -5,7 +5,7 @@ description: Use x-fern-ignore to exclude endpoints, schemas, properties, or par
 ---
 
 
-If you want Fern to skip reading any endpoints, schemas, properties, or parameters, use the `x-fern-ignore` extension. Ignored operations and parameters are also excluded from [generated CLIs](/learn/cli-generator/get-started/openapi-extensions#filtering).
+If you want Fern to skip reading any endpoints, schemas, properties, or parameters, use the `x-fern-ignore` extension.
 
 ## Ignore an endpoint
 

--- a/fern/products/api-def/openapi/extensions/method-names.mdx
+++ b/fern/products/api-def/openapi/extensions/method-names.mdx
@@ -5,7 +5,7 @@ description: Use `x-fern-sdk-method-name` and `x-fern-sdk-group-name` to finetun
 ---
 
 
-Use the `x-fern-sdk-group-name` and `x-fern-sdk-method-name` extensions to control how endpoints are organized in your SDK. These extensions also determine the [CLI Generator's](/learn/cli-generator/get-started/openapi-extensions) subcommand hierarchy — group names become nested subcommands and method names become leaf commands.
+Use the `x-fern-sdk-group-name` and `x-fern-sdk-method-name` extensions to control how endpoints are organized in your [SDKs](/learn/sdks/introduction) and [CLIs](/learn/cli-generator/get-started/openapi-extensions).
 
 <Note title="Fern automatically parses `operationId`">
   If no extensions are present, Fern uses your operation ID to generate SDK method names. Format operation IDs as `{tag_name}_{operation_name}` (example: `users_get`) to automatically generate methods like `users.get()`. If the operation ID doesn't start with a tag, Fern uses it directly as the method name.

--- a/fern/products/api-def/openapi/extensions/method-names.mdx
+++ b/fern/products/api-def/openapi/extensions/method-names.mdx
@@ -5,7 +5,7 @@ description: Use `x-fern-sdk-method-name` and `x-fern-sdk-group-name` to finetun
 ---
 
 
-Use the `x-fern-sdk-group-name` and `x-fern-sdk-method-name` extensions to control how endpoints are organized in your SDK.
+Use the `x-fern-sdk-group-name` and `x-fern-sdk-method-name` extensions to control how endpoints are organized in your SDK. These extensions also determine the [CLI Generator's](/learn/cli-generator/get-started/openapi-extensions) subcommand hierarchy — group names become nested subcommands and method names become leaf commands.
 
 <Note title="Fern automatically parses `operationId`">
   If no extensions are present, Fern uses your operation ID to generate SDK method names. Format operation IDs as `{tag_name}_{operation_name}` (example: `users_get`) to automatically generate methods like `users.get()`. If the operation ID doesn't start with a tag, Fern uses it directly as the method name.

--- a/fern/products/api-def/openapi/extensions/overview.md
+++ b/fern/products/api-def/openapi/extensions/overview.md
@@ -4,7 +4,7 @@ headline: Extensions overview (OpenAPI)
 description: Learn about OpenAPI extensions in Fern. Customize authentication, SDK methods, versioning, and more for better API specs.
 ---
 
-Fern supports a variety of OpenAPI extensions that enhance your API specification and generate higher-quality SDKs. 
+Fern supports a variety of OpenAPI extensions that enhance your API specification and generate higher-quality SDKs and [CLIs](/learn/cli-generator/get-started/openapi-extensions).
 
 You can apply these extensions in two ways: by overlaying them in a separate file or by embedding them directly in your OpenAPI specification. See [Overlays](/learn/api-definitions/openapi/overlays) for more information.
 

--- a/fern/products/api-def/openapi/extensions/pagination.mdx
+++ b/fern/products/api-def/openapi/extensions/pagination.mdx
@@ -7,7 +7,7 @@ description: Configure auto-pagination for list endpoints using the x-fern-pagin
 
 <Markdown src="/snippets/pro-plan.mdx"/>
 
-The `x-fern-pagination` extension configures auto-pagination for list endpoints in your OpenAPI specification. [Fern's generated SDKs](/learn/sdks/deep-dives/auto-pagination) provide simple iterators that handle pagination automatically, so SDK users can loop through all results without managing pagination complexity manually.
+The `x-fern-pagination` extension configures auto-pagination for list endpoints in your OpenAPI specification. [Fern's generated SDKs](/learn/sdks/deep-dives/auto-pagination) provide simple iterators that handle pagination automatically, and [generated CLIs](/learn/cli-generator/get-started/openapi-extensions#pagination) expose `--page-all`, `--page-limit`, and `--page-delay` flags on annotated endpoints.
 
 To configure pagination:
 

--- a/fern/products/api-def/openapi/extensions/pagination.mdx
+++ b/fern/products/api-def/openapi/extensions/pagination.mdx
@@ -7,7 +7,7 @@ description: Configure auto-pagination for list endpoints using the x-fern-pagin
 
 <Markdown src="/snippets/pro-plan.mdx"/>
 
-The `x-fern-pagination` extension configures auto-pagination for list endpoints in your OpenAPI specification. [Fern's generated SDKs](/learn/sdks/deep-dives/auto-pagination) provide simple iterators that handle pagination automatically, and [generated CLIs](/learn/cli-generator/get-started/openapi-extensions#pagination) expose `--page-all`, `--page-limit`, and `--page-delay` flags on annotated endpoints.
+The `x-fern-pagination` extension configures auto-pagination for list endpoints in your OpenAPI specification. [SDK](/learn/sdks/deep-dives/auto-pagination) and [CLI](/learn/cli-generator/get-started/openapi-extensions#pagination) users get automatic pagination without managing page tokens manually.
 
 To configure pagination:
 

--- a/fern/products/api-def/openapi/overlays.mdx
+++ b/fern/products/api-def/openapi/overlays.mdx
@@ -7,7 +7,7 @@ description: Use the OpenAPI Overlay Specification to customize your OpenAPI def
 Overlays let you customize your OpenAPI specification without modifying the original file. This is useful when:
 
 - Your API specification is auto-generated from server code
-- You need different configurations for SDKs versus documentation
+- You need different configurations for SDKs, documentation, or [generated CLIs](/learn/cli-generator/get-started/customization#overrides-and-overlays)
 - You want to add Fern configurations like pagination or SDK method names
 - You want to make bulk changes across many endpoints using JSONPath wildcards
 

--- a/fern/products/api-def/pages/overrides.mdx
+++ b/fern/products/api-def/pages/overrides.mdx
@@ -7,7 +7,7 @@ description: Customize your API definition using a separate overrides file.
 Use an overrides file to customize your OpenAPI, AsyncAPI, or OpenRPC definition without modifying the original spec. This is useful when:
 
 * Your API specification is auto-generated from server code
-* You need different configurations for SDKs versus documentation
+* You need different configurations for SDKs, documentation, or [generated CLIs](/learn/cli-generator/get-started/customization#overrides-and-overlays)
 
 Overrides are available for OpenAPI, AsyncAPI, and OpenRPC specifications.
 

--- a/fern/products/cli-generator/authentication.mdx
+++ b/fern/products/cli-generator/authentication.mdx
@@ -1,7 +1,12 @@
 ---
 title: Authentication
 description: Configure how generated CLIs authenticate with your API using environment variables, CLI flags, files, or fallback chains.
+availability: beta
 ---
+
+<Note title="Early access">
+The CLI generator is in early access. [Reach out](https://buildwithfern.com/book-demo?type=cli) to get started.
+</Note>
 
 Each generated CLI reads authentication credentials from the security schemes declared in your OpenAPI spec. Credentials can come from environment variables, CLI flags, files, or a combination of these through fallback chains.
 

--- a/fern/products/cli-generator/authentication.mdx
+++ b/fern/products/cli-generator/authentication.mdx
@@ -1,0 +1,63 @@
+---
+title: Authentication
+description: Configure how generated CLIs authenticate with your API using environment variables, CLI flags, files, or fallback chains.
+---
+
+Each generated CLI reads authentication credentials from the security schemes declared in your OpenAPI spec. Credentials can come from environment variables, CLI flags, files, or a combination of these through fallback chains.
+
+Without a credential, the CLI still works — you can explore the command tree, view help, and use `--dry-run`.
+
+## Credential sources
+
+The CLI supports several ways to supply credentials, configured at build time.
+
+| Source | Description |
+| --- | --- |
+| Environment variable | Read from an env var (the most common option). |
+| CLI flag | Auto-registered as a `--<flag-name>` global flag. |
+| File | Read trimmed contents from a file path (`~` is expanded). |
+| Literal | Baked into the binary at compile time. |
+| Fallback chain | Try multiple sources in order; first non-empty value wins. |
+
+A typical fallback chain lets the CLI flag override the env var, which in turn overrides a file:
+
+```bash
+# CLI flag takes priority
+box users get-current-user --api-token sk-123
+
+# Otherwise falls back to the environment variable
+export BOX_API_KEY=sk-123
+box users get-current-user
+
+# Otherwise reads from a file
+echo "sk-123" > ~/.box/token
+box users get-current-user
+```
+
+## Supported auth schemes
+
+The CLI supports every scheme type that OpenAPI's `securitySchemes` defines:
+
+| Scheme | How the CLI applies it |
+| --- | --- |
+| Bearer (`http: bearer`) | Sends `Authorization: Bearer <token>`. |
+| API key (`apiKey`) | Sends the key in the configured header (for example, `X-Auth-Token`). |
+| Basic (`http: basic`) | Sends `Authorization: Basic <base64(user:pass)>`. Each field has its own credential source. |
+| OAuth 2 | Treated as bearer — sends `Authorization: Bearer <token>`. |
+
+## Auth strategies
+
+When a spec declares multiple security schemes, the CLI composes them according to one of these strategies:
+
+| Strategy | Behavior |
+| --- | --- |
+| Auto | Default. Infers the right composition from the spec's `security` blocks. |
+| Any | The API accepts any one of the declared schemes. The first scheme with a credential wins. |
+| All | The API requires every scheme simultaneously (for example, HMAC signature plus API key). |
+| Routing | Per-operation dispatch. Each endpoint's `security` block determines which schemes to use. |
+
+Operations that declare `security: []` (an empty list) opt out of authentication entirely — no credentials are sent regardless of what's configured.
+
+## Help output
+
+Every generated CLI includes a dynamically rendered `Authentication:` section in its `--help` output listing every scheme, the expected env var or flag, and whether a credential is detected.

--- a/fern/products/cli-generator/cli-generator.yml
+++ b/fern/products/cli-generator/cli-generator.yml
@@ -4,4 +4,15 @@ navigation:
       - page: Overview
         path: ./overview.mdx
         slug: overview
-    
+      - page: Features
+        path: ./features.mdx
+        slug: features
+      - page: Authentication
+        path: ./authentication.mdx
+        slug: authentication
+      - page: OpenAPI extensions
+        path: ./openapi-extensions.mdx
+        slug: openapi-extensions
+      - page: Customization
+        path: ./customization.mdx
+        slug: customization

--- a/fern/products/cli-generator/customization.mdx
+++ b/fern/products/cli-generator/customization.mdx
@@ -1,0 +1,87 @@
+---
+title: Customization
+description: Customize generated CLIs with overrides, overlays, multi-spec merging, custom commands, and server URL templating.
+---
+
+## Overrides and overlays
+
+The CLI generator supports both [overrides](/learn/api-definitions/openapi/overrides) and [overlays](/learn/api-definitions/openapi/overlays) for customizing the OpenAPI spec before the CLI is built. This lets you add Fern extensions, rename parameters, or remove internal endpoints without modifying your original spec.
+
+Overlays follow the [OpenAPI Overlay Specification](https://spec.openapis.org/overlay/v1.0.0.html) and use JSONPath to target elements:
+
+```yaml title="overlay.yaml"
+overlay: 1.0.0
+info:
+  title: CLI customizations
+  version: 1.0.0
+actions:
+  - target: $.paths['/plants'].get
+    update:
+      x-fern-sdk-group-name: plants
+      x-fern-sdk-method-name: list
+  - target: $.paths['/internal/debug']
+    remove: true
+```
+
+When both are present, overrides are applied first, then overlays.
+
+## Multi-spec merging
+
+A single CLI can combine multiple OpenAPI specs into one command tree. This is useful for APIs that split their spec across domains or versions.
+
+Specs can be merged flat (all commands at the top level) or under a namespace prefix:
+
+```rust title="main.rs"
+CliApp::new("my-api")
+    .spec(include_str!("core.yaml"))
+    .spec_under("billing", include_str!("billing.yaml"))
+    .run()
+```
+
+This produces a CLI where core commands live at the top level and billing commands live under a `billing` subcommand:
+
+```bash
+my-api users list          # from core.yaml
+my-api billing invoices list  # from billing.yaml
+```
+
+When a namespace matches a top-level resource in the incoming spec, the CLI hoists that resource's methods into the namespace to avoid repetition (for example, `billing billing invoices list` becomes `billing invoices list`).
+
+## Server URL variables
+
+For APIs with templated server URLs (such as `https://api.example.com/stores/{store_hash}/v3`), the CLI automatically exposes each template variable as a CLI flag and environment variable.
+
+```bash
+# Pass the variable as a flag
+bigcommerce --store-hash abc123 v3 customers list
+
+# Or set it via an environment variable
+export BIGCOMMERCE_STORE_HASH=abc123
+bigcommerce v3 customers list
+```
+
+## Custom commands
+
+Generated CLIs can include custom commands alongside the spec-derived ones. Custom commands have access to the same API executor, so they can chain multiple API calls into a single workflow.
+
+```rust title="main.rs"
+CliApp::new("my-api")
+    .spec(include_str!("openapi.yaml"))
+    .auth_scheme_env("bearerAuth", "MY_API_TOKEN")
+    .command(whoami_cmd(), whoami_handler)
+    .run()
+```
+
+## GraphQL support
+
+The CLI generator also supports GraphQL APIs. Instead of an OpenAPI spec, you provide a GraphQL introspection schema. Queries and mutations become leaf commands.
+
+```rust title="main.rs"
+use fern_cli_sdk::graphql::CliApp;
+
+CliApp::new("linear")
+    .spec(include_str!("schema.json"))
+    .endpoint("https://api.linear.app/graphql")
+    .auth_scheme_env("apiKey", "LINEAR_API_KEY")
+    .run()
+```

--- a/fern/products/cli-generator/customization.mdx
+++ b/fern/products/cli-generator/customization.mdx
@@ -1,12 +1,14 @@
 ---
 title: Customization
-description: Customize generated CLIs with overrides, overlays, multi-spec merging, custom commands, and server URL templating.
+description: Customize generated CLIs with overrides, overlays, multi-spec merging, and custom commands.
 availability: beta
 ---
 
 <Note title="Early access">
 The CLI generator is in early access. [Reach out](https://buildwithfern.com/book-demo?type=cli) to get started.
 </Note>
+
+A generated CLI can be customized at three levels: the OpenAPI spec it's built from, the configuration that combines multiple specs into a single command tree, and code that adds custom commands alongside the spec-derived ones.
 
 ## Overrides and overlays
 
@@ -52,19 +54,6 @@ my-api billing invoices list  # from billing.yaml
 
 When a namespace matches a top-level resource in the incoming spec, the CLI hoists that resource's methods into the namespace to avoid repetition (for example, `billing billing invoices list` becomes `billing invoices list`).
 
-## Server URL variables
-
-For APIs with templated server URLs (such as `https://api.example.com/stores/{store_hash}/v3`), the CLI automatically exposes each template variable as a CLI flag and environment variable.
-
-```bash
-# Pass the variable as a flag
-bigcommerce --store-hash abc123 v3 customers list
-
-# Or set it via an environment variable
-export BIGCOMMERCE_STORE_HASH=abc123
-bigcommerce v3 customers list
-```
-
 ## Custom commands
 
 Generated CLIs can include custom commands alongside the spec-derived ones. Custom commands have access to the same API executor, so they can chain multiple API calls into a single workflow.
@@ -77,16 +66,3 @@ CliApp::new("my-api")
     .run()
 ```
 
-## GraphQL support
-
-The CLI generator also supports GraphQL APIs. Instead of an OpenAPI spec, you provide a GraphQL introspection schema. Queries and mutations become leaf commands.
-
-```rust title="main.rs"
-use fern_cli_sdk::graphql::CliApp;
-
-CliApp::new("linear")
-    .spec(include_str!("schema.json"))
-    .endpoint("https://api.linear.app/graphql")
-    .auth_scheme_env("apiKey", "LINEAR_API_KEY")
-    .run()
-```

--- a/fern/products/cli-generator/customization.mdx
+++ b/fern/products/cli-generator/customization.mdx
@@ -1,7 +1,12 @@
 ---
 title: Customization
 description: Customize generated CLIs with overrides, overlays, multi-spec merging, custom commands, and server URL templating.
+availability: beta
 ---
+
+<Note title="Early access">
+The CLI generator is in early access. [Reach out](https://buildwithfern.com/book-demo?type=cli) to get started.
+</Note>
 
 ## Overrides and overlays
 

--- a/fern/products/cli-generator/features.mdx
+++ b/fern/products/cli-generator/features.mdx
@@ -8,7 +8,7 @@ availability: beta
 The CLI generator is in early access. [Reach out](https://buildwithfern.com/book-demo?type=cli) to get started.
 </Note>
 
-Generated CLIs ship as a single statically linked binary with no runtime dependencies. Every feature described here works out of the box.
+Every command in a generated CLI accepts the same set of runtime flags and environment variables, regardless of the underlying API. This page documents what's available out of the box: output formats, pagination, dry-run previewing, TLS and proxy configuration, exit codes, and structured logging.
 
 ## Output formatting
 
@@ -71,6 +71,19 @@ contoso plants get --params '{"plantId": "abc"}'
 # Request body
 contoso plants create \
   --json '{"name": "Monstera", "species": "Monstera deliciosa", "sunlight": "indirect"}'
+```
+
+## Server URL variables
+
+For APIs with [templated server URLs](/learn/api-definitions/openapi/extensions/server-names-and-url-templating) (such as `https://api.example.com/stores/{store_hash}/v3`), the CLI automatically exposes each template variable as a CLI flag and environment variable.
+
+```bash
+# Pass the variable as a flag
+bigcommerce --store-hash abc123 v3 customers list
+
+# Or set it via an environment variable
+export BIGCOMMERCE_STORE_HASH=abc123
+bigcommerce v3 customers list
 ```
 
 ## File uploads and downloads

--- a/fern/products/cli-generator/features.mdx
+++ b/fern/products/cli-generator/features.mdx
@@ -1,0 +1,131 @@
+---
+title: Features
+description: Explore the capabilities of Fern's generated CLIs, including output formatting, pagination, dry-run mode, and TLS configuration.
+---
+
+Generated CLIs ship as a single statically linked binary with no runtime dependencies. Every feature described here works out of the box.
+
+## Output formatting
+
+Use the `--format` flag to control how responses are displayed.
+
+| Format | Flag | Description |
+| --- | --- | --- |
+| JSON | `--format json` | Default. Pretty-printed JSON. |
+| Table | `--format table` | Columnar table. Nested objects flatten to `parent.child` column names. |
+| YAML | `--format yaml` | YAML representation of the response. |
+| CSV | `--format csv` | Comma-separated values, suitable for piping into spreadsheet tools. |
+
+```bash
+# Display customers in a table
+bigcommerce v3 customers list --format table
+
+# Export orders as CSV
+bigcommerce v3 orders list --format csv > orders.csv
+```
+
+## Dry-run mode
+
+Pass `--dry-run` to validate arguments and preview the HTTP request without sending it. The CLI prints the method, URL, headers, and body it would send, then exits.
+
+```bash
+box users get-current-user --dry-run
+```
+
+## Pagination
+
+For endpoints annotated with [`x-fern-pagination`](/learn/api-definitions/openapi/extensions/pagination), the CLI auto-paginates when the `--page-all` flag is set.
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--page-all` | Fetch every page and emit one JSON line per page (NDJSON). | Off |
+| `--page-limit <N>` | Maximum number of pages to fetch. | 10 |
+| `--page-delay <MS>` | Delay in milliseconds between page requests. | 100 |
+
+```bash
+# Fetch all scheduled events, one JSON line per page
+box scheduled-events list-scheduled-events \
+  --params '{"user": "..."}' --page-all
+
+# Limit to 5 pages with a 200 ms delay
+box scheduled-events list-scheduled-events \
+  --params '{"user": "..."}' --page-all --page-limit 5 --page-delay 200
+```
+
+Paginated output works with all output formats. For table and CSV formats, headers are only emitted on the first page so the output concatenates cleanly.
+
+## Passing parameters
+
+| Flag | Purpose |
+| --- | --- |
+| `--params <JSON>` | URL path and query parameters as a JSON object. |
+| `--json <JSON>` | Request body for POST, PUT, and PATCH methods. |
+
+```bash
+# Path + query parameters
+box scheduled-events list-scheduled-events \
+  --params '{"user": "https://api.example.com/users/abc"}'
+
+# Request body
+box webhooks create-webhook-subscription \
+  --json '{"url": "https://example.com/hook", "events": ["invitee.created"], "scope": "organization"}'
+```
+
+## File uploads and downloads
+
+For endpoints with `format: binary` request bodies, pass a file path as the `--file` argument. For binary responses, use `--output <PATH>` to save the response body to a file.
+
+## Exit codes
+
+| Code | Meaning | Example cause |
+| --- | --- | --- |
+| `0` | Success | Command completed normally. |
+| `1` | API error | Server returned a 4xx/5xx response. |
+| `2` | Auth error | Credentials missing or invalid. |
+| `3` | Validation error | Bad arguments, unknown command, or invalid JSON. |
+| `4` | Discovery error | Couldn't load API schema. |
+| `5` | Internal error | Unexpected failure. |
+
+All errors are emitted as structured JSON on stderr, making them easy to parse in scripts and CI pipelines.
+
+## TLS, proxies, and CA bundles
+
+Every generated CLI honors environment variables for TLS and proxy configuration at runtime. Variables are scoped by binary name — `<NAME>` is the CLI's binary name uppercased with hyphens mapped to underscores (for example, `BIGCOMMERCE`).
+
+| Variable | Effect |
+| --- | --- |
+| `<NAME>_CA_BUNDLE` | Path to a PEM file appended to the default trust roots. |
+| `<NAME>_INSECURE=1` | Disable TLS verification. Logs a warning. Not for production use. |
+| `<NAME>_PROXY` | HTTP/HTTPS proxy URL, overriding `HTTPS_PROXY` / `HTTP_PROXY`. |
+| `<NAME>_NO_PROXY` | Comma-separated proxy bypass list scoped to this CLI. |
+| `<NAME>_TIMEOUT_SECS` | Total request timeout. None by default. |
+| `<NAME>_CONNECT_TIMEOUT_SECS` | Connection-establishment timeout. |
+
+Standard environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, `SSL_CERT_FILE`) are honored when the scoped overrides are absent.
+
+<Accordion title="Common scenarios">
+
+**Behind a MITM proxy (Proxyman, Charles, mitmproxy):**
+
+```bash
+export SSL_CERT_FILE=~/path/to/proxyman-ca.pem
+export HTTPS_PROXY=http://127.0.0.1:9090
+bigcommerce v3 customers list
+```
+
+**Corporate network with a custom root CA:**
+
+```bash
+export BIGCOMMERCE_CA_BUNDLE=/etc/ssl/corp-roots.pem
+bigcommerce v3 customers list
+```
+
+</Accordion>
+
+## Structured logging
+
+Logging is off by default. Set `FERN_CLI_LOG` to a [tracing filter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) to emit structured logs to stderr. Set `FERN_CLI_LOG_FILE` to a directory path to write daily rotated JSON log files.
+
+```bash
+FERN_CLI_LOG=debug box users get-current-user
+```

--- a/fern/products/cli-generator/features.mdx
+++ b/fern/products/cli-generator/features.mdx
@@ -1,7 +1,12 @@
 ---
 title: Features
 description: Explore the capabilities of Fern's generated CLIs, including output formatting, pagination, dry-run mode, and TLS configuration.
+availability: beta
 ---
+
+<Note title="Early access">
+The CLI generator is in early access. [Reach out](https://buildwithfern.com/book-demo?type=cli) to get started.
+</Note>
 
 Generated CLIs ship as a single statically linked binary with no runtime dependencies. Every feature described here works out of the box.
 

--- a/fern/products/cli-generator/features.mdx
+++ b/fern/products/cli-generator/features.mdx
@@ -17,11 +17,11 @@ Use the `--format` flag to control how responses are displayed.
 | CSV | `--format csv` | Comma-separated values, suitable for piping into spreadsheet tools. |
 
 ```bash
-# Display customers in a table
-bigcommerce v3 customers list --format table
+# Display plants in a table
+contoso plants list --format table
 
 # Export orders as CSV
-bigcommerce v3 orders list --format csv > orders.csv
+contoso orders list --format csv > orders.csv
 ```
 
 ## Dry-run mode
@@ -29,7 +29,7 @@ bigcommerce v3 orders list --format csv > orders.csv
 Pass `--dry-run` to validate arguments and preview the HTTP request without sending it. The CLI prints the method, URL, headers, and body it would send, then exits.
 
 ```bash
-box users get-current-user --dry-run
+contoso plants get --params '{"plantId": "abc"}' --dry-run
 ```
 
 ## Pagination
@@ -43,13 +43,11 @@ For endpoints annotated with [`x-fern-pagination`](/learn/api-definitions/openap
 | `--page-delay <MS>` | Delay in milliseconds between page requests. | 100 |
 
 ```bash
-# Fetch all scheduled events, one JSON line per page
-box scheduled-events list-scheduled-events \
-  --params '{"user": "..."}' --page-all
+# Fetch all plants, one JSON line per page
+contoso plants list --page-all
 
 # Limit to 5 pages with a 200 ms delay
-box scheduled-events list-scheduled-events \
-  --params '{"user": "..."}' --page-all --page-limit 5 --page-delay 200
+contoso plants list --page-all --page-limit 5 --page-delay 200
 ```
 
 Paginated output works with all output formats. For table and CSV formats, headers are only emitted on the first page so the output concatenates cleanly.
@@ -63,12 +61,11 @@ Paginated output works with all output formats. For table and CSV formats, heade
 
 ```bash
 # Path + query parameters
-box scheduled-events list-scheduled-events \
-  --params '{"user": "https://api.example.com/users/abc"}'
+contoso plants get --params '{"plantId": "abc"}'
 
 # Request body
-box webhooks create-webhook-subscription \
-  --json '{"url": "https://example.com/hook", "events": ["invitee.created"], "scope": "organization"}'
+contoso plants create \
+  --json '{"name": "Monstera", "species": "Monstera deliciosa", "sunlight": "indirect"}'
 ```
 
 ## File uploads and downloads
@@ -90,7 +87,7 @@ All errors are emitted as structured JSON on stderr, making them easy to parse i
 
 ## TLS, proxies, and CA bundles
 
-Every generated CLI honors environment variables for TLS and proxy configuration at runtime. Variables are scoped by binary name — `<NAME>` is the CLI's binary name uppercased with hyphens mapped to underscores (for example, `BIGCOMMERCE`).
+Every generated CLI honors environment variables for TLS and proxy configuration at runtime. Variables are scoped by binary name — `<NAME>` is the CLI's binary name uppercased with hyphens mapped to underscores (for example, `CONTOSO`).
 
 | Variable | Effect |
 | --- | --- |
@@ -110,22 +107,22 @@ Standard environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, `SSL_CE
 ```bash
 export SSL_CERT_FILE=~/path/to/proxyman-ca.pem
 export HTTPS_PROXY=http://127.0.0.1:9090
-bigcommerce v3 customers list
+contoso plants list
 ```
 
 **Corporate network with a custom root CA:**
 
 ```bash
-export BIGCOMMERCE_CA_BUNDLE=/etc/ssl/corp-roots.pem
-bigcommerce v3 customers list
+export CONTOSO_CA_BUNDLE=/etc/ssl/corp-roots.pem
+contoso plants list
 ```
 
 </Accordion>
 
 ## Structured logging
 
-Logging is off by default. Set `FERN_CLI_LOG` to a [tracing filter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) to emit structured logs to stderr. Set `FERN_CLI_LOG_FILE` to a directory path to write daily rotated JSON log files.
+Logging is off by default. Set `<NAME>_LOG` to a [tracing filter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) to emit structured logs to stderr. Set `<NAME>_LOG_FILE` to a directory path to write daily rotated JSON log files.
 
 ```bash
-FERN_CLI_LOG=debug box users get-current-user
+CONTOSO_LOG=debug contoso plants list
 ```

--- a/fern/products/cli-generator/features.mdx
+++ b/fern/products/cli-generator/features.mdx
@@ -8,7 +8,7 @@ availability: beta
 The CLI generator is in early access. [Reach out](https://buildwithfern.com/book-demo?type=cli) to get started.
 </Note>
 
-Every command in a generated CLI accepts the same set of runtime flags and environment variables, regardless of the underlying API. This page documents what's available out of the box: output formats, pagination, dry-run previewing, TLS and proxy configuration, exit codes, and structured logging.
+Generated CLIs ship with a common set of runtime flags and environment variables: output formatting, pagination, dry-run previewing, TLS and proxy configuration, exit codes, and structured logging. APIs with templated server URLs also expose per-variable flags and environment variables.
 
 ## Output formatting
 

--- a/fern/products/cli-generator/openapi-extensions.mdx
+++ b/fern/products/cli-generator/openapi-extensions.mdx
@@ -1,7 +1,12 @@
 ---
 title: OpenAPI extensions
 description: Learn which Fern OpenAPI extensions influence the generated CLI and how they map to commands, flags, and help text.
+availability: beta
 ---
+
+<Note title="Early access">
+The CLI generator is in early access. [Reach out](https://buildwithfern.com/book-demo?type=cli) to get started.
+</Note>
 
 The CLI generator reads several [Fern OpenAPI extensions](/learn/api-definitions/openapi/extensions/overview) to shape the generated CLI. You can add these extensions directly in your spec or apply them through [overlays](/learn/api-definitions/openapi/overlays).
 

--- a/fern/products/cli-generator/openapi-extensions.mdx
+++ b/fern/products/cli-generator/openapi-extensions.mdx
@@ -101,7 +101,7 @@ See [Availability](/learn/api-definitions/openapi/extensions/availability) for m
 
 Overrides the CLI flag name derived from a parameter. By default, parameter names are converted to kebab-case for use as flags.
 
-```yaml title="openapi.yaml" {8}
+```yaml title="openapi.yaml" {9}
 paths:
   /users:
     get:

--- a/fern/products/cli-generator/openapi-extensions.mdx
+++ b/fern/products/cli-generator/openapi-extensions.mdx
@@ -45,6 +45,8 @@ Produces: `cli get-current-user` (or nested under a group if `x-fern-sdk-group-n
 If neither extension is present, the CLI falls back to the `operationId`.
 </Note>
 
+See [SDK method names](/learn/api-definitions/openapi/extensions/method-names) for more details.
+
 ## Filtering
 
 ### `x-fern-ignore`

--- a/fern/products/cli-generator/openapi-extensions.mdx
+++ b/fern/products/cli-generator/openapi-extensions.mdx
@@ -1,0 +1,137 @@
+---
+title: OpenAPI extensions
+description: Learn which Fern OpenAPI extensions influence the generated CLI and how they map to commands, flags, and help text.
+---
+
+The CLI generator reads several [Fern OpenAPI extensions](/learn/api-definitions/openapi/extensions/overview) to shape the generated CLI. You can add these extensions directly in your spec or apply them through [overlays](/learn/api-definitions/openapi/overlays).
+
+## Command structure
+
+### `x-fern-sdk-group-name`
+
+Determines the subcommand group hierarchy. Each list element becomes a nested subcommand, with names converted from camelCase to kebab-case.
+
+```yaml title="openapi.yaml" {4-6}
+paths:
+  /scheduled-events/{uuid}/invitees:
+    get:
+      x-fern-sdk-group-name:
+        - scheduledEvents
+        - invitees
+      x-fern-sdk-method-name: list-event-invitees
+```
+
+Produces: `cli scheduled-events invitees list-event-invitees`
+
+### `x-fern-sdk-method-name`
+
+Sets the leaf command name (used as-is).
+
+```yaml title="openapi.yaml" {4}
+paths:
+  /users/me:
+    get:
+      x-fern-sdk-method-name: get-current-user
+```
+
+Produces: `cli get-current-user` (or nested under a group if `x-fern-sdk-group-name` is also set).
+
+<Note>
+If neither extension is present, the CLI falls back to the `operationId`.
+</Note>
+
+## Filtering
+
+### `x-fern-ignore`
+
+Excludes operations or parameters from the generated CLI. An ignored operation produces no command; an ignored parameter produces no flag.
+
+```yaml title="openapi.yaml" {4}
+paths:
+  /internal/debug:
+    get:
+      x-fern-ignore: true
+```
+
+At the parameter level:
+
+```yaml title="openapi.yaml" {7}
+paths:
+  /users:
+    get:
+      parameters:
+        - name: internalParam
+          in: query
+          x-fern-ignore: true
+          schema:
+            type: string
+```
+
+See [Ignoring elements](/learn/api-definitions/openapi/extensions/ignoring-elements) for more details.
+
+## Availability badges
+
+### `x-fern-availability`
+
+Adds a status badge next to the command in `--help` output.
+
+| Value | Badge |
+| --- | --- |
+| `alpha` | `[Alpha]` |
+| `beta` | `[Beta]` |
+| `preview` | `[Preview]` |
+| `generally-available` or `ga` | `[GA]` |
+| `deprecated` | `[Deprecated]` |
+| `legacy` | `[Legacy]` |
+
+```yaml title="openapi.yaml" {4}
+paths:
+  /v2/reports:
+    get:
+      x-fern-availability: beta
+```
+
+OpenAPI's standard `deprecated: true` is also honored and maps to `[Deprecated]` when `x-fern-availability` isn't set.
+
+See [Availability](/learn/api-definitions/openapi/extensions/availability) for more details.
+
+## Parameter naming
+
+### `x-fern-parameter-name`
+
+Overrides the CLI flag name derived from a parameter. By default, parameter names are converted to kebab-case for use as flags.
+
+```yaml title="openapi.yaml" {8}
+paths:
+  /users:
+    get:
+      parameters:
+        - name: X-API-Version
+          in: header
+          schema:
+            type: string
+          x-fern-parameter-name: api-version
+```
+
+Produces `--api-version` instead of `--x-api-version`.
+
+See [Customize parameter names](/learn/api-definitions/openapi/extensions/parameter-names) for more details.
+
+## Pagination
+
+### `x-fern-pagination`
+
+Enables auto-pagination for an endpoint. When present, the CLI recognizes `--page-all`, `--page-limit`, and `--page-delay` flags for that command.
+
+```yaml title="openapi.yaml" {5-8}
+paths:
+  /plants:
+    get:
+      operationId: list_plants
+      x-fern-pagination:
+        cursor: $request.cursor
+        next_cursor: $response.next
+        results: $response.results
+```
+
+See [Pagination](/learn/api-definitions/openapi/extensions/pagination) for all supported pagination schemes (offset, cursor, URI, and path).

--- a/fern/products/cli-generator/overview.mdx
+++ b/fern/products/cli-generator/overview.mdx
@@ -51,3 +51,20 @@ The output is a single statically linked Rust binary. Users drop it onto their P
     Each release maps to a specific API version.
   </Card>
 </CardGroup>
+
+## Learn more
+
+<CardGroup cols={2}>
+  <Card title="Features" icon="fa-duotone fa-list-check" href="/learn/cli-generator/get-started/features">
+    Output formatting, pagination, dry-run mode, TLS configuration, and more.
+  </Card>
+  <Card title="Authentication" icon="fa-duotone fa-key" href="/learn/cli-generator/get-started/authentication">
+    Environment variables, CLI flags, files, and fallback chains.
+  </Card>
+  <Card title="OpenAPI extensions" icon="fa-duotone fa-puzzle-piece" href="/learn/cli-generator/get-started/openapi-extensions">
+    How Fern extensions shape the generated command tree.
+  </Card>
+  <Card title="Customization" icon="fa-duotone fa-sliders" href="/learn/cli-generator/get-started/customization">
+    Overrides, overlays, multi-spec merging, and custom commands.
+  </Card>
+</CardGroup>

--- a/fern/products/cli-generator/overview.mdx
+++ b/fern/products/cli-generator/overview.mdx
@@ -25,6 +25,10 @@ Building a CLI by hand is a multi-quarter project — commands, auth, pagination
 
 ## How it works
 
+<Info title="Supported API definitions">
+Generate a CLI from an OpenAPI spec or a GraphQL introspection schema.
+</Info>
+
 The CLI generator plugs into the same Fern workflow as your Docs and SDKs. When your spec changes, Fern opens a PR against your CLI repo with the generated source. On release, Fern automatically publishes the CLI to npm, Homebrew, and GitHub Releases so your users can install it with their package manager of choice. The CLI stays in sync with your Docs and SDKs, and you never need to write CLI code by hand.
 
 The output is a single statically linked Rust binary. Users drop it onto their PATH and run it. There's no language runtime and no dependencies.
@@ -49,22 +53,5 @@ The output is a single statically linked Rust binary. Users drop it onto their P
   </Card>
   <Card title="Version-pinned" icon="fa-duotone fa-code-branch">
     Each release maps to a specific API version.
-  </Card>
-</CardGroup>
-
-## Learn more
-
-<CardGroup cols={2}>
-  <Card title="Features" icon="fa-duotone fa-list-check" href="/learn/cli-generator/get-started/features">
-    Output formatting, pagination, dry-run mode, TLS configuration, and more.
-  </Card>
-  <Card title="Authentication" icon="fa-duotone fa-key" href="/learn/cli-generator/get-started/authentication">
-    Environment variables, CLI flags, files, and fallback chains.
-  </Card>
-  <Card title="OpenAPI extensions" icon="fa-duotone fa-puzzle-piece" href="/learn/cli-generator/get-started/openapi-extensions">
-    How Fern extensions shape the generated command tree.
-  </Card>
-  <Card title="Customization" icon="fa-duotone fa-sliders" href="/learn/cli-generator/get-started/customization">
-    Overrides, overlays, multi-spec merging, and custom commands.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

Expands the CLI Generator docs section from a single overview page to five pages covering the full feature set of the CLI SDK. Also cross-references the CLI Generator from the relevant OpenAPI extension pages.

**New pages:**
- **Features** — output formatting (JSON, table, YAML, CSV), pagination (`--page-all`), dry-run mode, passing parameters, file uploads/downloads, exit codes, TLS/proxy configuration, structured logging
- **Authentication** — credential sources (env var, CLI flag, file, literal, fallback chains), supported auth schemes (bearer, API key, basic, OAuth2), auth strategies (Auto, Any, All, Routing)
- **OpenAPI extensions** — how `x-fern-sdk-group-name`, `x-fern-sdk-method-name`, `x-fern-availability`, `x-fern-ignore`, `x-fern-parameter-name`, and `x-fern-pagination` map to CLI commands, flags, and help text
- **Customization** — overrides, overlays, multi-spec merging, server URL variables, custom commands, GraphQL support

**Updated pages:**
- `extensions/overview.md` — mentions CLIs alongside SDKs
- `extensions/method-names.mdx` — notes CLI subcommand hierarchy
- `extensions/availability.mdx` — notes CLI help badges
- `extensions/ignore.mdx` — notes CLI exclusion behavior
- `extensions/pagination.mdx` — notes CLI pagination flags
- `cli-generator/overview.mdx` — adds "Learn more" card group linking to new pages

## Review & Testing Checklist for Human
- [ ] Verify the four new pages render correctly in the preview (navigation, code blocks, tables, accordions)
- [ ] Confirm all internal links resolve (especially cross-references between CLI Generator pages and OpenAPI extension pages)
- [ ] Check that the navigation sidebar shows the new pages under CLI Generator → Get started

### Notes
All content is based on the actual CLI SDK source code at `fern-api/cli-sdk` (main branch). Features documented include only what's implemented and tested in the codebase.

Link to Devin session: https://app.devin.ai/sessions/a7ba8ccb747e42dc84475d28eb56c0f4
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->