### PR TITLE
ui: reorder product switcher dropdown with divider before Fern CLI/Dashboard

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -121,6 +121,7 @@ h1, h2, h3 {
     gap: 1.5rem;
     padding: 1.25rem;
     height: 248px;
+    position: relative;
     
     > a {
       max-width: 320px;
@@ -131,6 +132,20 @@ h1, h2, h3 {
         border-radius: 1rem;
       }
 
+    }
+
+    /* Divider between row 2 (Docs / CLI Generator) and row 3 (Fern CLI /
+       Dashboard), spanning the left two columns. The spec column on the
+       right stacks tightly via translateY, so we do not draw across it. */
+    &::after {
+      content: '';
+      position: absolute;
+      top: calc(1.25rem + (248px - 2.5rem - 3rem) * 2 / 3 + 2.25rem);
+      left: 1.25rem;
+      width: calc((100% - 2.5rem - 3rem) * 2 / 3 + 1.5rem);
+      height: 1px;
+      background-color: var(--grayscale-5, rgba(128, 128, 128, 0.15));
+      pointer-events: none;
     }
 
     > a[href*="home"] {
@@ -148,13 +163,18 @@ h1, h2, h3 {
       grid-row: 2;
     }
 
-    > a[href*="dashboard"] {
+    > a[href*="cli-generator"] {
       grid-column: 2;
       grid-row: 2;
     }
 
     > a[href*="cli-api-reference"] {
       grid-column: 1;
+      grid-row: 3;
+    }
+
+    > a[href*="dashboard"] {
+      grid-column: 2;
       grid-row: 3;
     }
 
@@ -239,6 +259,16 @@ h1, h2, h3 {
 
   div.fern-scroll-area-viewport.group\/sidebar.mask-grad-y-3.sticky.overscroll-contain > div > div {
     border-top-width: 0px !important;
+  }
+}
+
+/* Stacked layout (mobile and tablet, below desktop grid): mirror the desktop
+   divider by drawing a thin rule above the Fern CLI entry. */
+@media (max-width: 1023px) {
+  .fern-product-selector-radio-group > a[href*="cli-api-reference"] {
+    border-top: 1px solid var(--grayscale-5, rgba(128, 128, 128, 0.15));
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
   }
 }
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -44,13 +44,6 @@ products:
     slug: sdks
     subtitle: Generate client libraries in multiple languages
 
-  - display-name: CLI Generator
-    path: ./products/cli-generator/cli-generator.yml
-    icon: fa-regular fa-rectangle-terminal
-    image: ./images/product-switcher/product-switcher-cli-generator-light.png
-    slug: cli-generator
-    subtitle: Generate a CLI from your API definition
-
   - display-name: Docs
     path: ./products/docs/docs.yml
     icon: fa-regular fa-browser
@@ -58,12 +51,12 @@ products:
     slug: docs
     subtitle: Generate beautiful, interactive documentation websites
 
-  - display-name: Dashboard
-    path: ./products/dashboard/dashboard.yml
-    icon: fa-regular fa-grid-2
-    image: ./images/product-switcher/product-switcher-dashboard-light.png
-    slug: dashboard
-    subtitle: Manage your Fern projects and settings
+  - display-name: CLI Generator
+    path: ./products/cli-generator/cli-generator.yml
+    icon: fa-regular fa-rectangle-terminal
+    image: ./images/product-switcher/product-switcher-cli-generator-light.png
+    slug: cli-generator
+    subtitle: Generate a CLI from your API definition
 
   - display-name: Fern CLI
     subtitle: Manage and configure your Fern projects
@@ -71,6 +64,13 @@ products:
     icon: fa-regular fa-terminal
     image: ./images/product-switcher/product-switcher-cliapi-light.png
     slug: cli-api-reference
+
+  - display-name: Dashboard
+    path: ./products/dashboard/dashboard.yml
+    icon: fa-regular fa-grid-2
+    image: ./images/product-switcher/product-switcher-dashboard-light.png
+    slug: dashboard
+    subtitle: Manage your Fern projects and settings
 
   - display-name: API Definitions
     path: ./products/api-def/api-def.yml


### PR DESCRIPTION
## Summary

Reorders the product switcher dropdown on `buildwithfern.com/learn` so the
primary products (Home, SDKs, Docs, CLI Generator) appear first, followed
by a divider, then secondary products (Fern CLI, Dashboard). The specs
column (OpenAPI, AsyncAPI, OpenRPC, gRPC) on the right is unchanged.

### Layout

Desktop (≥1024px) grid:

```
Row 1:   Home              | SDKs             | OpenAPI
Row 2:   Docs              | CLI Generator    | AsyncAPI
        ───── divider ─────                   | OpenRPC
Row 3:   Fern CLI          | Dashboard        | gRPC
```

Mobile / tablet (<1024px) stacks vertically in the same order with a
thin rule above Fern CLI to mirror the divider.

### Changes

- `fern/docs.yml`: reorder the `products` list to: Home → SDKs → Docs →
  CLI Generator → Fern CLI → Dashboard (specs entries unchanged).
- `fern/assets/styles.css`:
  - Update the desktop grid placement so Docs+CLI Generator occupy row 2
    and Fern CLI+Dashboard occupy row 3.
  - Add a `::after` pseudo-element on `.fern-product-selector-radio-group`
    that draws a 1px divider in the gap between row 2 and row 3,
    spanning columns 1 and 2 only.
  - Add a `border-top` divider above Fern CLI for stacked layouts.

## Review & Testing Checklist for Human

- [ ] Open the Vercel preview, click the "Docs" product switcher in the
      header on a desktop viewport, and verify the order matches the
      layout above with the divider visible between row 2 and row 3.
- [ ] Confirm the specs column on the right (OpenAPI, AsyncAPI, OpenRPC,
      gRPC) looks visually identical to today.
- [ ] Resize the viewport below ~1024px (or open on mobile) and verify
      the stacked dropdown still shows a divider above Fern CLI.
- [ ] Toggle to dark mode and check the divider color still reads as a
      subtle hairline (uses `--grayscale-5`).

### Notes

The divider is drawn purely in CSS — no schema or component changes are
required. The math for the desktop divider position is keyed to the
existing `height: 248px`, `padding: 1.25rem`, and `gap: 1.5rem` on the
radio group; if those values change the divider position may need to be
retuned.

Link to Devin session: https://app.devin.ai/sessions/8b89134331b8478fa7ab28ecd2091911
Requested by: @kgowru