### PR TITLE
ci: guard scheduled workflows to only run on fern-api/docs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   check-links:
+    if: github.repository == 'fern-api/docs'
     name: Check links
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   stale:
+    if: github.repository == 'fern-api/docs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10

--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   sync:
+    if: github.repository == 'fern-api/docs'
     name: Update stale translations
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update-versions:
+    if: github.repository == 'fern-api/docs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5


### PR DESCRIPTION
## Summary

Adds `if: github.repository == 'fern-api/docs'` to all four scheduled workflows so that forks inherit the workflow files but the jobs become no-ops.

**Affected workflows:**
- `check-links.yml` — link checker (weekdays)
- `stale-bot.yml` — stale PR closer (daily)
- `sync-translations.yml` — zh translation sync (daily)
- `update-versions.yml` — Docker Hub version updater (hourly)

**Context:** A fork (`Thegreatsura/fern-docs`) inherited these workflows and has been running them on schedule, generating noisy PRs and Devin alerts. The `check-links` workflow in particular opened a PR tagging `@devin-ai-integration` and requesting review from `@davidkonigsberg`, causing repeated notifications.

## Review & Testing Checklist for Human

- [ ] Verify the four `if:` guards use the correct repository name (`fern-api/docs`)
- [ ] Confirm `workflow_dispatch` still works on the upstream repo (the guard only checks at job level, so manual triggers from the upstream repo will still pass)

### Notes

This is a minimal, zero-risk change — the `if` condition evaluates to `true` on the upstream repo and `false` on any fork. No functional behavior changes for `fern-api/docs`.

Link to Devin session: https://app.devin.ai/sessions/d5f2f0eb38d44fa7ae8c064a48fb438e