### PR TITLE
fix: escape bare < in Python changelog to fix MDX parse error

### DIFF
--- a/fern/products/sdks/generators/python/changelog/2026-05-14.mdx
+++ b/fern/products/sdks/generators/python/changelog/2026-05-14.mdx
@@ -1,6 +1,6 @@
 ## 5.12.8
 **`(chore):`** Bump Poetry from 1.8.5 to 2.4.1 in the python-sdk and pydantic-model
-container images. Clears CVE-2026-34591 (Poetry <2.3.3 stored credentials
+container images. Clears CVE-2026-34591 (Poetry `<2.3.3` stored credentials
 in cleartext when keyring storage was unavailable). pyproject.toml's
 `poetry-core` constraint moves from `^1.9.0` to `^2.0.0` to stay in
 lockstep with Poetry 2.4.1's bundled `poetry-core 2.4.0` under


### PR DESCRIPTION
## Summary
The `Publish Docs` workflow has been failing on every push to `main` because `fern generate --docs` cannot parse `products/sdks/generators/python/changelog/2026-05-14.mdx`.

The changelog entry for Python SDK 5.12.8 contains `Poetry <2.3.3` — the bare `<2` is interpreted by the MDX parser as a JSX opening tag, which fails because tag names cannot start with a digit.

Wrapping `<2.3.3` in backticks (`` `<2.3.3` ``) fixes the parse error while keeping the content readable.

## Review & Testing Checklist for Human
- [ ] Verify the `Publish Docs` workflow passes after merging
- [ ] Confirm the rendered changelog entry on the docs site displays correctly

### Notes
The source of this changelog is `generators/python/sdk/versions.yml` in fern-api/fern. A companion PR is being opened there to fix the source so future changelog syncs don't reintroduce the issue.

Link to Devin session: https://app.devin.ai/sessions/3803b1403da444e287c6bbe790b55357
Requested by: @Ryan-Amirthan