### PR TITLE
docs(sdks): document SDK auto-versioning for self-hosted setups

### DIFF
--- a/.vale/styles/FernStyles/Acronyms.yml
+++ b/.vale/styles/FernStyles/Acronyms.yml
@@ -108,3 +108,5 @@ exceptions:
   - SPDX
   - BCP
   - ISO
+  - AUTO
+  - SHA

--- a/fern/products/sdks/deep-dives/self-hosted-versioning.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted-versioning.mdx
@@ -1,0 +1,213 @@
+---
+title: Self-hosted SDK versioning
+description: Compute the next SDK version number from your own CI when self-hosting Fern SDK generation.
+---
+
+<Markdown src="/snippets/enterprise-plan.mdx" />
+
+When self-hosting, your pipeline picks the version number for each SDK release. Cloud generation handles this automatically via Fern Autorelease, but [self-hosted setups](/learn/sdks/deep-dives/self-hosted) need to compute the next version themselves.
+
+The CLI exposes two workflows for this. Both can be wired into the same generation pipeline:
+
+- **`--version AUTO`** is the recommended approach. Fern classifies the change, picks the next version, and writes the changelog entry, PR description, and conventional-commit message for you. This is also the path that continues to receive improvements.
+- **`fern ir` + `fern diff`** is the deterministic alternative. It returns only the computed bump and next version — the rest of the release artifacts are yours to write. Use it when you need explicit control over how the version number is derived, or when you can't depend on an external LLM provider.
+
+## `--version AUTO` (recommended)
+
+Pass `--version AUTO` to `fern generate` and Fern analyzes the diff between the previous and current SDK output, classifies the change as `MAJOR`, `MINOR`, or `PATCH`, and applies the next [semantic version](https://semver.org/) to the generated package. The same analysis also produces:
+
+- A changelog entry describing what changed
+- A PR description summarizing the release
+- A [conventional commit](https://www.conventionalcommits.org/) message
+
+<Info>
+`--version AUTO` requires:
+- A `FERN_TOKEN` for organization verification (same as all self-hosted generation).
+- A [GitHub output](/learn/sdks/deep-dives/self-hosted#setup) configured in `generators.yml`, since the pipeline pushes the version bump and changelog back to the SDK repo.
+</Info>
+
+<Steps>
+<Step title="Configure the AI provider">
+
+Set the provider and model in `generators.yml`:
+
+```yaml title="generators.yml"
+ai:
+  provider: openai   # openai | anthropic | bedrock
+  model: gpt-4o      # any model name the provider accepts
+```
+
+</Step>
+<Step title="Set provider credentials">
+
+Export the matching API key so the Fern CLI can call the provider:
+
+- `OPENAI_API_KEY` for OpenAI
+- `ANTHROPIC_API_KEY` for Anthropic
+- Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) for AWS Bedrock
+
+The diff is sent to the provider's API using your credentials — Fern's infrastructure is not involved in the analysis.
+
+</Step>
+<Step title="Run generation with `--version AUTO`">
+
+```bash
+FERN_TOKEN=<token> fern generate --version AUTO
+```
+
+</Step>
+</Steps>
+
+## Deterministic versioning with `fern ir` + `fern diff`
+
+If you'd rather derive the version number yourself, use the `fern ir` and `fern diff` commands to compute the bump from your API definition. This flow has no LLM dependency: `fern diff` walks the intermediate representation (IR) of both specs and returns a deterministic result.
+
+The workflow has three steps:
+
+<Steps>
+<Step title="Generate the previous IR">
+
+Check out the spec as it was at the last SDK generation and write its IR to disk:
+
+```bash
+fern ir old-ir.json
+```
+
+Pass `--api <name>` if your [project defines multiple APIs](/learn/sdks/overview/project-structure).
+
+</Step>
+<Step title="Generate the current IR">
+
+Check out the spec at `HEAD` and write its IR to disk:
+
+```bash
+fern ir new-ir.json
+```
+
+</Step>
+<Step title="Diff the two IRs">
+
+Run `fern diff` with `--from-version` set to the SDK's current version. When `--from-version` is provided, the command prints a JSON object containing the computed bump and the next version:
+
+```bash
+fern diff \
+  --from old-ir.json \
+  --to new-ir.json \
+  --from-version 1.4.2
+```
+
+```json
+{
+  "bump": "minor",
+  "nextVersion": "1.5.0",
+  "errors": []
+}
+```
+
+`bump` is one of `major`, `minor`, `patch`, or `no_change`. Pass `nextVersion` to `fern generate` to release that exact version:
+
+<Tabs>
+<Tab title="CLI v1" language="cli-v1">
+```bash
+fern generate --version 1.5.0
+```
+</Tab>
+<Tab title="CLI v2" language="cli-v2">
+```bash
+fern generate --output-version 1.5.0
+```
+</Tab>
+</Tabs>
+
+</Step>
+</Steps>
+
+<Info>
+`fern diff` exits with a non-zero status when the computed bump is `major`. This makes it easy to gate breaking changes on a manual review step in CI.
+</Info>
+
+### Wiring `fern ir` + `fern diff` into CI
+
+The non-obvious part is reproducing the IR for the *previous* spec. Each generated SDK records the config repo commit it was generated from in `.fern/metadata.json`:
+
+```json title=".fern/metadata.json"
+{
+  "cliVersion": "0.74.0",
+  "generatorName": "fernapi/fern-python-sdk",
+  "generatorVersion": "4.0.0",
+  "originGitCommit": "a1b2c3d4e5f6...",
+  "requestedVersion": "1.4.2",
+  "sdkVersion": "1.4.2"
+}
+```
+
+`originGitCommit` is the SHA in the **config repo** that produced the SDK at its current version. Check that commit out, run `fern ir`, then switch back to `HEAD` and run `fern ir` again to produce both inputs to `fern diff`.
+
+<Accordion title="Example: GitHub Actions workflow">
+
+The following snippet runs in the config repo on every push to `main` and computes the next version for a Python SDK whose `originGitCommit` and `sdkVersion` are read from the SDK repo:
+
+```yaml title=".github/workflows/release-sdk.yml"
+name: Release SDK
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+      SDK_REPO: your-org/python-sdk
+    steps:
+      - name: Check out config repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Fern CLI
+        uses: fern-api/setup-fern-cli@v1
+
+      - name: Read previous SDK metadata
+        id: meta
+        run: |
+          curl -fsSL \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.raw" \
+            "https://api.github.com/repos/${SDK_REPO}/contents/.fern/metadata.json" \
+            > metadata.json
+          echo "old_sha=$(jq -r .originGitCommit metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "from_version=$(jq -r .sdkVersion metadata.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate previous IR
+        run: |
+          git checkout ${{ steps.meta.outputs.old_sha }}
+          fern ir old-ir.json --api <your-api-name>
+
+      - name: Generate current IR
+        run: |
+          git checkout ${{ github.sha }}
+          fern ir new-ir.json --api <your-api-name>
+
+      - name: Compute next version
+        id: diff
+        run: |
+          result=$(fern diff \
+            --from old-ir.json \
+            --to new-ir.json \
+            --from-version ${{ steps.meta.outputs.from_version }}) || true
+          bump=$(echo "$result" | jq -r .bump)
+          if [ "$bump" = "major" ]; then
+            echo "Computed a major version bump — manual review required before releasing."
+            exit 1
+          fi
+          echo "next_version=$(echo "$result" | jq -r .nextVersion)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate SDK
+        run: fern generate --group python-sdk --version ${{ steps.diff.outputs.next_version }}
+```
+
+`fetch-depth: 0` on the checkout step is required so the runner has the history needed to check out `originGitCommit`. Replace the metadata-fetch step with whatever mechanism gives your pipeline access to the SDK repo's `.fern/metadata.json` (a checkout of the SDK repo, a release artifact, an internal API, and so on).
+
+</Accordion>

--- a/fern/products/sdks/deep-dives/self-hosted-versioning.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted-versioning.mdx
@@ -52,7 +52,7 @@ The diff is sent to the provider's API using your credentials — Fern's infrast
 <Step title="Run generation with `--version AUTO`">
 
 ```bash
-FERN_TOKEN=<token> fern generate --version AUTO
+FERN_TOKEN=<token> fern generate --local --version AUTO
 ```
 
 </Step>
@@ -109,12 +109,12 @@ fern diff \
 <Tabs>
 <Tab title="CLI v1" language="cli-v1">
 ```bash
-fern generate --version 1.5.0
+fern generate --local --version 1.5.0
 ```
 </Tab>
 <Tab title="CLI v2" language="cli-v2">
 ```bash
-fern generate --output-version 1.5.0
+fern generate --local --output-version 1.5.0
 ```
 </Tab>
 </Tabs>
@@ -205,7 +205,7 @@ jobs:
           echo "next_version=$(echo "$result" | jq -r .nextVersion)" >> "$GITHUB_OUTPUT"
 
       - name: Generate SDK
-        run: fern generate --group python-sdk --version ${{ steps.diff.outputs.next_version }}
+        run: fern generate --local --group python-sdk --version ${{ steps.diff.outputs.next_version }}
 ```
 
 `fetch-depth: 0` on the checkout step is required so the runner has the history needed to check out `originGitCommit`. Replace the metadata-fetch step with whatever mechanism gives your pipeline access to the SDK repo's `.fern/metadata.json` (a checkout of the SDK repo, a release artifact, an internal API, and so on).

--- a/fern/products/sdks/deep-dives/self-hosted-versioning.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted-versioning.mdx
@@ -5,7 +5,7 @@ description: Compute the next SDK version number from your own CI when self-host
 
 <Markdown src="/snippets/enterprise-plan.mdx" />
 
-When self-hosting, your pipeline picks the version number for each SDK release. Cloud generation handles this automatically via Fern Autorelease, but [self-hosted setups](/learn/sdks/deep-dives/self-hosted) need to compute the next version themselves.
+When self-hosting, your pipeline picks the version number for each SDK release. Unlike cloud generation, [self-hosted setups](/learn/sdks/deep-dives/self-hosted) need to compute the next version themselves.
 
 The CLI exposes two workflows for this. Both can be wired into the same generation pipeline:
 

--- a/fern/products/sdks/deep-dives/self-hosted-versioning.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted-versioning.mdx
@@ -9,8 +9,8 @@ When self-hosting, your pipeline picks the version number for each SDK release. 
 
 The CLI exposes two workflows for this. Both can be wired into the same generation pipeline:
 
-- **`--version AUTO`** is the recommended approach. Fern classifies the change, picks the next version, and writes the changelog entry, PR description, and conventional-commit message for you. This is also the path that continues to receive improvements.
-- **`fern ir` + `fern diff`** is the deterministic alternative. It returns only the computed bump and next version — the rest of the release artifacts are yours to write. Use it when you need explicit control over how the version number is derived, or when you can't depend on an external LLM provider.
+- **`--version AUTO`** is the recommended approach. Fern classifies the change against the full SDK output — so changes driven by `generators.yml` settings, a generator version bump, or a CLI version bump are reflected in the version it picks — and writes the changelog entry, PR description, and conventional-commit message for you. This is also the path that continues to receive improvements.
+- **`fern ir` + `fern diff`** is the deterministic alternative. It compares the intermediate representation (IR) of your API spec and returns only the computed bump and next version. Because the diff is over the spec alone, it doesn't account for SDK-implementation changes that come from `generators.yml` configuration, generator version, or CLI version — if any of those move, you'll need to bump the version yourself. The rest of the release artifacts (changelog, PR description, commit message) are also yours to write. Use this flow when you need explicit control over how the version number is derived, or when you can't depend on an external LLM provider.
 
 ## `--version AUTO` (recommended)
 

--- a/fern/products/sdks/deep-dives/self-hosted.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted.mdx
@@ -205,7 +205,7 @@ When self-hosting, your pipeline picks the version number for each SDK release. 
 The CLI exposes two workflows for this. Both can be wired into the same generation pipeline:
 
 - **`--version AUTO`** is the recommended approach. Fern classifies the change and picks the next version for you. This is the path that continues to receive improvements.
-- **`fern ir` + `fern diff`** is the deterministic alternative. Use it when you need explicit control over how the version number is derived, or when you can't depend on Fern's hosted AI service.
+- **`fern ir` + `fern diff`** is the deterministic alternative. Use it when you need explicit control over how the version number is derived, or when you can't depend on an external LLM provider.
 
 ### `--version AUTO` (recommended)
 
@@ -222,11 +222,13 @@ FERN_TOKEN=<token> fern generate --version AUTO
 <Info>
 `--version AUTO` requires:
 - A `FERN_TOKEN` (for organization verification, same as all local generation).
-- An LLM provider API key for the diff analysis. Set one of:
+- Credentials for the LLM provider that performs the diff analysis. Set one of:
   - `OPENAI_API_KEY` for OpenAI.
   - `ANTHROPIC_API_KEY` for Anthropic.
   - Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) for AWS Bedrock.
 - A self-hosted GitHub output configured in `generators.yml` (with `github.uri` and `github.token`, [as shown above](#setup)), because the auto-versioning pipeline pushes the version bump and changelog back to the SDK repo.
+
+The diff is sent to whichever LLM provider you configure. The Fern CLI calls that provider's API directly using your credentials — Fern's infrastructure is not involved in the analysis.
 </Info>
 
 This approach is designed for the [`fern-api/fern-generate`](https://github.com/fern-api/fern-generate) GitHub Action that powers Fern's automated release pipeline, but it works standalone anywhere that meets the requirements above.

--- a/fern/products/sdks/deep-dives/self-hosted.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted.mdx
@@ -221,14 +221,20 @@ FERN_TOKEN=<token> fern generate --version AUTO
 
 <Info>
 `--version AUTO` requires:
-- A `FERN_TOKEN` (for organization verification, same as all local generation).
-- Credentials for the LLM provider that performs the diff analysis. Set one of:
+- A `FERN_TOKEN` for organization verification (same as all local generation).
+- An `ai:` block in `generators.yml` that picks the LLM provider and model:
+  ```yaml title="generators.yml"
+  ai:
+    provider: openai   # openai | anthropic | bedrock
+    model: gpt-4o      # any model name the provider accepts
+  ```
+- The corresponding API key in your environment so the provider's SDK can authenticate:
   - `OPENAI_API_KEY` for OpenAI.
   - `ANTHROPIC_API_KEY` for Anthropic.
   - Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) for AWS Bedrock.
 - A self-hosted GitHub output configured in `generators.yml` (with `github.uri` and `github.token`, [as shown above](#setup)), because the auto-versioning pipeline pushes the version bump and changelog back to the SDK repo.
 
-The diff is sent to whichever LLM provider you configure. The Fern CLI calls that provider's API directly using your credentials — Fern's infrastructure is not involved in the analysis.
+The diff is sent to the provider's API using your credentials — Fern's infrastructure is not involved in the analysis.
 </Info>
 
 This approach is designed for the [`fern-api/fern-generate`](https://github.com/fern-api/fern-generate) GitHub Action that powers Fern's automated release pipeline, but it works standalone anywhere that meets the requirements above.

--- a/fern/products/sdks/deep-dives/self-hosted.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted.mdx
@@ -13,7 +13,7 @@ Fern SDK generation [runs on Fern's infrastructure by default](/sdks/overview/ho
 - Has strict compliance or security requirements
 - Needs full control over your SDK generation process
 
-When you self-host, you're responsible for infrastructure management and SDK distribution. Self-hosted SDK generation includes [all Fern SDK features](/learn/sdks/overview/capabilities).
+When you self-host, you're responsible for infrastructure management, SDK distribution, and [computing SDK version numbers](/learn/sdks/deep-dives/self-hosted-versioning). Self-hosted SDK generation includes [all Fern SDK features](/learn/sdks/overview/capabilities).
 
 <Info>
 Unless you have specific requirements that prevent using Fern's default hosting, we recommend **using our managed cloud generation solution** for easier setup and maintenance.
@@ -120,6 +120,12 @@ Set up GitHub secrets for authentication. In your repository's **Settings** > **
 </Tabs>
 </Step>
 
+<Step title="Configure version computation">
+
+Cloud generation picks SDK version numbers automatically. With self-hosting, your pipeline computes the next version itself — see [Self-hosted SDK versioning](/learn/sdks/deep-dives/self-hosted-versioning) for the two supported workflows.
+
+</Step>
+
 <Step title="Run generation locally">
 
 Use the `--local` flag to generate SDKs locally instead of using Fern's cloud infrastructure. You can combine `--local` with `--group` to generate specific SDKs locally.
@@ -197,198 +203,3 @@ sequenceDiagram
     CLI->>CLI: Run container, generate SDK
     CLI->>CLI: Push to output (local/GitHub)
 ```
-
-## Determining SDK versions
-
-When self-hosting, your pipeline picks the version number for each SDK release. Cloud generation handles this automatically via Fern Autorelease, but self-hosted setups need to compute the next version themselves.
-
-The CLI exposes two workflows for this. Both can be wired into the same generation pipeline:
-
-- **`--version AUTO`** is the recommended approach. Fern classifies the change, picks the next version, and writes the changelog entry, PR description, and conventional-commit message for you. This is also the path that continues to receive improvements.
-- **`fern ir` + `fern diff`** is the deterministic alternative. It returns only the computed bump and next version — the rest of the release artifacts are yours to write. Use it when you need explicit control over how the version number is derived, or when you can't depend on an external LLM provider.
-
-### `--version AUTO` (recommended)
-
-Pass `--version AUTO` to `fern generate` and Fern analyzes the diff between the previous and current SDK output, classifies the change as `MAJOR`, `MINOR`, or `PATCH`, and applies the next [semantic version](https://semver.org/) to the generated package. The same analysis also produces:
-
-- A changelog entry describing what changed
-- A PR description summarizing the release
-- A [conventional commit](https://www.conventionalcommits.org/) message
-
-```bash
-FERN_TOKEN=<token> fern generate --version AUTO
-```
-
-<Info>
-`--version AUTO` requires:
-- A `FERN_TOKEN` for organization verification (same as all local generation).
-- An `ai:` block in `generators.yml` selecting the LLM provider and model (see below).
-- The corresponding provider credentials in your environment (see below).
-- A self-hosted GitHub output configured in `generators.yml` (with `github.uri` and `github.token`, [as shown above](#setup)), because the auto-versioning pipeline pushes the version bump and changelog back to the SDK repo.
-</Info>
-
-Configure the provider and model in `generators.yml`:
-
-```yaml title="generators.yml"
-ai:
-  provider: openai   # openai | anthropic | bedrock
-  model: gpt-4o      # any model name the provider accepts
-```
-
-Set the matching API key in your environment so the Fern CLI can call the provider:
-
-- `OPENAI_API_KEY` for OpenAI
-- `ANTHROPIC_API_KEY` for Anthropic
-- Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) for AWS Bedrock
-
-The diff is sent to the provider's API using your credentials — Fern's infrastructure is not involved in the analysis.
-
-### Deterministic versioning with `fern ir` + `fern diff`
-
-If you'd rather derive the version number yourself, use the `fern ir` and `fern diff` commands to compute the bump from your API definition. This flow has no LLM dependency: `fern diff` walks the intermediate representation (IR) of both specs and returns a deterministic result.
-
-The workflow has three steps:
-
-<Steps>
-<Step title="Generate the previous IR">
-
-Check out the spec as it was at the last SDK generation and write its IR to disk:
-
-```bash
-fern ir old-ir.json
-```
-
-Pass `--api <name>` if your [project defines multiple APIs](/learn/sdks/overview/project-structure).
-
-</Step>
-<Step title="Generate the current IR">
-
-Check out the spec at `HEAD` and write its IR to disk:
-
-```bash
-fern ir new-ir.json
-```
-
-</Step>
-<Step title="Diff the two IRs">
-
-Run `fern diff` with `--from-version` set to the SDK's current version. When `--from-version` is provided, the command prints a JSON object containing the computed bump and the next version:
-
-```bash
-fern diff \
-  --from old-ir.json \
-  --to new-ir.json \
-  --from-version 1.4.2
-```
-
-```json
-{
-  "bump": "minor",
-  "nextVersion": "1.5.0",
-  "errors": []
-}
-```
-
-`bump` is one of `major`, `minor`, `patch`, or `no_change`. Pass `nextVersion` to `fern generate` to release that exact version:
-
-<Tabs>
-<Tab title="CLI v1" language="cli-v1">
-```bash
-fern generate --version 1.5.0
-```
-</Tab>
-<Tab title="CLI v2" language="cli-v2">
-```bash
-fern generate --output-version 1.5.0
-```
-</Tab>
-</Tabs>
-
-</Step>
-</Steps>
-
-<Info>
-`fern diff` exits with a non-zero status when the computed bump is `major`. This makes it easy to gate breaking changes on a manual review step in CI.
-</Info>
-
-#### Wiring `fern ir` + `fern diff` into CI
-
-The non-obvious part is reproducing the IR for the *previous* spec. Each generated SDK records the config repo commit it was generated from in `.fern/metadata.json`:
-
-```json title=".fern/metadata.json"
-{
-  "cliVersion": "0.74.0",
-  "generatorName": "fernapi/fern-python-sdk",
-  "generatorVersion": "4.0.0",
-  "originGitCommit": "a1b2c3d4e5f6...",
-  "requestedVersion": "1.4.2",
-  "sdkVersion": "1.4.2"
-}
-```
-
-`originGitCommit` is the SHA in the **config repo** that produced the SDK at its current version. Check that commit out, run `fern ir`, then switch back to `HEAD` and run `fern ir` again to produce both inputs to `fern diff`.
-
-The following GitHub Actions snippet runs in the config repo on every push to `main` and computes the next version for a Python SDK whose `originGitCommit` and `sdkVersion` are read from the SDK repo:
-
-```yaml title=".github/workflows/release-sdk.yml"
-name: Release SDK
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    env:
-      FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-      SDK_REPO: your-org/python-sdk
-    steps:
-      - name: Check out config repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Fern CLI
-        uses: fern-api/setup-fern-cli@v1
-
-      - name: Read previous SDK metadata
-        id: meta
-        run: |
-          curl -fsSL \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.raw" \
-            "https://api.github.com/repos/${SDK_REPO}/contents/.fern/metadata.json" \
-            > metadata.json
-          echo "old_sha=$(jq -r .originGitCommit metadata.json)" >> "$GITHUB_OUTPUT"
-          echo "from_version=$(jq -r .sdkVersion metadata.json)" >> "$GITHUB_OUTPUT"
-
-      - name: Generate previous IR
-        run: |
-          git checkout ${{ steps.meta.outputs.old_sha }}
-          fern ir old-ir.json --api <your-api-name>
-
-      - name: Generate current IR
-        run: |
-          git checkout ${{ github.sha }}
-          fern ir new-ir.json --api <your-api-name>
-
-      - name: Compute next version
-        id: diff
-        run: |
-          result=$(fern diff \
-            --from old-ir.json \
-            --to new-ir.json \
-            --from-version ${{ steps.meta.outputs.from_version }}) || true
-          bump=$(echo "$result" | jq -r .bump)
-          if [ "$bump" = "major" ]; then
-            echo "Computed a major version bump — manual review required before releasing."
-            exit 1
-          fi
-          echo "next_version=$(echo "$result" | jq -r .nextVersion)" >> "$GITHUB_OUTPUT"
-
-      - name: Generate SDK
-        run: fern generate --group python-sdk --version ${{ steps.diff.outputs.next_version }}
-```
-
-`fetch-depth: 0` on the checkout step is required so the runner has the history needed to check out `originGitCommit`. Replace the metadata-fetch step with whatever mechanism gives your pipeline access to the SDK repo's `.fern/metadata.json` (a checkout of the SDK repo, a release artifact, an internal API, and so on).

--- a/fern/products/sdks/deep-dives/self-hosted.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted.mdx
@@ -222,20 +222,26 @@ FERN_TOKEN=<token> fern generate --version AUTO
 <Info>
 `--version AUTO` requires:
 - A `FERN_TOKEN` for organization verification (same as all local generation).
-- An `ai:` block in `generators.yml` that picks the LLM provider and model:
-  ```yaml title="generators.yml"
-  ai:
-    provider: openai   # openai | anthropic | bedrock
-    model: gpt-4o      # any model name the provider accepts
-  ```
-- The corresponding API key in your environment so the provider's SDK can authenticate:
-  - `OPENAI_API_KEY` for OpenAI.
-  - `ANTHROPIC_API_KEY` for Anthropic.
-  - Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) for AWS Bedrock.
+- An `ai:` block in `generators.yml` selecting the LLM provider and model (see below).
+- The corresponding provider credentials in your environment (see below).
 - A self-hosted GitHub output configured in `generators.yml` (with `github.uri` and `github.token`, [as shown above](#setup)), because the auto-versioning pipeline pushes the version bump and changelog back to the SDK repo.
+</Info>
+
+Configure the provider and model in `generators.yml`:
+
+```yaml title="generators.yml"
+ai:
+  provider: openai   # openai | anthropic | bedrock
+  model: gpt-4o      # any model name the provider accepts
+```
+
+Set the matching API key in your environment so the Fern CLI can call the provider:
+
+- `OPENAI_API_KEY` for OpenAI
+- `ANTHROPIC_API_KEY` for Anthropic
+- Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) for AWS Bedrock
 
 The diff is sent to the provider's API using your credentials — Fern's infrastructure is not involved in the analysis.
-</Info>
 
 This approach is designed for the [`fern-api/fern-generate`](https://github.com/fern-api/fern-generate) GitHub Action that powers Fern's automated release pipeline, but it works standalone anywhere that meets the requirements above.
 

--- a/fern/products/sdks/deep-dives/self-hosted.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted.mdx
@@ -200,12 +200,12 @@ sequenceDiagram
 
 ## Determining SDK versions
 
-When self-hosting, your pipeline picks the version number for each SDK release. Cloud generation handles this automatically via [Fern Autorelease](/learn/sdks/overview/autorelease), but self-hosted setups need to compute the next version themselves.
+When self-hosting, your pipeline picks the version number for each SDK release. Cloud generation handles this automatically via Fern Autorelease, but self-hosted setups need to compute the next version themselves.
 
 The CLI exposes two workflows for this. Both can be wired into the same generation pipeline:
 
-- **`--version AUTO`** is the recommended approach. Fern classifies the change and picks the next version for you. This is the path that continues to receive improvements.
-- **`fern ir` + `fern diff`** is the deterministic alternative. Use it when you need explicit control over how the version number is derived, or when you can't depend on an external LLM provider.
+- **`--version AUTO`** is the recommended approach. Fern classifies the change, picks the next version, and writes the changelog entry, PR description, and conventional-commit message for you. This is also the path that continues to receive improvements.
+- **`fern ir` + `fern diff`** is the deterministic alternative. It returns only the computed bump and next version — the rest of the release artifacts are yours to write. Use it when you need explicit control over how the version number is derived, or when you can't depend on an external LLM provider.
 
 ### `--version AUTO` (recommended)
 

--- a/fern/products/sdks/deep-dives/self-hosted.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted.mdx
@@ -221,7 +221,11 @@ FERN_TOKEN=<token> fern generate --version AUTO
 
 <Info>
 `--version AUTO` requires:
-- A `FERN_TOKEN` (the diff analysis runs as a hosted Fern service that authenticates your organization the same way [cloud generation](/learn/sdks/overview/how-it-works) does).
+- A `FERN_TOKEN` (for organization verification, same as all local generation).
+- An LLM provider API key for the diff analysis. Set one of:
+  - `OPENAI_API_KEY` for OpenAI.
+  - `ANTHROPIC_API_KEY` for Anthropic.
+  - Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) for AWS Bedrock.
 - A self-hosted GitHub output configured in `generators.yml` (with `github.uri` and `github.token`, [as shown above](#setup)), because the auto-versioning pipeline pushes the version bump and changelog back to the SDK repo.
 </Info>
 
@@ -229,7 +233,7 @@ This approach is designed for the [`fern-api/fern-generate`](https://github.com/
 
 ### Deterministic versioning with `fern ir` + `fern diff`
 
-If you'd rather derive the version number yourself, use the `fern ir` and `fern diff` commands to compute the bump from your API definition. This flow has no dependency on hosted AI: `fern diff` walks the intermediate representation (IR) of both specs and returns a deterministic result. It's the legacy path — `--version AUTO` will keep getting improvements first — but it remains fully supported for setups that need explicit control.
+If you'd rather derive the version number yourself, use the `fern ir` and `fern diff` commands to compute the bump from your API definition. This flow has no LLM dependency: `fern diff` walks the intermediate representation (IR) of both specs and returns a deterministic result.
 
 The workflow has three steps:
 
@@ -268,7 +272,8 @@ fern diff \
 ```json
 {
   "bump": "minor",
-  "nextVersion": "1.5.0"
+  "nextVersion": "1.5.0",
+  "errors": []
 }
 ```
 

--- a/fern/products/sdks/deep-dives/self-hosted.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted.mdx
@@ -243,7 +243,7 @@ Set the matching API key in your environment so the Fern CLI can call the provid
 
 The diff is sent to the provider's API using your credentials — Fern's infrastructure is not involved in the analysis.
 
-This approach is designed for the [`fern-api/fern-generate`](https://github.com/fern-api/fern-generate) GitHub Action that powers Fern's automated release pipeline, but it works standalone anywhere that meets the requirements above.
+This approach is designed for use with `fern automations generate`, which powers Fern's automated release pipeline, but it works standalone anywhere that meets the requirements above.
 
 ### Deterministic versioning with `fern ir` + `fern diff`
 
@@ -368,12 +368,12 @@ jobs:
       - name: Generate previous IR
         run: |
           git checkout ${{ steps.meta.outputs.old_sha }}
-          fern ir old-ir.json --api plants
+          fern ir old-ir.json --api <your-api-name>
 
       - name: Generate current IR
         run: |
           git checkout ${{ github.sha }}
-          fern ir new-ir.json --api plants
+          fern ir new-ir.json --api <your-api-name>
 
       - name: Compute next version
         id: diff
@@ -381,7 +381,12 @@ jobs:
           result=$(fern diff \
             --from old-ir.json \
             --to new-ir.json \
-            --from-version ${{ steps.meta.outputs.from_version }})
+            --from-version ${{ steps.meta.outputs.from_version }}) || true
+          bump=$(echo "$result" | jq -r .bump)
+          if [ "$bump" = "major" ]; then
+            echo "Computed a major version bump — manual review required before releasing."
+            exit 1
+          fi
           echo "next_version=$(echo "$result" | jq -r .nextVersion)" >> "$GITHUB_OUTPUT"
 
       - name: Generate SDK

--- a/fern/products/sdks/deep-dives/self-hosted.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted.mdx
@@ -243,8 +243,6 @@ Set the matching API key in your environment so the Fern CLI can call the provid
 
 The diff is sent to the provider's API using your credentials — Fern's infrastructure is not involved in the analysis.
 
-This approach is designed for use with `fern automations generate`, which powers Fern's automated release pipeline, but it works standalone anywhere that meets the requirements above.
-
 ### Deterministic versioning with `fern ir` + `fern diff`
 
 If you'd rather derive the version number yourself, use the `fern ir` and `fern diff` commands to compute the bump from your API definition. This flow has no LLM dependency: `fern diff` walks the intermediate representation (IR) of both specs and returns a deterministic result.

--- a/fern/products/sdks/deep-dives/self-hosted.mdx
+++ b/fern/products/sdks/deep-dives/self-hosted.mdx
@@ -197,3 +197,176 @@ sequenceDiagram
     CLI->>CLI: Run container, generate SDK
     CLI->>CLI: Push to output (local/GitHub)
 ```
+
+## Determining SDK versions
+
+When self-hosting, your pipeline picks the version number for each SDK release. Cloud generation handles this automatically via [Fern Autorelease](/learn/sdks/overview/autorelease), but self-hosted setups need to compute the next version themselves.
+
+The CLI exposes two workflows for this. Both can be wired into the same generation pipeline:
+
+- **`--version AUTO`** is the recommended approach. Fern classifies the change and picks the next version for you. This is the path that continues to receive improvements.
+- **`fern ir` + `fern diff`** is the deterministic alternative. Use it when you need explicit control over how the version number is derived, or when you can't depend on Fern's hosted AI service.
+
+### `--version AUTO` (recommended)
+
+Pass `--version AUTO` to `fern generate` and Fern analyzes the diff between the previous and current SDK output, classifies the change as `MAJOR`, `MINOR`, or `PATCH`, and applies the next [semantic version](https://semver.org/) to the generated package. The same analysis also produces:
+
+- A changelog entry describing what changed
+- A PR description summarizing the release
+- A [conventional commit](https://www.conventionalcommits.org/) message
+
+```bash
+FERN_TOKEN=<token> fern generate --version AUTO
+```
+
+<Info>
+`--version AUTO` requires:
+- A `FERN_TOKEN` (the diff analysis runs as a hosted Fern service that authenticates your organization the same way [cloud generation](/learn/sdks/overview/how-it-works) does).
+- A self-hosted GitHub output configured in `generators.yml` (with `github.uri` and `github.token`, [as shown above](#setup)), because the auto-versioning pipeline pushes the version bump and changelog back to the SDK repo.
+</Info>
+
+This approach is designed for the [`fern-api/fern-generate`](https://github.com/fern-api/fern-generate) GitHub Action that powers Fern's automated release pipeline, but it works standalone anywhere that meets the requirements above.
+
+### Deterministic versioning with `fern ir` + `fern diff`
+
+If you'd rather derive the version number yourself, use the `fern ir` and `fern diff` commands to compute the bump from your API definition. This flow has no dependency on hosted AI: `fern diff` walks the intermediate representation (IR) of both specs and returns a deterministic result. It's the legacy path — `--version AUTO` will keep getting improvements first — but it remains fully supported for setups that need explicit control.
+
+The workflow has three steps:
+
+<Steps>
+<Step title="Generate the previous IR">
+
+Check out the spec as it was at the last SDK generation and write its IR to disk:
+
+```bash
+fern ir old-ir.json
+```
+
+Pass `--api <name>` if your [project defines multiple APIs](/learn/sdks/overview/project-structure).
+
+</Step>
+<Step title="Generate the current IR">
+
+Check out the spec at `HEAD` and write its IR to disk:
+
+```bash
+fern ir new-ir.json
+```
+
+</Step>
+<Step title="Diff the two IRs">
+
+Run `fern diff` with `--from-version` set to the SDK's current version. When `--from-version` is provided, the command prints a JSON object containing the computed bump and the next version:
+
+```bash
+fern diff \
+  --from old-ir.json \
+  --to new-ir.json \
+  --from-version 1.4.2
+```
+
+```json
+{
+  "bump": "minor",
+  "nextVersion": "1.5.0"
+}
+```
+
+`bump` is one of `major`, `minor`, `patch`, or `no_change`. Pass `nextVersion` to `fern generate` to release that exact version:
+
+<Tabs>
+<Tab title="CLI v1" language="cli-v1">
+```bash
+fern generate --version 1.5.0
+```
+</Tab>
+<Tab title="CLI v2" language="cli-v2">
+```bash
+fern generate --output-version 1.5.0
+```
+</Tab>
+</Tabs>
+
+</Step>
+</Steps>
+
+<Info>
+`fern diff` exits with a non-zero status when the computed bump is `major`. This makes it easy to gate breaking changes on a manual review step in CI.
+</Info>
+
+#### Wiring `fern ir` + `fern diff` into CI
+
+The non-obvious part is reproducing the IR for the *previous* spec. Each generated SDK records the config repo commit it was generated from in `.fern/metadata.json`:
+
+```json title=".fern/metadata.json"
+{
+  "cliVersion": "0.74.0",
+  "generatorName": "fernapi/fern-python-sdk",
+  "generatorVersion": "4.0.0",
+  "originGitCommit": "a1b2c3d4e5f6...",
+  "requestedVersion": "1.4.2",
+  "sdkVersion": "1.4.2"
+}
+```
+
+`originGitCommit` is the SHA in the **config repo** that produced the SDK at its current version. Check that commit out, run `fern ir`, then switch back to `HEAD` and run `fern ir` again to produce both inputs to `fern diff`.
+
+The following GitHub Actions snippet runs in the config repo on every push to `main` and computes the next version for a Python SDK whose `originGitCommit` and `sdkVersion` are read from the SDK repo:
+
+```yaml title=".github/workflows/release-sdk.yml"
+name: Release SDK
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+      SDK_REPO: your-org/python-sdk
+    steps:
+      - name: Check out config repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Fern CLI
+        uses: fern-api/setup-fern-cli@v1
+
+      - name: Read previous SDK metadata
+        id: meta
+        run: |
+          curl -fsSL \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.raw" \
+            "https://api.github.com/repos/${SDK_REPO}/contents/.fern/metadata.json" \
+            > metadata.json
+          echo "old_sha=$(jq -r .originGitCommit metadata.json)" >> "$GITHUB_OUTPUT"
+          echo "from_version=$(jq -r .sdkVersion metadata.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate previous IR
+        run: |
+          git checkout ${{ steps.meta.outputs.old_sha }}
+          fern ir old-ir.json --api plants
+
+      - name: Generate current IR
+        run: |
+          git checkout ${{ github.sha }}
+          fern ir new-ir.json --api plants
+
+      - name: Compute next version
+        id: diff
+        run: |
+          result=$(fern diff \
+            --from old-ir.json \
+            --to new-ir.json \
+            --from-version ${{ steps.meta.outputs.from_version }})
+          echo "next_version=$(echo "$result" | jq -r .nextVersion)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate SDK
+        run: fern generate --group python-sdk --version ${{ steps.diff.outputs.next_version }}
+```
+
+`fetch-depth: 0` on the checkout step is required so the runner has the history needed to check out `originGitCommit`. Replace the metadata-fetch step with whatever mechanism gives your pipeline access to the SDK repo's `.fern/metadata.json` (a checkout of the SDK repo, a release artifact, an internal API, and so on).

--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -256,13 +256,16 @@ navigation:
       - page: Testing
         path: ./deep-dives/testing.mdx
         slug: testing
-  - section: Hosting
+  - section: Self-hosting
     slug: deep-dives
     collapsed: true
     contents:
-      - page: Self-hosted SDKs
+      - page: Setup
         path: ./deep-dives/self-hosted.mdx
         slug: self-hosted
+      - page: Versioning
+        path: ./deep-dives/self-hosted-versioning.mdx
+        slug: self-hosted-versioning
   - section: Reference
     contents: 
       - page: generators.yml


### PR DESCRIPTION
## Summary

Adds a new **Determining SDK versions** section to the [Self-hosted SDKs deep dive](https://buildwithfern.com/learn/sdks/deep-dives/self-hosted), covering the two CLI workflows for auto-determining the next version when generating SDKs on your own infrastructure. This is a real docs gap — Anduril and Cohere North both hit it independently and assumed they had to pick versions by hand.

The new section sits after **How it works** on the same page (`fern/products/sdks/deep-dives/self-hosted.mdx`) and documents:

- **`--version AUTO`** (recommended): one-line `fern generate --version AUTO` invocation, what the LLM-powered diff analysis produces (changelog entry, PR description, conventional-commit message), and the `FERN_TOKEN` + self-hosted GitHub config requirements. Framed as the modern path that will continue to receive improvements.
- **`fern ir` + `fern diff`** (deterministic/legacy): three-step workflow with the JSON output shape from `fern diff --from-version`, including the `--version`/`--output-version` split between CLI v1 and v2.
- **Wiring `fern ir` + `fern diff` into CI**: full GitHub Actions snippet that reads `originGitCommit` and `sdkVersion` from the SDK repo's `.fern/metadata.json`, checks out the previous spec, runs `fern ir` against both revisions, computes the next version, and generates the SDK. Includes the `fetch-depth: 0` callout.

Linear: [FER-10500](https://linear.app/buildwithfern/issue/FER-10500)

## Review & Testing Checklist for Human

- [ ] Open the preview link and confirm the page renders cleanly (Steps, Tabs, Info blocks, code blocks all formatted as expected).
- [ ] Sanity-check the GitHub Actions snippet — in particular the metadata-fetch step (uses the GitHub Contents API with the workflow's `GITHUB_TOKEN`) and the `git checkout ${{ github.sha }}` step that returns to HEAD.
- [ ] Confirm the framing of `--version AUTO` vs. `fern ir` + `fern diff` matches how you want enterprise customers to think about the two paths. Easiest to flag any phrasing nits as inline comments on the preview.

### Notes

- The `--version AUTO` requirements callout is based on the `selfhostedGithubConfig` check in `runLocalGenerationForWorkspace.ts` — it explicitly rejects AUTO when `github.uri`/`github.token` are absent, so the page now states that requirement up front.
- The CI snippet assumes the workflow runs in the config repo on push to `main`. If your typical customer setup runs the SDK generation from the SDK repo instead, happy to add a second variant.


Link to Devin session: https://app.devin.ai/sessions/27d62d318ccf41778b6cef95603e28fc
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->