### PR TITLE
ci: bump Node-20-built actions to Node 24 versions

### DIFF
--- a/.github/workflows/fern-scribe.yml
+++ b/.github/workflows/fern-scribe.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: .github/scripts/package.json
 

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -78,8 +78,8 @@ jobs:
           fi
 
       - name: Post PR comment
-        uses: thollander/actions-comment-pull-request@v2.4.3
+        uses: thollander/actions-comment-pull-request@v3
         with:
-          filePath: comment.md
-          comment_tag: preview-docs
+          file-path: comment.md
+          comment-tag: preview-docs
           mode: upsert


### PR DESCRIPTION
## Summary

GitHub is deprecating actions built on the Node 20 runtime starting June 2, 2026. Audited every action used in `.github/workflows/` against [its release notes](https://github.com/fern-api/fern-platform/pull/10859) — everything else (`actions/checkout@v5`, `actions/github-script@v8`, `actions/setup-node@v5`, `tj-actions/changed-files@v47`, etc.) is already on a major built on Node 24.

Two classes of change in this PR:

**1. `actions/setup-node` `node-version` 20 → 24** (`fern-scribe.yml`):
Brings the scribe job onto the current Active LTS — matches the rest of CI here.

**2. `thollander/actions-comment-pull-request@v2.4.3` → `@v3`** (`preview-docs.yml`):
v2.x is built on Node 20; [v3.0.0](https://github.com/thollander/actions-comment-pull-request/releases/tag/v3.0.0) moved to Node 24 and renamed inputs to kebab-case. Updated inputs accordingly:

```diff
- uses: thollander/actions-comment-pull-request@v2.4.3
+ uses: thollander/actions-comment-pull-request@v3
  with:
-   filePath: comment.md
-   comment_tag: preview-docs
+   file-path: comment.md
+   comment-tag: preview-docs
    mode: upsert
```

`mode: upsert` is unchanged in v3. The `GITHUB_TOKEN` env-var fallback is also unchanged; we don't pass `token`/`github-token` explicitly.

Following the same pattern as fern-api/fern-platform#10859.

## Review & Testing Checklist for Human

- [ ] CI on this PR will hit `preview-docs.yml` and post the "Preview your docs:" comment using the new v3 action — eyeball that the comment still upserts under the `preview-docs` tag (not a duplicate).
- [ ] `fern-scribe.yml` is only triggered on labeled PRs / `workflow_dispatch`; verify on the next scribe run that the Node 24 setup-node step still resolves the right pnpm/Node combo.

### Notes
This is purely a CI-runtime change — no docs content is touched.

Link to Devin session: https://app.devin.ai/sessions/cef8d96eb5864047beaacde8bda48cbe
Requested by: @davidkonigsberg