### PR TITLE
Add Fern Replay docs and migration guide

### DIFF
--- a/.vale/styles/FernStyles/Headings.yml
+++ b/.vale/styles/FernStyles/Headings.yml
@@ -90,3 +90,4 @@ exceptions:
   - OG
   - BCP
   - ISO
+  - Replay

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -38,6 +38,8 @@ hideOnThisPage: true
 | [`fern generate`](#fern-generate) | Build & publish SDK updates |
 | [`fern write-overrides`](#fern-write-overrides) | Create OpenAPI customizations |
 | [`fern generator upgrade`](#fern-generator-upgrade) | Update SDK generators to latest versions |
+| [`fern replay resolve`](#fern-replay-resolve) | Resolve patch conflicts left by [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay) |
+| [`fern replay forget`](#fern-replay-forget) | Remove tracked customization patches from `.fern/replay.lock` |
 
 ## Detailed command documentation
 
@@ -173,7 +175,7 @@ hideOnThisPage: true
 
     <CodeBlock title="terminal">
     ```bash
-    fern generate [--group <group>] [--api <api>] [--version <version>] [--preview] [--fernignore <path>] [--local] [--force]
+    fern generate [--group <group>] [--api <api>] [--version <version>] [--preview] [--fernignore <path>] [--local] [--force] [--no-replay]
     ```
     </CodeBlock>
 
@@ -269,6 +271,18 @@ hideOnThisPage: true
     # Generate without confirmation prompts
     fern generate --group python-sdk --force
     ```
+
+    ### no-replay
+
+    Use `--no-replay` to skip [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay)'s patch detection and application phase for a single generation. The generation still produces the new SDK code, but tracked customization patches aren't applied on top. Useful for a clean regeneration — for example, to debug whether a conflict is caused by a specific patch.
+
+    ```bash
+    fern generate --no-replay --local
+    ```
+
+    <Note>
+    `--no-replay` works only for local generation (`--local`).
+    </Note>
 
   </Accordion>
 
@@ -708,6 +722,75 @@ hideOnThisPage: true
      Use `--include-major` to include major version upgrades. Major versions are skipped by default to prevent breaking changes.
   
   </Accordion>
+
+  <Accordion title="fern replay resolve">
+
+    Use `fern replay resolve` to work through patch conflicts that [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay) couldn't merge cleanly during `fern generate`. The command runs in two phases: the first run applies unresolved patches to your working tree with standard merge markers (`<<<<<<<` / `=======` / `>>>>>>>`) for you to edit; the second run verifies no markers remain and commits the resolved patches.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern replay resolve [directory] [--no-check-markers]
+    ```
+    </CodeBlock>
+
+    ### directory
+
+    Path to the SDK directory containing `.fern/replay.lock`. Defaults to the current directory.
+
+    ### no-check-markers
+
+    Skip the conflict-marker check before committing. Use with caution — committing files that still contain merge markers will break the next regeneration.
+
+  </Accordion>
+
+  <Accordion title="fern replay forget">
+
+    Use `fern replay forget` to remove tracked customization patches from `.fern/replay.lock`. Useful when the generator now supports a customization natively, or when you want to stop replaying a specific edit on future regenerations.
+
+    <CodeBlock title="terminal">
+    ```bash
+    fern replay forget <patch-id-or-pattern>... [--all] [--dry-run] [--yes]
+    ```
+    </CodeBlock>
+
+    The command accepts three modes:
+
+    - **By patch ID.** Pass one or more patch IDs to remove specific patches.
+
+      ```bash
+      fern replay forget patch-abc123 patch-def456
+      ```
+
+    - **By search pattern.** Pass a pattern to find matching patches. The command shows the matches with diff stats and prompts for confirmation before removing.
+
+      ```bash
+      fern replay forget "src/utils"
+      ```
+
+    - **All patches.** Pass `--all` to remove every tracked patch.
+
+      ```bash
+      fern replay forget --all
+      ```
+
+    ### dry-run
+
+    Show what would be removed without actually removing.
+
+    ```bash
+    fern replay forget "src/utils" --dry-run
+    ```
+
+    ### yes
+
+    Skip confirmation prompts. Required in non-interactive or CI environments.
+
+    ```bash
+    fern replay forget "src/utils" --yes
+    ```
+
+  </Accordion>
+
   <Accordion title="fern api update">
   Pulls the latest OpenAPI spec from the specified `origin` in `generators.yml` and
   updates the local spec. Alternatively, you can [automate this process by setting up a GitHub Action](/api-definitions/openapi/sync-your-open-api-specification).

--- a/fern/products/cli-api-reference/pages/commands.mdx
+++ b/fern/products/cli-api-reference/pages/commands.mdx
@@ -38,7 +38,7 @@ hideOnThisPage: true
 | [`fern generate`](#fern-generate) | Build & publish SDK updates |
 | [`fern write-overrides`](#fern-write-overrides) | Create OpenAPI customizations |
 | [`fern generator upgrade`](#fern-generator-upgrade) | Update SDK generators to latest versions |
-| [`fern replay resolve`](#fern-replay-resolve) | Resolve patch conflicts left by [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay) |
+| [`fern replay resolve`](#fern-replay-resolve) | Resolve patch conflicts left by [Fern Replay](/learn/sdks/overview/custom-code#replay) |
 | [`fern replay forget`](#fern-replay-forget) | Remove tracked customization patches from `.fern/replay.lock` |
 
 ## Detailed command documentation
@@ -274,7 +274,7 @@ hideOnThisPage: true
 
     ### no-replay
 
-    Use `--no-replay` to skip [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay)'s patch detection and application phase for a single generation. The generation still produces the new SDK code, but tracked customization patches aren't applied on top. Useful for a clean regeneration — for example, to debug whether a conflict is caused by a specific patch.
+    Use `--no-replay` to skip [Fern Replay](/learn/sdks/overview/custom-code#replay)'s patch detection and application phase for a single generation. The generation still produces the new SDK code, but tracked customization patches aren't applied on top. Useful for a clean regeneration — for example, to debug whether a conflict is caused by a specific patch.
 
     ```bash
     fern generate --no-replay --local
@@ -725,7 +725,7 @@ hideOnThisPage: true
 
   <Accordion title="fern replay resolve">
 
-    Use `fern replay resolve` to work through patch conflicts that [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay) couldn't merge cleanly during `fern generate`. The command runs in two phases: the first run applies unresolved patches to your working tree with standard merge markers (`<<<<<<<` / `=======` / `>>>>>>>`) for you to edit; the second run verifies no markers remain and commits the resolved patches.
+    Use `fern replay resolve` to work through patch conflicts that [Fern Replay](/learn/sdks/overview/custom-code#replay) couldn't merge cleanly during `fern generate`. The command runs in two phases: the first run applies unresolved patches to your working tree with standard merge markers (`<<<<<<<` / `=======` / `>>>>>>>`) for you to edit; the second run verifies no markers remain and commits the resolved patches.
 
     <CodeBlock title="terminal">
     ```bash

--- a/fern/products/sdks/custom-code.mdx
+++ b/fern/products/sdks/custom-code.mdx
@@ -84,7 +84,7 @@ If the generator and your customization changed the same lines, Replay reports t
 
 ### Disable Replay
 
-To disable Replay for a specific generator, set `replay.enabled: false` in `generators.yml`. See the [`replay` reference](/learn/sdks/reference/generators-yml#replay) for global and per-generator configuration.
+To disable Replay, set `replay.enabled: false` at the top level of `generators.yml`. See the [`replay` reference](/learn/sdks/reference/generators-yml#replay).
 
 ## Customization patterns by language
 

--- a/fern/products/sdks/custom-code.mdx
+++ b/fern/products/sdks/custom-code.mdx
@@ -67,12 +67,6 @@ You'll have a separate `.fernignore` file for each of your SDKs:
 
 ## Line-level edits with Replay [#replay]
 
-<Note title="Requirements">
-Replay is on by default for SDKs using [`pull-request` output mode](/learn/sdks/reference/generators-yml#pull-request). To enable Replay on an SDK that's currently on `release` or `push` mode, switch to `pull-request` mode via the [migration guide](/learn/sdks/overview/replay-migration).
-</Note>
-
-To confirm Replay is active, run `fern generate` once and check that `.fern/replay.lock` is committed to your SDK repo. From that point on, edits you make to generated files are tracked automatically.
-
 Replay automatically preserves the edits you make to your generated SDK across regenerations. When you commit a change to generated code, Replay scans your repo's history since the last `[fern-generated]` commit and stores each customer commit as a tracked patch in `.fern/replay.lock`. On the next `fern generate`, those patches are reapplied to the freshly generated SDK via 3-way merge, and the result lands as a `[fern-replay]` commit on top of `[fern-generated]` in the regeneration PR:
 
 ```text title="Regeneration PR"
@@ -83,6 +77,12 @@ Replay automatically preserves the edits you make to your generated SDK across r
 ```
 
 If the generator and your customization changed the same lines, Replay reports the conflict in the PR body. Run [`fern replay resolve`](/learn/cli-api-reference/cli-reference/commands#fern-replay-resolve) locally to walk through it.
+
+### Enable Replay
+
+Replay is on by default for SDKs using [`pull-request` output mode](/learn/sdks/reference/generators-yml#pull-request). To enable Replay on an SDK that's currently on `release` or `push` mode, switch to `pull-request` mode via the [migration guide](/learn/sdks/overview/replay-migration).
+
+To confirm Replay is active, run `fern generate` once and check that `.fern/replay.lock` is committed to your SDK repo. From that point on, edits you make to generated files are tracked automatically.
 
 ### Disable Replay
 

--- a/fern/products/sdks/custom-code.mdx
+++ b/fern/products/sdks/custom-code.mdx
@@ -12,7 +12,7 @@ Fern provides two complementary tools for keeping your customizations safe acros
 - **`.fernignore`** — Full-file ownership. The generator stops touching listed files entirely. Use for fully hand-written modules, READMEs, or custom workflows. Trade-off: you also stop receiving generator updates to those files.
 - **Replay** — Line-level edits. Keep generated files under generator control, and reapply your edits via 3-way merge on every regeneration.
 
-## Full-file ownership with `.fernignore`
+## Full-file ownership with `.fernignore` [#fernignore]
 
 <Note>`.fernignore` applies only to SDK generation. It has no effect on [Fern Docs](/learn/docs/getting-started/overview) builds.</Note>
 
@@ -65,7 +65,7 @@ You'll have a separate `.fernignore` file for each of your SDKs:
   </Folder>
 </Files>
 
-## Line-level edits with Replay
+## Line-level edits with Replay [#replay]
 
 <Note title="Requirements">
 Replay is on by default for SDKs using [`pull-request` output mode](/learn/sdks/reference/generators-yml#pull-request). To enable Replay on an SDK that's currently on `release` or `push` mode, switch to `pull-request` mode via the [migration guide](/learn/sdks/overview/replay-migration).

--- a/fern/products/sdks/custom-code.mdx
+++ b/fern/products/sdks/custom-code.mdx
@@ -13,8 +13,8 @@ Fern provides two complementary tools for keeping your customizations safe acros
 
 ## Preserving customizations with replay
 
-<Note title="Early Access">
-Fern Replay is rolling out across customer orgs. [Contact us](https://buildwithfern.com/contact) to enable it for your organization.
+<Note>
+Replay requires the latest Fern CLI and SDK generator versions. Run `fern upgrade` to make sure you're current.
 </Note>
 
 Replay automatically preserves the edits you make to your generated SDK across regenerations. When you commit a change to generated code, Replay records it as a patch. On the next `fern generate`, the patch is reapplied to the freshly generated SDK using a 3-way merge.

--- a/fern/products/sdks/custom-code.mdx
+++ b/fern/products/sdks/custom-code.mdx
@@ -71,6 +71,8 @@ You'll have a separate `.fernignore` file for each of your SDKs:
 Replay is on by default for SDKs using [`pull-request` output mode](/learn/sdks/reference/generators-yml#pull-request). To enable Replay on an SDK that's currently on `release` or `push` mode, switch to `pull-request` mode via the [migration guide](/learn/sdks/overview/replay-migration).
 </Note>
 
+To confirm Replay is active, run `fern generate` once and check that `.fern/replay.lock` is committed to your SDK repo. From that point on, edits you make to generated files are tracked automatically.
+
 Replay automatically preserves the edits you make to your generated SDK across regenerations. When you commit a change to generated code, Replay scans your repo's history since the last `[fern-generated]` commit and stores each customer commit as a tracked patch in `.fern/replay.lock`. On the next `fern generate`, those patches are reapplied to the freshly generated SDK via 3-way merge, and the result lands as a `[fern-replay]` commit on top of `[fern-generated]` in the regeneration PR:
 
 ```text title="Regeneration PR"

--- a/fern/products/sdks/custom-code.mdx
+++ b/fern/products/sdks/custom-code.mdx
@@ -7,51 +7,18 @@ description: Extend Fern-generated SDKs with custom methods, logic, and dependen
 
 Fern-generated SDKs are designed to be extended with custom logic, methods, and dependencies. If you want your SDK to do more than just make basic API calls (like combining multiple calls, processing data, adding utilities), you can add custom code that lives in harmony with the generated code. 
 
-You can also add custom methods by inheriting the Fern generated client and extending it, plus add any dependencies that your custom methods depend on in your `generators.yml` file.
+Fern provides two complementary tools for keeping your customizations safe across regenerations:
 
-Fern provides two complementary tools for keeping your customizations safe across regenerations: **Replay** for line-level edits to generated files, and **`.fernignore`** for files you own end-to-end.
+- **`.fernignore`** — Full-file ownership. The generator stops touching listed files entirely. Use for fully hand-written modules, READMEs, or custom workflows. Trade-off: you also stop receiving generator updates to those files.
+- **Replay** — Line-level edits. Keep generated files under generator control, and reapply your edits via 3-way merge on every regeneration.
 
-## Preserving customizations with replay
-
-<Note title="Early Access">
-Fern Replay is rolling out across customer orgs. [Contact us](https://buildwithfern.com/contact) to enable it for your organization.
-</Note>
-
-Replay automatically preserves the edits you make to your generated SDK across regenerations. When you commit a change to generated code, Replay records it as a patch. On the next `fern generate`, the patch is reapplied to the freshly generated SDK using a 3-way merge.
-
-Replay handles the common case where `.fernignore` is too heavy-handed: you want to change a few lines, not own the whole file forever.
-
-### How it works
-
-1. Edit generated SDK code and commit to your SDK repo.
-2. On the next `fern generate`, Replay scans your repo's history for customer commits since the last `[fern-generated]` commit and stores each one as a tracked patch in `.fern/replay.lock`.
-3. The patches are reapplied on top of the freshly generated code via 3-way merge.
-4. The result lands as a `[fern-replay]` commit on top of `[fern-generated]` in the regeneration PR.
-
-```text title="Regeneration PR"
-* abc123 (HEAD -> main) [fern-replay] Apply customizations
-* 789abc [fern-generated] Update SDK to spec rev 0451
-* 234bcd Add helpers on top of User type
-* ...
-```
-
-If the generator and your customization changed the same lines, Replay reports the conflict in the PR body. Run `fern replay resolve` locally to walk through it.
-
-### Requirements
-
-Replay requires `pull-request` output mode. If your SDK uses `release` or `push` mode, see the [migration guide](/learn/sdks/overview/replay-migration) for the switch.
-
-### Disable replay
-
-To disable Replay for a specific generator, set `replay.enabled: false` in `generators.yml`. See the [`replay` reference](/learn/sdks/reference/generators-yml#replay) for global and per-generator configuration.
-
-##  Using `.fernignore` to preserve your customizations
-
-Use `.fernignore` to protect files you own end-to-end from being overwritten during SDK regeneration. Where Replay reapplies line-level edits to generated files, `.fernignore` makes the file entirely yours. The generator won't touch it, but generator updates to that file also stop flowing.
-
-Add your custom files to the SDK repository and list them in `.fernignore`. A `.fernignore` file is automatically created in your SDK repository when you use GitHub publishing.
+## Full-file ownership with `.fernignore`
 
 <Note>`.fernignore` applies only to SDK generation. It has no effect on [Fern Docs](/learn/docs/getting-started/overview) builds.</Note>
+
+Use `.fernignore` to protect files you own end-to-end from being overwritten during SDK regeneration.
+
+Add your custom files to the SDK repository and list them in `.fernignore`. A `.fernignore` file is automatically created in your SDK repository when you use GitHub publishing.
 
 Your `.fernignore` file might look something like this:
 
@@ -67,7 +34,8 @@ LICENSE
 # Custom code
 src/CustomClient.ts
 ```
-<Note>For another example, see Cohere's [`.fernignore` file for their TypeScript SDK](https://github.com/cohere-ai/cohere-typescript/blob/ad583e3003bd51e80a82317f9e16beec85881b86/.fernignore).</Note> 
+
+For another real-world example, see Cohere's [`.fernignore` file for their TypeScript SDK](https://github.com/cohere-ai/cohere-typescript/blob/ad583e3003bd51e80a82317f9e16beec85881b86/.fernignore).
 
 You'll have a separate `.fernignore` file for each of your SDKs:
 
@@ -97,24 +65,39 @@ You'll have a separate `.fernignore` file for each of your SDKs:
   </Folder>
 </Files>
 
+## Line-level edits with Replay
 
-  ## Augmenting your SDK with custom code
+<Note title="Requirements">
+Replay is on by default for SDKs using [`pull-request` output mode](/learn/sdks/reference/generators-yml#pull-request). To enable Replay on an SDK that's currently on `release` or `push` mode, switch to `pull-request` mode via the [migration guide](/learn/sdks/overview/replay-migration).
 
-  Get started adding custom code to a specific SDK:
+Replay requires the latest Fern CLI and SDK generator versions — run `fern upgrade` to make sure you're current.
+</Note>
 
-    <CardGroup cols={3}>
-    <Card title="TypeScript" icon={<img src="./images/icons/ts-light.svg" alt="TypeScript logo" className="h-6 w-6" noZoom />}  href="/sdks/generators/typescript/custom-code">
-    </Card>
-    <Card title="Python" icon={<img src="./images/icons/python-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/python/custom-code">
-    </Card>
-    <Card title="Go" icon={<img src="./images/icons/go-light.svg" className="h-6 w-6" noZoom />} href="/learn/sdks/generators/go/custom-code">
-    </Card>
-    <Card title="Java" icon={<img src="./images/icons/java-light.svg" className="h-6 w-6" noZoom />} href="/learn/sdks/generators/java/custom-code">
-    </Card>
-    <Card title=".NET" icon={<img src="./images/icons/csharp-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/csharp/custom-code">
-    </Card>
-    <Card title="PHP" icon={<img src="./images/icons/php-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/php/custom-code">
-    </Card>
-    <Card title="Ruby" icon={<img src="./images/icons/ruby-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/ruby/custom-code">
-    </Card>
-  </CardGroup>
+Replay automatically preserves the edits you make to your generated SDK across regenerations. When you commit a change to generated code, Replay scans your repo's history since the last `[fern-generated]` commit and stores each customer commit as a tracked patch in `.fern/replay.lock`. On the next `fern generate`, those patches are reapplied to the freshly generated SDK via 3-way merge, and the result lands as a `[fern-replay]` commit on top of `[fern-generated]` in the regeneration PR:
+
+```text title="Regeneration PR"
+* abc123 (HEAD -> main) [fern-replay] Apply customizations
+* 789abc [fern-generated] Update SDK to spec rev 0451
+* 234bcd Add helpers on top of User type
+* ...
+```
+
+If the generator and your customization changed the same lines, Replay reports the conflict in the PR body. Run [`fern replay resolve`](/learn/cli-api-reference/cli-reference/commands#fern-replay-resolve) locally to walk through it.
+
+### Disable Replay
+
+To disable Replay for a specific generator, set `replay.enabled: false` in `generators.yml`. See the [`replay` reference](/learn/sdks/reference/generators-yml#replay) for global and per-generator configuration.
+
+## Customization patterns by language
+
+Each SDK generator has its own conventions for adding custom code: how to extend the generated client, where helpers go, how to declare dependencies. See the guide for your language:
+
+<CardGroup cols={4}>
+  <Card title="TypeScript" icon={<img src="./images/icons/ts-light.svg" alt="TypeScript logo" className="h-6 w-6" noZoom />} href="/sdks/generators/typescript/custom-code" />
+  <Card title="Python" icon={<img src="./images/icons/python-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/python/custom-code" />
+  <Card title="Go" icon={<img src="./images/icons/go-light.svg" className="h-6 w-6" noZoom />} href="/learn/sdks/generators/go/custom-code" />
+  <Card title="Java" icon={<img src="./images/icons/java-light.svg" className="h-6 w-6" noZoom />} href="/learn/sdks/generators/java/custom-code" />
+  <Card title=".NET" icon={<img src="./images/icons/csharp-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/csharp/custom-code" />
+  <Card title="PHP" icon={<img src="./images/icons/php-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/php/custom-code" />
+  <Card title="Ruby" icon={<img src="./images/icons/ruby-light.svg" className="h-6 w-6" noZoom />} href="/sdks/generators/ruby/custom-code" />
+</CardGroup>

--- a/fern/products/sdks/custom-code.mdx
+++ b/fern/products/sdks/custom-code.mdx
@@ -69,8 +69,6 @@ You'll have a separate `.fernignore` file for each of your SDKs:
 
 <Note title="Requirements">
 Replay is on by default for SDKs using [`pull-request` output mode](/learn/sdks/reference/generators-yml#pull-request). To enable Replay on an SDK that's currently on `release` or `push` mode, switch to `pull-request` mode via the [migration guide](/learn/sdks/overview/replay-migration).
-
-Replay requires the latest Fern CLI and SDK generator versions — run `fern upgrade` to make sure you're current.
 </Note>
 
 Replay automatically preserves the edits you make to your generated SDK across regenerations. When you commit a change to generated code, Replay scans your repo's history since the last `[fern-generated]` commit and stores each customer commit as a tracked patch in `.fern/replay.lock`. On the next `fern generate`, those patches are reapplied to the freshly generated SDK via 3-way merge, and the result lands as a `[fern-replay]` commit on top of `[fern-generated]` in the regeneration PR:

--- a/fern/products/sdks/custom-code.mdx
+++ b/fern/products/sdks/custom-code.mdx
@@ -11,7 +11,7 @@ You can also add custom methods by inheriting the Fern generated client and exte
 
 Fern provides two complementary tools for keeping your customizations safe across regenerations: **Replay** for line-level edits to generated files, and **`.fernignore`** for files you own end-to-end.
 
-## Preserving customizations with Replay
+## Preserving customizations with replay
 
 <Note title="Early Access">
 Fern Replay is rolling out across customer orgs. [Contact us](https://buildwithfern.com/contact) to enable it for your organization.
@@ -41,7 +41,7 @@ If the generator and your customization changed the same lines, Replay reports t
 
 Replay requires `pull-request` output mode. If your SDK uses `release` or `push` mode, see the [migration guide](/learn/sdks/overview/replay-migration) for the switch.
 
-### Disable Replay
+### Disable replay
 
 To disable Replay for a specific generator, set `replay.enabled: false` in `generators.yml`. See the [`replay` reference](/learn/sdks/reference/generators-yml#replay) for global and per-generator configuration.
 

--- a/fern/products/sdks/custom-code.mdx
+++ b/fern/products/sdks/custom-code.mdx
@@ -1,7 +1,7 @@
 ---
 title: Adding custom code
 headline: Adding custom code (overview)
-description: Extend Fern-generated SDKs with custom methods, logic, and dependencies. Use .fernignore to protect your code from being overwritten during regeneration.
+description: Extend Fern-generated SDKs with custom methods, logic, and dependencies. Use Fern Replay for line-level edits and .fernignore for files you own end-to-end.
 ---
 
 
@@ -9,11 +9,47 @@ Fern-generated SDKs are designed to be extended with custom logic, methods, and 
 
 You can also add custom methods by inheriting the Fern generated client and extending it, plus add any dependencies that your custom methods depend on in your `generators.yml` file.
 
+Fern provides two complementary tools for keeping your customizations safe across regenerations: **Replay** for line-level edits to generated files, and **`.fernignore`** for files you own end-to-end.
+
+## Preserving customizations with Replay
+
+<Note title="Early Access">
+Fern Replay is rolling out across customer orgs. [Contact us](https://buildwithfern.com/contact) to enable it for your organization.
+</Note>
+
+Replay automatically preserves the edits you make to your generated SDK across regenerations. When you commit a change to generated code, Replay records it as a patch. On the next `fern generate`, the patch is reapplied to the freshly generated SDK using a 3-way merge.
+
+Replay handles the common case where `.fernignore` is too heavy-handed: you want to change a few lines, not own the whole file forever.
+
+### How it works
+
+1. Edit generated SDK code and commit to your SDK repo.
+2. On the next `fern generate`, Replay scans your repo's history for customer commits since the last `[fern-generated]` commit and stores each one as a tracked patch in `.fern/replay.lock`.
+3. The patches are reapplied on top of the freshly generated code via 3-way merge.
+4. The result lands as a `[fern-replay]` commit on top of `[fern-generated]` in the regeneration PR.
+
+```text title="Regeneration PR"
+* abc123 (HEAD -> main) [fern-replay] Apply customizations
+* 789abc [fern-generated] Update SDK to spec rev 0451
+* 234bcd Add helpers on top of User type
+* ...
+```
+
+If the generator and your customization changed the same lines, Replay reports the conflict in the PR body. Run `fern replay resolve` locally to walk through it.
+
+### Requirements
+
+Replay requires `pull-request` output mode. If your SDK uses `release` or `push` mode, see the [migration guide](/learn/sdks/overview/replay-migration) for the switch.
+
+### Disable Replay
+
+To disable Replay for a specific generator, set `replay.enabled: false` in `generators.yml`. See the [`replay` reference](/learn/sdks/reference/generators-yml#replay) for global and per-generator configuration.
+
 ##  Using `.fernignore` to preserve your customizations
 
-Once you add files containing custom code, use `.fernignore` to protect your custom code from being overwritten when Fern regenerates your SDK.
+Use `.fernignore` to protect files you own end-to-end from being overwritten during SDK regeneration. Where Replay reapplies line-level edits to generated files, `.fernignore` makes the file entirely yours. The generator won't touch it, but generator updates to that file also stop flowing.
 
-Simply add your custom files to the SDK repository and list them in `.fernignore`. Fern won't override any files listed there. A `.fernignore` file is automatically created in your SDK repository when you use GitHub publishing.
+Add your custom files to the SDK repository and list them in `.fernignore`. A `.fernignore` file is automatically created in your SDK repository when you use GitHub publishing.
 
 <Note>`.fernignore` applies only to SDK generation. It has no effect on [Fern Docs](/learn/docs/getting-started/overview) builds.</Note>
 

--- a/fern/products/sdks/generators/csharp/custom-code.mdx
+++ b/fern/products/sdks/generators/csharp/custom-code.mdx
@@ -7,11 +7,11 @@ description: Add custom logic and methods to your .NET SDK with Fern. Extend Bas
 
 This page covers how to add custom logic and methods to your .NET SDK. 
 
-<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
-
 ## Adding custom logic
 
 To get started adding custom code:
+
+<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
 
 <Steps>
   <Step title="Create a new file and add your custom logic">

--- a/fern/products/sdks/generators/go/custom-code.mdx
+++ b/fern/products/sdks/generators/go/custom-code.mdx
@@ -7,11 +7,11 @@ description: Learn how to add custom logic and methods to your Go SDK with Fern.
 
 This page covers how to add custom logic and methods to your Go SDK. 
 
-<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
-
 ## Adding custom logic
 
 To get started adding custom code:
+
+<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
 
 <Steps>
 

--- a/fern/products/sdks/generators/java/custom-code.mdx
+++ b/fern/products/sdks/generators/java/custom-code.mdx
@@ -7,11 +7,11 @@ description: Augment your Java SDK with custom utilities
 
 This page covers how to add custom logic, methods, and dependencies to your TypeScript SDK. 
 
-<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
-
 ## Adding custom logic
 
 To get started adding custom code:
+
+<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
 
 <Steps>
 

--- a/fern/products/sdks/generators/php/custom-code.mdx
+++ b/fern/products/sdks/generators/php/custom-code.mdx
@@ -7,11 +7,11 @@ description: Learn how to add custom logic, methods, and dependencies to your PH
 
 This page covers how to add custom logic, methods, and dependencies to your PHP SDK. 
 
-<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
-
 ## Adding custom logic
 
 To get started adding custom code:
+
+<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
 
 <Steps>
   <Step title="Create a new file and add your custom logic">

--- a/fern/products/sdks/generators/python/custom-code.mdx
+++ b/fern/products/sdks/generators/python/custom-code.mdx
@@ -7,11 +7,11 @@ description: Learn how to add custom logic, methods, and dependencies to your Py
 
 This page covers how to add custom logic, methods, and dependencies to your Python SDK. 
 
-<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
-
 ## Adding custom logic
 
 To get started adding custom code:
+
+<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
 
 <Steps>
 

--- a/fern/products/sdks/generators/ruby/custom-code.mdx
+++ b/fern/products/sdks/generators/ruby/custom-code.mdx
@@ -7,11 +7,11 @@ description: Augment your Ruby SDK with custom utilities
 
 This page covers how to add custom logic, methods, and dependencies to your Ruby SDK. 
 
-<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
-
 ## Adding custom logic
 
 To get started adding custom code:
+
+<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
 
 <Steps>
   <Step title="Create a new file and add your custom logic">

--- a/fern/products/sdks/generators/typescript/custom-code.mdx
+++ b/fern/products/sdks/generators/typescript/custom-code.mdx
@@ -7,11 +7,11 @@ description: Learn how to add custom logic, methods, and dependencies to your Ty
 
 This page covers how to add custom logic, methods, and dependencies to your TypeScript SDK. 
 
-<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
-
 ## Adding custom logic
 
 To get started adding custom code:
+
+<Markdown src="/products/sdks/snippets/custom-code-callout.mdx"/>
 
 <Steps>
 

--- a/fern/products/sdks/reference/generators-yml-reference.mdx
+++ b/fern/products/sdks/reference/generators-yml-reference.mdx
@@ -408,7 +408,7 @@ autorelease: true
 
 ## `replay`
 
-Override [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay) behavior globally. Replay runs based on your organization's configuration; use this setting to disable it across all generators in this `generators.yml`. Alternatively, you can [configure Replay for individual SDKs](#replay-1).
+Override [Fern Replay](/learn/sdks/overview/custom-code#replay) behavior globally. Replay runs based on your organization's configuration; use this setting to disable it across all generators in this `generators.yml`. Alternatively, you can [configure Replay for individual SDKs](#replay-1).
 
 ```yaml title="generators.yml"
 replay:
@@ -1034,7 +1034,7 @@ groups:
 
 #### `replay`
 
-Override [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay) for an individual SDK. Alternatively, you can [configure Replay globally for all SDKs](#replay).
+Override [Fern Replay](/learn/sdks/overview/custom-code#replay) for an individual SDK. Alternatively, you can [configure Replay globally for all SDKs](#replay).
 
 ```yml title="generators.yml" {6-7}
 groups:

--- a/fern/products/sdks/reference/generators-yml-reference.mdx
+++ b/fern/products/sdks/reference/generators-yml-reference.mdx
@@ -406,6 +406,19 @@ autorelease: true
   Set to `true` to enable Autorelease, `false` to disable it. [Per-generator settings](#autorelease-2) override this global configuration.
 </ParamField>
 
+## `replay`
+
+Override [Fern Replay](/learn/sdks/overview/custom-code#preserving-customizations-with-replay) behavior globally. Replay runs based on your organization's configuration; use this setting to disable it across all generators in this `generators.yml`. Alternatively, you can [configure Replay for individual SDKs](#replay-2).
+
+```yaml title="generators.yml"
+replay:
+  enabled: false
+```
+
+<ParamField path="replay.enabled" type="boolean" required={false} toc={true}>
+  Set to `false` to skip Replay for all SDK generations, even if Replay is enabled for your organization. [Per-generator settings](#replay-2) override this global configuration.
+</ParamField>
+
 ## `aliases`
 
 Define shortcuts that map to multiple generator groups, allowing you to run several groups with a single command. When you run `fern generate --group <alias>`, all groups in the alias run in parallel. You can also set an alias as your `default-group`.
@@ -1017,6 +1030,24 @@ groups:
 
 <ParamField path="autorelease" type="boolean" default={false} required={false} toc={true}>
   Set to `true` to enable Autorelease for this generator, `false` to disable it. Per-generator settings override the global [`autorelease`](#autorelease-1) configuration.
+</ParamField>
+
+#### `replay`
+
+Override [Fern Replay](/learn/sdks/overview/custom-code#preserving-customizations-with-replay) for an individual SDK. Alternatively, you can [configure Replay globally for all SDKs](#replay-1).
+
+```yml title="generators.yml" {6-7}
+groups:
+  ts-sdk:
+    generators:
+      - name: fernapi/fern-typescript-sdk
+      ...
+        replay:
+          enabled: false
+```
+
+<ParamField path="replay.enabled" type="boolean" required={false} toc={true}>
+  Set to `false` to skip Replay for this generator, even if Replay is enabled for your organization or globally in this `generators.yml`. Per-generator settings override the global [`replay`](#replay-1) configuration.
 </ParamField>
 
 #### `snippets`

--- a/fern/products/sdks/reference/generators-yml-reference.mdx
+++ b/fern/products/sdks/reference/generators-yml-reference.mdx
@@ -408,7 +408,7 @@ autorelease: true
 
 ## `replay`
 
-Override [Fern Replay](/learn/sdks/overview/custom-code#replay) behavior globally. Replay runs based on your organization's configuration; use this setting to disable it across all generators in this `generators.yml`. Alternatively, you can [configure Replay for individual SDKs](#replay-1).
+Override [Fern Replay](/learn/sdks/overview/custom-code#replay) behavior. Replay runs based on your organization's configuration; use this setting to disable it for all generators in this `generators.yml`.
 
 ```yaml title="generators.yml"
 replay:
@@ -416,7 +416,7 @@ replay:
 ```
 
 <ParamField path="replay.enabled" type="boolean" required={false} toc={true}>
-  Set to `false` to skip Replay for all SDK generations, even if Replay is enabled for your organization. [Per-generator settings](#replay-1) override this global configuration.
+  Set to `false` to skip Replay for all SDK generations in this `generators.yml`, even if Replay is enabled for your organization.
 </ParamField>
 
 ## `aliases`
@@ -1030,24 +1030,6 @@ groups:
 
 <ParamField path="autorelease" type="boolean" default={false} required={false} toc={true}>
   Set to `true` to enable Autorelease for this generator, `false` to disable it. Per-generator settings override the global [`autorelease`](#autorelease-1) configuration.
-</ParamField>
-
-#### `replay`
-
-Override [Fern Replay](/learn/sdks/overview/custom-code#replay) for an individual SDK. Alternatively, you can [configure Replay globally for all SDKs](#replay).
-
-```yml title="generators.yml" {6-7}
-groups:
-  ts-sdk:
-    generators:
-      - name: fernapi/fern-typescript-sdk
-      ...
-        replay:
-          enabled: false
-```
-
-<ParamField path="replay.enabled" type="boolean" required={false} toc={true}>
-  Set to `false` to skip Replay for this generator, even if Replay is enabled for your organization or globally in this `generators.yml`. Per-generator settings override the global [`replay`](#replay) configuration.
 </ParamField>
 
 #### `snippets`

--- a/fern/products/sdks/reference/generators-yml-reference.mdx
+++ b/fern/products/sdks/reference/generators-yml-reference.mdx
@@ -408,7 +408,7 @@ autorelease: true
 
 ## `replay`
 
-Override [Fern Replay](/learn/sdks/overview/custom-code#preserving-customizations-with-replay) behavior globally. Replay runs based on your organization's configuration; use this setting to disable it across all generators in this `generators.yml`. Alternatively, you can [configure Replay for individual SDKs](#replay-2).
+Override [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay) behavior globally. Replay runs based on your organization's configuration; use this setting to disable it across all generators in this `generators.yml`. Alternatively, you can [configure Replay for individual SDKs](#replay-1).
 
 ```yaml title="generators.yml"
 replay:
@@ -416,7 +416,7 @@ replay:
 ```
 
 <ParamField path="replay.enabled" type="boolean" required={false} toc={true}>
-  Set to `false` to skip Replay for all SDK generations, even if Replay is enabled for your organization. [Per-generator settings](#replay-2) override this global configuration.
+  Set to `false` to skip Replay for all SDK generations, even if Replay is enabled for your organization. [Per-generator settings](#replay-1) override this global configuration.
 </ParamField>
 
 ## `aliases`
@@ -1034,7 +1034,7 @@ groups:
 
 #### `replay`
 
-Override [Fern Replay](/learn/sdks/overview/custom-code#preserving-customizations-with-replay) for an individual SDK. Alternatively, you can [configure Replay globally for all SDKs](#replay-1).
+Override [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay) for an individual SDK. Alternatively, you can [configure Replay globally for all SDKs](#replay).
 
 ```yml title="generators.yml" {6-7}
 groups:
@@ -1047,7 +1047,7 @@ groups:
 ```
 
 <ParamField path="replay.enabled" type="boolean" required={false} toc={true}>
-  Set to `false` to skip Replay for this generator, even if Replay is enabled for your organization or globally in this `generators.yml`. Per-generator settings override the global [`replay`](#replay-1) configuration.
+  Set to `false` to skip Replay for this generator, even if Replay is enabled for your organization or globally in this `generators.yml`. Per-generator settings override the global [`replay`](#replay) configuration.
 </ParamField>
 
 #### `snippets`

--- a/fern/products/sdks/replay-migration.mdx
+++ b/fern/products/sdks/replay-migration.mdx
@@ -79,7 +79,7 @@ If you use `version: AUTO`, no other changes are needed. Autoversioning runs as 
 
 ## Phase 3: Decouple publishing from generation (optional)
 
-If you want to control publishing separately from generation, keep your publish workflow out of Fern's generation cycle:
+To control publishing on your own schedule rather than on every Fern generation, keep your publish workflow out of Fern's generation cycle:
 
 1. Add the workflow to `.fernignore`:
 
@@ -104,7 +104,7 @@ on:
 
 3. Update any secret references if you renamed credentials in Phase 1.
 
-## Phase 4: First generation with Replay
+## Phase 4: First generation with replay
 
 1. Run `fern generate --group <group-name>` from the config repo (or trigger via your existing CI).
 2. The first run auto-creates `.fern/replay.lock`. Replay tracks customer commits to generated files from this point on.

--- a/fern/products/sdks/replay-migration.mdx
+++ b/fern/products/sdks/replay-migration.mdx
@@ -16,7 +16,8 @@ This guide migrates an SDK from `release` or `push` output mode to `pull-request
 ## Before you start
 
 - Install the [Fern GitHub App](https://github.com/apps/fern-api) on your SDK repositories.
-- Update to the latest Fern CLI and SDK generator versions (`fern upgrade`).
+- Update to the latest Fern CLI: `fern upgrade`.
+- Update to the latest SDK generator versions: `fern generator upgrade`.
 
 ## Phase 1: Move publishing secrets to the SDK repo
 
@@ -187,7 +188,7 @@ After your first real customization, verify Replay's behavior end-to-end:
 
 Replay never modifies files destructively. Your `main` branch always has correct code, so rolling back is straightforward.
 
-**Quick disable.** If you only want to stop Replay and stay in `pull-request` mode, delete `.fern/replay.lock` from the SDK repo and commit. The next `fern generate` runs without Replay; PRs land in the same shape as before, just without the `[fern-replay]` commit.
+**Quick disable.** To stop Replay while staying in `pull-request` mode, set `replay.enabled: false` in your `generators.yml` (see the [`replay` reference](/learn/sdks/reference/generators-yml#replay)). The next `fern generate` skips the patch detection and application phase; PRs land in the same shape as before, just without the `[fern-replay]` commit.
 
 **Full revert to `release` or `push` mode:**
 
@@ -230,5 +231,5 @@ Re-add the credentials you removed in Phase 1.
 
 ## Known caveats
 
-- **Closed-without-merge replay PRs.** If a replay PR is closed without merging, the next generation detects the abandoned state and re-anchors automatically. No manual cleanup needed.
-- **Force pushes and rewritten history.** Replay handles force-pushed branches via a fallback detection path. Existing patches still apply correctly.
+- **Closed-without-merge replay PRs.** If a replay PR is closed without merging, the next generation re-derives its anchor from the current branch history. No manual cleanup needed.
+- **Force pushes and rewritten history.** Replay re-derives its scan anchor from `git log` on every run, so force-pushed branches continue to work and existing patches still apply correctly.

--- a/fern/products/sdks/replay-migration.mdx
+++ b/fern/products/sdks/replay-migration.mdx
@@ -4,11 +4,11 @@ headline: Migrating from release or push mode to pull-request mode
 description: Step-by-step guide for switching SDK generation from release or push mode to pull-request mode so Fern Replay can run.
 ---
 
-<Note title="Early Access">
-Fern Replay is rolling out across customer orgs. [Contact us](https://buildwithfern.com/contact) to enable it for your organization.
+<Note>
+  Replay requires the latest Fern CLI and SDK generator versions. Run `fern upgrade` to make sure you're current.
 </Note>
 
-[Fern Replay](/learn/sdks/overview/custom-code#preserving-customizations-with-replay) requires `pull-request` output mode. This guide covers the migration from `release` or `push` mode in five phases.
+This guide migrates an SDK from `release` or `push` output mode to `pull-request` output mode — the mode required to enable [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay). Only follow it if your SDK is currently on `release` or `push` mode and you want to switch in order to use Replay. SDKs already using `pull-request` mode have Replay on by default; no migration is needed.
 
 ## What changes
 
@@ -27,15 +27,29 @@ Fern sets GitHub Actions secrets in your SDK repo on every generation. When you 
 
 For each SDK repo:
 
-1. Identify which secrets your `generators.yml` references for publishing:
-    - Python: `PYPI_USERNAME`, `PYPI_PASSWORD`
-    - TypeScript / npm: `NPM_TOKEN`
-    - Java / Maven: `MAVEN_USERNAME`, `MAVEN_PASSWORD`, `MAVEN_SIGNATURE_KID`, `MAVEN_SIGNATURE_PASSWORD`, `MAVEN_SIGNATURE_SECRET_KEY`
-    - Ruby: `RUBY_GEMS_API_KEY`
-    - C# / NuGet: `NUGET_API_KEY`
-    - Rust / Crates: `CRATES_TOKEN`
-2. Add the real publish credentials directly to the SDK repo: **Settings → Secrets and variables → Actions → New repository secret**.
-3. Remove the publish credential values from the config repo's `generators.yml`:
+<Steps>
+<Step title="Identify the publishing secrets">
+
+Find which secrets your `generators.yml` references for publishing:
+
+- Python: `PYPI_USERNAME`, `PYPI_PASSWORD`
+- TypeScript / npm: `NPM_TOKEN`
+- Java / Maven: `MAVEN_USERNAME`, `MAVEN_PASSWORD`, `MAVEN_SIGNATURE_KID`, `MAVEN_SIGNATURE_PASSWORD`, `MAVEN_SIGNATURE_SECRET_KEY`
+- Ruby: `RUBY_GEMS_API_KEY`
+- C# / NuGet: `NUGET_API_KEY`
+- Rust / Crates: `CRATES_TOKEN`
+
+</Step>
+
+<Step title="Add credentials to the SDK repo">
+
+Add the real publish credentials directly to the SDK repo: **Settings → Secrets and variables → Actions → New repository secret**.
+
+</Step>
+
+<Step title="Remove credentials from generators.yml">
+
+Remove the publish credential values from the config repo's `generators.yml`:
 
 ```yaml title="generators.yml"
 # BEFORE
@@ -63,7 +77,14 @@ groups:
           mode: pull-request
 ```
 
-4. Run a generation. Confirm the SDK repo's secrets weren't overwritten by checking the "Last updated" timestamp under **SDK repo → Settings → Secrets**.
+</Step>
+
+<Step title="Verify secrets are preserved">
+
+Run a generation. Confirm the SDK repo's secrets weren't overwritten by checking the "Last updated" timestamp under **SDK repo → Settings → Secrets**.
+
+</Step>
+</Steps>
 
 ## Phase 2: Switch output mode
 
@@ -81,13 +102,18 @@ If you use `version: AUTO`, no other changes are needed. Autoversioning runs as 
 
 To control publishing on your own schedule rather than on every Fern generation, keep your publish workflow out of Fern's generation cycle:
 
-1. Add the workflow to `.fernignore`:
+<Steps>
+<Step title="Add the workflow to .fernignore">
 
 ```text title=".fernignore"
 .github/workflows/ci.yml
 ```
 
-2. Change the workflow trigger from push-to-main to manual or release-tagged:
+</Step>
+
+<Step title="Change the workflow trigger">
+
+Switch from push-to-main to manual or release-tagged:
 
 ```yaml title=".github/workflows/ci.yml"
 # Instead of:
@@ -102,21 +128,50 @@ on:
     types: [published]
 ```
 
-3. Update any secret references if you renamed credentials in Phase 1.
+</Step>
+
+<Step title="Update secret references">
+
+Update any secret references if you renamed credentials in Phase 1.
+
+</Step>
+</Steps>
 
 ## Phase 4: First generation with replay
 
-1. Run `fern generate --group <group-name>` from the config repo (or trigger via your existing CI).
-2. The first run auto-creates `.fern/replay.lock`. Replay tracks customer commits to generated files from this point on.
-3. Review the resulting PR. It contains:
-    - `[fern-generated]`: pure generator output
-    - `[fern-replay]`: patches re-applied (empty on first run, since no patches exist yet)
-    - Updated `.fern/replay.lock`
-4. Squash-merge the PR. The next generation re-anchors correctly even after the squash.
+<Steps>
+<Step title="Run fern generate">
+
+Run `fern generate --group <group-name>` from the config repo (or trigger via your existing CI).
+
+</Step>
+
+<Step title="Confirm the lockfile was created">
+
+The first run auto-creates `.fern/replay.lock`. Replay tracks customer commits to generated files from this point on.
+
+</Step>
+
+<Step title="Review the resulting PR">
+
+The PR contains:
+
+- `[fern-generated]`: pure generator output
+- `[fern-replay]`: patches re-applied (empty on first run, since no patches exist yet)
+- Updated `.fern/replay.lock`
+
+</Step>
+
+<Step title="Squash-merge the PR">
+
+The next generation re-anchors correctly even after the squash.
+
+</Step>
+</Steps>
 
 ## Phase 5: Validate
 
-After the first generation and merge:
+After the first generation and merge, confirm the following:
 
 - A PR was created (not a direct push to `main`).
 - No unintended package release was triggered.
@@ -139,7 +194,8 @@ Replay never modifies files destructively. Your `main` branch always has correct
 
 **Full revert to `release` or `push` mode:**
 
-1. Switch `mode` back in `generators.yml`:
+<Steps>
+<Step title="Switch mode back in generators.yml">
 
 ```yaml title="generators.yml" {3}
 github:
@@ -147,18 +203,33 @@ github:
   mode: release   # or mode: push
 ```
 
-2. Re-add publish credentials to the config repo (if you removed them in Phase 1).
-3. Clean up Replay state in the SDK repo:
-    - Delete `.fern/replay.lock`
-    - Delete `.fern/replay.yml`
-    - Delete the `fern-generation-base` tag if it exists
-4. Close any open `fern-bot` PRs from PR mode.
+</Step>
 
-## Escape hatches
+<Step title="Re-add publish credentials to the config repo">
 
-- `fern generate --no-replay`: skip patch application for one generation. Generation still creates `[fern-generated]`; patches aren't applied. Useful for debugging.
-- `fern replay forget <pattern>`: untrack specific patches. The next generation overwrites those files.
-- `fern replay reset`: delete the lockfile entirely. Your code stays, but Replay loses all state. Run `fern replay bootstrap` to start fresh.
+Re-add the credentials you removed in Phase 1.
+
+</Step>
+
+<Step title="Clean up Replay state in the SDK repo">
+
+- Delete `.fern/replay.lock`
+- Delete `.fern/replay.yml`
+- Delete the `fern-generation-base` tag if it exists
+
+</Step>
+
+<Step title="Close any open fern-bot PRs from PR mode">
+
+</Step>
+</Steps>
+
+## Troubleshooting
+
+| Command | Effect |
+|---------|--------|
+| [`fern generate --no-replay`](/learn/cli-api-reference/cli-reference/commands#no-replay) | Skip patch application for one generation. Generation still creates `[fern-generated]`; patches aren't applied. Useful for debugging. |
+| [`fern replay forget`](/learn/cli-api-reference/cli-reference/commands#fern-replay-forget) | Untrack patches by ID, by pattern, or all at once. The next generation overwrites those files. |
 
 ## Known caveats
 

--- a/fern/products/sdks/replay-migration.mdx
+++ b/fern/products/sdks/replay-migration.mdx
@@ -4,10 +4,6 @@ headline: Migrating from release or push mode to pull-request mode
 description: Step-by-step guide for switching SDK generation from release or push mode to pull-request mode so Fern Replay can run.
 ---
 
-<Note>
-  Replay requires the latest Fern CLI and SDK generator versions. Run `fern upgrade` to make sure you're current.
-</Note>
-
 This guide migrates an SDK from `release` or `push` output mode to `pull-request` output mode — the mode required to enable [Fern Replay](/learn/sdks/overview/custom-code#replay). Only follow it if your SDK is currently on `release` or `push` mode and you want to switch in order to use Replay. SDKs already using `pull-request` mode have Replay on by default; no migration is needed.
 
 ## What changes
@@ -24,7 +20,7 @@ This guide migrates an SDK from `release` or `push` output mode to `pull-request
 
 ## Phase 1: Move publishing secrets to the SDK repo
 
-Fern sets GitHub Actions secrets in your SDK repo on every generation. When you switch to PR mode, that write would clobber any secrets you set directly. To avoid this, move secret ownership from the config repo to the SDK repo before flipping modes.
+Fern sets GitHub Actions secrets in your SDK repo on every generation. When you switch to `pull-request` output mode, that write would clobber any secrets you set directly. To avoid this, move secret ownership from the config repo to the SDK repo before flipping modes.
 
 For each SDK repo:
 
@@ -48,7 +44,7 @@ Add the real publish credentials directly to the SDK repo: **Settings → Secret
 
 </Step>
 
-<Step title="Remove credentials from generators.yml">
+<Step title="Remove credentials from `generators.yml`">
 
 Remove the publish credential values from the config repo's `generators.yml`:
 
@@ -138,7 +134,7 @@ Update any secret references if you renamed credentials in Phase 1.
 </Step>
 </Steps>
 
-## Phase 4: First generation with replay
+## Phase 4: First generation with Replay
 
 <Steps>
 <Step title="Run fern generate">

--- a/fern/products/sdks/replay-migration.mdx
+++ b/fern/products/sdks/replay-migration.mdx
@@ -1,0 +1,166 @@
+---
+title: Migrating to Replay
+headline: Migrating from release or push mode to pull-request mode
+description: Step-by-step guide for switching SDK generation from release or push mode to pull-request mode so Fern Replay can run.
+---
+
+<Note title="Early Access">
+Fern Replay is rolling out across customer orgs. [Contact us](https://buildwithfern.com/contact) to enable it for your organization.
+</Note>
+
+[Fern Replay](/learn/sdks/overview/custom-code#preserving-customizations-with-replay) requires `pull-request` output mode. This guide covers the migration from `release` or `push` mode in five phases.
+
+## What changes
+
+- SDK updates arrive as PRs instead of direct pushes to `main`.
+- Customizations to generated code survive regeneration via 3-way merge.
+- Version bumps are computed from pure generator output, never contaminated by customizations.
+- Publishing is decoupled from generation, so you control when to release.
+
+## Before you start
+
+Make sure the [Fern GitHub App](https://github.com/apps/fern-api) is installed on your SDK repositories. [Contact us](https://buildwithfern.com/contact) to flip your organization onto the Replay-enabled pipeline.
+
+## Phase 1: Move publishing secrets to the SDK repo
+
+Fern sets GitHub Actions secrets in your SDK repo on every generation. When you switch to PR mode, that write would clobber any secrets you set directly. To avoid this, move secret ownership from the config repo to the SDK repo before flipping modes.
+
+For each SDK repo:
+
+1. Identify which secrets your `generators.yml` references for publishing:
+    - Python: `PYPI_USERNAME`, `PYPI_PASSWORD`
+    - TypeScript / npm: `NPM_TOKEN`
+    - Java / Maven: `MAVEN_USERNAME`, `MAVEN_PASSWORD`, `MAVEN_SIGNATURE_KID`, `MAVEN_SIGNATURE_PASSWORD`, `MAVEN_SIGNATURE_SECRET_KEY`
+    - Ruby: `RUBY_GEMS_API_KEY`
+    - C# / NuGet: `NUGET_API_KEY`
+    - Rust / Crates: `CRATES_TOKEN`
+2. Add the real publish credentials directly to the SDK repo: **Settings → Secrets and variables → Actions → New repository secret**.
+3. Remove the publish credential values from the config repo's `generators.yml`:
+
+```yaml title="generators.yml"
+# BEFORE
+groups:
+  python-sdk:
+    generators:
+      - name: fernapi/fern-python-sdk
+        version: "..."
+        github:
+          repository: customer/python-sdk
+          mode: pull-request
+        output:
+          pypi:
+            username: $PYPI_USERNAME
+            password: $PYPI_PASSWORD
+
+# AFTER (remove the output/pypi block entirely)
+groups:
+  python-sdk:
+    generators:
+      - name: fernapi/fern-python-sdk
+        version: "..."
+        github:
+          repository: customer/python-sdk
+          mode: pull-request
+```
+
+4. Run a generation. Confirm the SDK repo's secrets weren't overwritten by checking the "Last updated" timestamp under **SDK repo → Settings → Secrets**.
+
+## Phase 2: Switch output mode
+
+In `generators.yml`:
+
+```yaml title="generators.yml" {3}
+github:
+  repository: customer/python-sdk
+  mode: pull-request   # was: mode: release   (or: mode: push)
+```
+
+If you use `version: AUTO`, no other changes are needed. Autoversioning runs as part of the generator-cli pipeline and diffs pure generator output, so customer customizations never contaminate the version diff.
+
+## Phase 3: Decouple publishing from generation (optional)
+
+If you want to control publishing separately from generation, keep your publish workflow out of Fern's generation cycle:
+
+1. Add the workflow to `.fernignore`:
+
+```text title=".fernignore"
+.github/workflows/ci.yml
+```
+
+2. Change the workflow trigger from push-to-main to manual or release-tagged:
+
+```yaml title=".github/workflows/ci.yml"
+# Instead of:
+on:
+  push:
+    branches: [main]
+
+# Use:
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+```
+
+3. Update any secret references if you renamed credentials in Phase 1.
+
+## Phase 4: First generation with Replay
+
+1. Run `fern generate --group <group-name>` from the config repo (or trigger via your existing CI).
+2. The first run auto-creates `.fern/replay.lock`. Replay tracks customer commits to generated files from this point on.
+3. Review the resulting PR. It contains:
+    - `[fern-generated]`: pure generator output
+    - `[fern-replay]`: patches re-applied (empty on first run, since no patches exist yet)
+    - Updated `.fern/replay.lock`
+4. Squash-merge the PR. The next generation re-anchors correctly even after the squash.
+
+## Phase 5: Validate
+
+After the first generation and merge:
+
+- A PR was created (not a direct push to `main`).
+- No unintended package release was triggered.
+- SDK code is correct and passes CI.
+- `.fern/replay.lock` exists in the SDK repo.
+- `.fernignore` contains `replay.lock` (and `replay.yml`).
+
+After your first real customization, verify Replay's behavior end-to-end:
+
+- You edit a generated file, commit, and merge to `main`.
+- The next `fern generate` detects the patch (PR body shows `patches detected: 1`).
+- The customization survives regeneration via a clean 3-way merge.
+- `.fern/replay.lock` shows the patch stored.
+
+## Rollback
+
+Replay never modifies files destructively. Your `main` branch always has correct code, so rolling back is straightforward.
+
+**Quick disable.** If you only want to stop Replay and stay in `pull-request` mode, delete `.fern/replay.lock` from the SDK repo and commit. The next `fern generate` runs without Replay; PRs land in the same shape as before, just without the `[fern-replay]` commit.
+
+**Full revert to `release` or `push` mode:**
+
+1. Switch `mode` back in `generators.yml`:
+
+```yaml title="generators.yml" {3}
+github:
+  repository: customer/python-sdk
+  mode: release   # or mode: push
+```
+
+2. Re-add publish credentials to the config repo (if you removed them in Phase 1).
+3. Clean up Replay state in the SDK repo:
+    - Delete `.fern/replay.lock`
+    - Delete `.fern/replay.yml`
+    - Delete the `fern-generation-base` tag if it exists
+4. Close any open `fern-bot` PRs from PR mode.
+
+## Escape hatches
+
+- `fern generate --no-replay`: skip patch application for one generation. Generation still creates `[fern-generated]`; patches aren't applied. Useful for debugging.
+- `fern replay forget <pattern>`: untrack specific patches. The next generation overwrites those files.
+- `fern replay reset`: delete the lockfile entirely. Your code stays, but Replay loses all state. Run `fern replay bootstrap` to start fresh.
+
+## Known caveats
+
+- **Closed-without-merge replay PRs.** If a replay PR is closed without merging, the next generation detects the abandoned state and re-anchors automatically. No manual cleanup needed.
+- **Force pushes and rewritten history.** Replay handles force-pushed branches via a fallback detection path. Existing patches still apply correctly.

--- a/fern/products/sdks/replay-migration.mdx
+++ b/fern/products/sdks/replay-migration.mdx
@@ -8,7 +8,7 @@ description: Step-by-step guide for switching SDK generation from release or pus
   Replay requires the latest Fern CLI and SDK generator versions. Run `fern upgrade` to make sure you're current.
 </Note>
 
-This guide migrates an SDK from `release` or `push` output mode to `pull-request` output mode — the mode required to enable [Fern Replay](/learn/sdks/overview/custom-code#line-level-edits-with-replay). Only follow it if your SDK is currently on `release` or `push` mode and you want to switch in order to use Replay. SDKs already using `pull-request` mode have Replay on by default; no migration is needed.
+This guide migrates an SDK from `release` or `push` output mode to `pull-request` output mode — the mode required to enable [Fern Replay](/learn/sdks/overview/custom-code#replay). Only follow it if your SDK is currently on `release` or `push` mode and you want to switch in order to use Replay. SDKs already using `pull-request` mode have Replay on by default; no migration is needed.
 
 ## What changes
 

--- a/fern/products/sdks/replay-migration.mdx
+++ b/fern/products/sdks/replay-migration.mdx
@@ -4,8 +4,8 @@ headline: Migrating from release or push mode to pull-request mode
 description: Step-by-step guide for switching SDK generation from release or push mode to pull-request mode so Fern Replay can run.
 ---
 
-<Note title="Early Access">
-Fern Replay is rolling out across customer orgs. [Contact us](https://buildwithfern.com/contact) to enable it for your organization.
+<Note>
+Replay requires the latest Fern CLI and SDK generator versions. Run `fern upgrade` to make sure you're current.
 </Note>
 
 [Fern Replay](/learn/sdks/overview/custom-code#preserving-customizations-with-replay) requires `pull-request` output mode. This guide covers the migration from `release` or `push` mode in five phases.
@@ -19,7 +19,8 @@ Fern Replay is rolling out across customer orgs. [Contact us](https://buildwithf
 
 ## Before you start
 
-Make sure the [Fern GitHub App](https://github.com/apps/fern-api) is installed on your SDK repositories. [Contact us](https://buildwithfern.com/contact) to flip your organization onto the Replay-enabled pipeline.
+- Install the [Fern GitHub App](https://github.com/apps/fern-api) on your SDK repositories.
+- Update to the latest Fern CLI and SDK generator versions (`fern upgrade`).
 
 ## Phase 1: Move publishing secrets to the SDK repo
 

--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -21,7 +21,6 @@ navigation:
         path: ./custom-code.mdx
         slug: custom-code
       - page: Migrating to Replay
-        hidden: true
         path: ./replay-migration.mdx
         slug: replay-migration
       - page: Capabilities

--- a/fern/products/sdks/sdks.yml
+++ b/fern/products/sdks/sdks.yml
@@ -20,6 +20,10 @@ navigation:
       - page: Adding custom code
         path: ./custom-code.mdx
         slug: custom-code
+      - page: Migrating to Replay
+        hidden: true
+        path: ./replay-migration.mdx
+        slug: replay-migration
       - page: Capabilities
         path: ./capabilities.mdx
         slug: capabilities
@@ -66,7 +70,7 @@ navigation:
             path: ./generators/python/configuration.mdx
             slug: configuration
           - page: Adding custom code
-            path: ./generators/python/custom-code.mdx  
+            path: ./generators/python/custom-code.mdx
             slug: custom-code
           - page: Dynamic authentication
             path: ./generators/python/dynamic-authentication.mdx
@@ -90,7 +94,7 @@ navigation:
             path: ./generators/go/configuration.mdx
             slug: configuration
           - page: Adding custom code
-            path: ./generators/go/custom-code.mdx  
+            path: ./generators/go/custom-code.mdx
             slug: custom-code
           - changelog: ./generators/go/changelog
             slug: changelog
@@ -264,7 +268,7 @@ navigation:
         path: ./deep-dives/self-hosted.mdx
         slug: self-hosted
   - section: Reference
-    contents: 
+    contents:
       - page: generators.yml
         path: ./reference/generators-yml-reference.mdx
         slug: generators-yml

--- a/fern/products/sdks/snippets/custom-code-callout.mdx
+++ b/fern/products/sdks/snippets/custom-code-callout.mdx
@@ -1,2 +1,2 @@
 
-<Info>Before getting started, [read about how Fern SDKs use custom code and learn about the `.fernignore` file](/sdks/overview/custom-code).</Info>
+<Note>These steps cover adding a new custom file to the SDK. To preserve line-level edits to a generated file, use [Replay](/sdks/overview/custom-code#line-level-edits-with-replay) instead.</Note>

--- a/fern/products/sdks/snippets/custom-code-callout.mdx
+++ b/fern/products/sdks/snippets/custom-code-callout.mdx
@@ -1,2 +1,2 @@
 
-<Note>These steps cover adding a new custom file to the SDK. To preserve line-level edits to a generated file, use [Replay](/sdks/overview/custom-code#line-level-edits-with-replay) instead.</Note>
+<Note>These steps cover adding a new custom file to the SDK. To preserve line-level edits to a generated file, use [Replay](/sdks/overview/custom-code#replay) instead.</Note>


### PR DESCRIPTION
## Summary

Customer-facing docs for the Fern Replay GA launch. Replay preserves SDK customizations across regenerations via 3-way merge, complementing `.fernignore`'s file-level protection.

- **`custom-code.mdx`** — adds a `## Preserving customizations with replay` section between the opening and the existing `.fernignore` section. Lightly reframes the `.fernignore` intro so the two tools coexist clearly (Replay for line-level edits, `.fernignore` for full-file ownership). The Note on customer requirements: latest Fern CLI + SDK generator versions (`fern upgrade`).
- **`replay-migration.mdx`** (new) — 5-phase customer guide for switching SDK generation from `release` or `push` mode to `pull-request` mode (a Replay requirement). Includes a quick-disable rollback option (`delete .fern/replay.lock`) and a full revert path. Hidden in nav until launch.
- **`sdks.yml`** — adds a hidden nav entry for the migration page, slotted between `custom-code` and `capabilities` (matches the Autorelease slot pattern).
- **`generators-yml-reference.mdx`** — adds `replay` reference entries (global + per-generator) for opt-out config. Mirrors the existing `autorelease` shape.

## Test plan

- [ ] \`fern docs dev\` and visit \`/learn/sdks/overview/custom-code\` — verify the new Replay section renders, the commit-tree code block lexes cleanly, and the cross-link to the migration guide works.
- [ ] Visit \`/learn/sdks/overview/replay-migration\` directly (hidden in nav) — verify all 5 phases render, YAML/text/bash code blocks highlight correctly.
- [ ] Visit \`/learn/sdks/reference/generators-yml#replay\` and \`#replay-2\` — verify the anchors resolve and the cross-references between global and per-generator entries work.
- [ ] Run repo link checker against the new content.

## Coordination with launch

This PR should merge in coordination with the org-gate removal in fiddle (\`replay-enabled-orgs.json\`), since the docs claim Replay is GA. Merging earlier than that would tell customers Replay is ready when it isn't yet rolled out to their org.

On launch day, one additional change flips the migration guide into public nav: in \`sdks.yml\`, change \`hidden: true\` to \`hidden: false\` on the **Migrating to Replay** entry. The custom-code Replay section goes live the moment this PR merges.