### PR TITLE
fix: change fern.yml to docs.yml in 5.26.0 changelog entry

### DIFF
--- a/fern/products/cli-api-reference/cli-changelog/2026-05-14.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2026-05-14.mdx
@@ -28,7 +28,7 @@ against the language-specific validator on opted-in runs.
 ## 5.26.0
 **`(feat):`** Add `fern docs link check` command to validate links on live documentation sites.
 Supports text, JSON, and CSV output formats via `--output` flag.
-Use `--url <url>` to specify which docs site to check, or auto-detect from fern.yml.
+Use `--url <url>` to specify which docs site to check, or auto-detect from docs.yml.
 
 
 **`(feat):`** Add progress bars matching `fern docs dev` style for `fern docs link check`.


### PR DESCRIPTION
## Summary
Fix typo in the 5.26.0 CLI changelog entry: `fern.yml` → `docs.yml`. The `fern docs link check` command auto-detects from `docs.yml`, not `fern.yml`.

## Review & Testing Checklist for Human
- [ ] Verify the rendered changelog at `/learn/cli-api-reference/cli-reference/changelog#2026-05-14-5260` shows `docs.yml`

Link to Devin session: https://app.devin.ai/sessions/523bc7ee373141128f7eae98bcf71d21
Requested by: @Ryan-Amirthan