### PR TITLE
feat(docs): add reverse proxy setup guide with provider-specific instructions

### DIFF
--- a/fern/products/dashboard/pages/domains.mdx
+++ b/fern/products/dashboard/pages/domains.mdx
@@ -46,6 +46,11 @@ instances:
 Log in to your domain registrar and add the DNS records shown in the Fern Dashboard. The specific records depend on your domain type (subdomain, subpath, or root domain).
 </Step>
 
+<Step title="Set up a reverse proxy (subpath only)">
+
+Subpath hosting needs more than DNS — your infrastructure has to forward requests from the subpath to Fern's origin with the `x-fern-host` header set to your bare domain. Follow the [reverse proxy setup instructions](/learn/docs/preview-publish/reverse-proxy) for your provider (Cloudflare Workers, AWS CloudFront, Netlify, Vercel, Nginx, Akamai, or Caddy). Skip this step for subdomain or root domain hosting.
+</Step>
+
 <Step title="Verify the setup">
 
 Once you've added the DNS records, return to the Fern Dashboard to verify your domain. SSL is automatically provisioned for your domain, but it may take a few minutes to propagate globally.

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -248,6 +248,8 @@ navigation:
         path: ./pages/preview-publish/publishing-your-docs.mdx
       - page: Setting up your domain
         path: ./pages/preview-publish/setting-up-your-domain.mdx
+      - page: Reverse proxy setup
+        path: ./pages/preview-publish/reverse-proxy.mdx
       - page: Multi-source docs
         path: ./pages/preview-publish/multi-source.mdx
   - section: Customization

--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -250,6 +250,7 @@ navigation:
         path: ./pages/preview-publish/setting-up-your-domain.mdx
       - page: Reverse proxy setup
         path: ./pages/preview-publish/reverse-proxy.mdx
+        slug: reverse-proxy
       - page: Multi-source docs
         path: ./pages/preview-publish/multi-source.mdx
   - section: Customization

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -31,34 +31,34 @@ The `x-fern-host` value is the bare domain without the subpath. For `mydomain.co
 Create a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that intercepts requests to your docs subpath and proxies them to Fern.
 
 ```js
-const FERN_ORIGIN = "https://app.buildwithfern.com";
+const SUBPATH = "/docs";
+const FERN_HOST = "mydomain.com";
 
 export default {
   async fetch(request) {
     const url = new URL(request.url);
 
-    // Only proxy requests under /docs
-    if (!url.pathname.startsWith("/docs")) {
-      return fetch(request);
+    if (
+      url.pathname !== SUBPATH &&
+      !url.pathname.startsWith(`${SUBPATH}/`)
+    ) {
+      return new Response("Not found", { status: 404 });
     }
 
-    const targetUrl = new URL(url.pathname + url.search, FERN_ORIGIN);
+    const upstreamUrl = new URL(request.url);
+    upstreamUrl.protocol = "https:";
+    upstreamUrl.hostname = "app.buildwithfern.com";
+    upstreamUrl.port = "";
 
-    const headers = new Headers(request.headers);
-    headers.set("x-fern-host", url.hostname);
-    headers.set("Host", "app.buildwithfern.com");
+    const proxiedRequest = new Request(upstreamUrl, request);
+    proxiedRequest.headers.set("x-fern-host", FERN_HOST);
 
-    return fetch(targetUrl.toString(), {
-      method: request.method,
-      headers,
-      body: request.body,
-      redirect: "manual",
-    });
+    return fetch(proxiedRequest);
   },
 };
 ```
 
-Attach the Worker to a route pattern like `mydomain.com/docs/*` in the Cloudflare dashboard under **Workers Routes**.
+Replace `SUBPATH` and `FERN_HOST` with your subpath and bare domain. Attach the Worker to a route pattern like `mydomain.com/docs/*` in the Cloudflare dashboard under **Workers Routes**.
 
 </Tab>
 <Tab title="AWS CloudFront">

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -5,30 +5,36 @@ description: Configure a reverse proxy to serve Fern docs from a subpath on your
 
 When you host Fern docs on a [subpath](/learn/docs/preview-publish/setting-up-your-domain) like `mydomain.com/docs`, your infrastructure must proxy requests from that path to Fern's origin. Subdomain setups (`docs.mydomain.com`) use a CNAME record instead and don't require a reverse proxy.
 
+## How it works
+
 A working reverse proxy does two things:
 
-1. **Routes requests** from your subpath to Fern's origin, with the `x-fern-host` header set so Fern identifies your site.
+1. **Routes requests** from your subpath to Fern's origin at `app.buildwithfern.com`, preserving the original path. The `x-fern-host` header tells Fern which docs site to serve.
 2. **Disables caching** of HTML responses so visitors always receive the current deployment.
 
-## Routing
-
-Your proxy must forward all requests under your docs subpath to Fern's origin at `app.buildwithfern.com`, preserving the original path. Set two headers on every proxied request:
+Every proxied request needs two headers:
 
 | Header | Value | Purpose |
-|--------|-------|---------|
-| `x-fern-host` | Your bare domain (e.g. `mydomain.com`) | Tells Fern which docs site to serve |
+|---|---|---|
+| `x-fern-host` | Your bare domain without the subpath (e.g. `mydomain.com`, not `mydomain.com/docs`) | Tells Fern which docs site to serve |
 | `Host` | `app.buildwithfern.com` | Routes the request to Fern's origin |
 
-<Note>
-The `x-fern-host` value is the bare domain without the subpath. For `mydomain.com/docs`, set `x-fern-host: mydomain.com` — not `mydomain.com/docs`.
-</Note>
+Fern sets `Cache-Control: public, max-age=0, must-revalidate` on HTML responses, which most providers respect by default. If yours overrides origin cache headers or applies its own time-to-live, explicitly disable caching for the proxied path.
 
-### Provider-specific routing
+<Warning>
+Don't cache HTML responses from Fern. Cached HTML references JavaScript and CSS from older deployments — those files no longer exist, so pages fail to load. Static assets (`/_next/static/*`) are served directly by Fern's CDN and don't pass through your proxy.
+</Warning>
 
-<Tabs>
-<Tab title="Cloudflare Workers">
+## Set up your provider
 
-Create a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that intercepts requests to your docs subpath and proxies them to Fern.
+
+<AccordionGroup>
+<Accordion title="Cloudflare Workers">
+
+<Steps>
+<Step title="Create the Worker">
+
+Create a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that intercepts requests to your docs subpath and proxies them to Fern:
 
 ```js
 const SUBPATH = "/docs";
@@ -58,35 +64,55 @@ export default {
 };
 ```
 
-Replace `SUBPATH` and `FERN_HOST` with your subpath and bare domain. Attach the Worker to a route pattern like `mydomain.com/docs/*` in the Cloudflare dashboard under **Workers Routes**.
+Replace `SUBPATH` and `FERN_HOST` with your subpath and bare domain.
+</Step>
+<Step title="Attach the Worker to a route">
 
-</Tab>
-<Tab title="AWS CloudFront">
+In the Cloudflare dashboard under **Workers Routes**, attach the Worker to a route pattern like `mydomain.com/docs/*`.
+</Step>
+<Step title="Check for conflicting cache rules">
 
-Add a second origin and behavior to your CloudFront distribution.
+The Worker forwards Fern's `Cache-Control` header, so caching works automatically. In the Cloudflare dashboard, confirm that no Page Rule or Cache Rule sets "Cache Level: Cache Everything" for `/docs*` — if one exists, remove it or override it with "Cache Level: Bypass."
+</Step>
+</Steps>
+</Accordion>
 
-**1. Create an origin** pointing to `app.buildwithfern.com` (HTTPS only, port 443).
+<Accordion title="AWS CloudFront">
 
-**2. Add a custom origin header:**
+<Steps>
+<Step title="Add a Fern origin">
+
+Add an origin to your CloudFront distribution pointing to `app.buildwithfern.com` (HTTPS only, port 443). Add a custom origin header:
 
 | Header name | Value |
 |---|---|
 | `x-fern-host` | `mydomain.com` |
 
 CloudFront automatically sets the `Host` header to the origin domain.
+</Step>
+<Step title="Create a cache behavior for `/docs*`">
 
-**3. Create a cache behavior** for the path pattern `/docs*`:
+Set the behavior to:
 
-- Origin: the Fern origin created above
-- Cache policy: `CachingDisabled` (AWS managed policy)
-- Origin request policy: `AllViewer` (forwards all headers, query strings, and cookies)
+- **Origin**: the Fern origin you just created
+- **Cache policy**: `CachingDisabled` (AWS managed policy)
+- **Origin request policy**: `AllViewer` (forwards all headers, query strings, and cookies)
 
-If you need fine-grained control instead of `CachingDisabled`, create a custom cache policy with time-to-live (TTL) values set to `0` and forward the `Host` and `x-fern-host` headers.
+To use a custom cache policy instead of `CachingDisabled`, set min, max, and default TTL to `0` and forward `Host` and `x-fern-host`.
+</Step>
+</Steps>
 
-</Tab>
-<Tab title="Netlify">
+<Warning>
+CloudFront ignores `CDN-Cache-Control` and `Surrogate-Control` — only the standard `Cache-Control` header is read. A custom cache policy with a non-zero default TTL caches responses regardless of Fern's `Cache-Control: max-age=0` directive.
+</Warning>
+</Accordion>
 
-Add a rewrite rule in your `netlify.toml` or `_redirects` file. Netlify rewrites proxy the request server-side and return the upstream response directly.
+<Accordion title="Netlify">
+
+<Steps>
+<Step title="Add a rewrite rule">
+
+In `netlify.toml` (or `_redirects`):
 
 ```toml netlify.toml
 [[redirects]]
@@ -98,15 +124,20 @@ Add a rewrite rule in your `netlify.toml` or `_redirects` file. Netlify rewrites
   [redirects.headers]
     x-fern-host = "mydomain.com"
 ```
+</Step>
+</Steps>
 
 <Note>
-Netlify rewrites with `status = 200` act as a reverse proxy. The visitor's browser sees your domain while the content comes from Fern.
+Netlify rewrites with `status = 200` act as a reverse proxy — the visitor's browser sees your domain while the content comes from Fern. Netlify respects the origin's `Cache-Control` header, so no extra caching configuration is needed.
 </Note>
+</Accordion>
 
-</Tab>
-<Tab title="Vercel">
+<Accordion title="Vercel">
 
-Configure rewrites in your `vercel.json` (or `next.config.js` if using Next.js). Vercel rewrites proxy the request and serve the response from your domain.
+<Steps>
+<Step title="Configure rewrites">
+
+In `vercel.json`:
 
 ```json vercel.json
 {
@@ -155,15 +186,22 @@ module.exports = {
   },
 };
 ```
+</Step>
+<Step title="Pass `x-fern-host` via middleware (Next.js only)">
+
+Vercel forwards the `Host` header automatically, but Next.js rewrites don't propagate `x-fern-host` from the rewrite config. Add a [middleware function](https://vercel.com/docs/functions/middleware) that sets `x-fern-host` on requests under `/docs`.
+</Step>
+</Steps>
 
 <Note>
-Vercel rewrites automatically forward the `Host` header. To pass `x-fern-host`, you may need a middleware function. See Vercel's [middleware documentation](https://vercel.com/docs/functions/middleware) for details.
+Vercel respects the origin's `Cache-Control` header for rewrite destinations, so no extra caching configuration is needed.
 </Note>
+</Accordion>
 
-</Tab>
-<Tab title="Nginx">
+<Accordion title="Nginx">
 
-Add a `location` block that proxies your docs subpath to Fern.
+<Steps>
+<Step title="Add a `location` block">
 
 ```nginx
 location /docs {
@@ -177,33 +215,54 @@ location /docs {
 
     # Prevent encoding issues with Brotli responses
     proxy_set_header Accept-Encoding "gzip, deflate";
+
+    # Do not cache HTML
+    proxy_no_cache 1;
+    proxy_cache_bypass 1;
+    add_header Cache-Control "public, max-age=0, must-revalidate" always;
 }
 ```
+</Step>
+</Steps>
 
 <Warning>
 Nginx doesn't natively support [Brotli](https://github.com/google/brotli) decompression. The `Accept-Encoding` override above prevents HTTP/2 transfer errors caused by Fern's default Brotli-compressed responses.
 </Warning>
+</Accordion>
 
-</Tab>
-<Tab title="Akamai">
+<Accordion title="Akamai">
 
-Configure a **Site Delivery** or **Ion** property to proxy your docs subpath.
+<Steps>
+<Step title="Add a routing rule">
 
-**1. Add a rule** matching the path `/docs*`:
+In a **Site Delivery** or **Ion** property, add a rule matching path `/docs*`:
 
 - **Origin Server**: `app.buildwithfern.com`
 - **Forward Host Header**: Origin Hostname
 
-**2. Add a Modify Outgoing Request Header behavior** to set:
+Add a **Modify Outgoing Request Header** behavior:
 
 | Action | Header name | Value |
 |---|---|---|
 | Add | `x-fern-host` | `mydomain.com` |
+</Step>
+<Step title="Disable caching on the rule">
 
-**3. Set the caching behavior** (see [Caching](#caching) below).
+Add a **Caching** behavior to the same rule:
 
-</Tab>
-<Tab title="Caddy">
+| Setting | Value |
+|---|---|
+| Caching Option | No Store |
+
+Alternatively, set **Honor Origin Cache-Control** to **Yes** so Akamai respects Fern's `Cache-Control: public, max-age=0, must-revalidate` header.
+</Step>
+</Steps>
+</Accordion>
+
+<Accordion title="Caddy">
+
+<Steps>
+<Step title="Add to your Caddyfile">
 
 ```caddyfile
 mydomain.com {
@@ -215,97 +274,18 @@ mydomain.com {
     }
 }
 ```
+</Step>
+</Steps>
 
-</Tab>
-</Tabs>
-
-## Caching
-
-Fern sets `Cache-Control: public, max-age=0, must-revalidate` on HTML responses, which tells your proxy not to cache page content. Most providers respect this header by default. However, if your provider overrides origin cache headers or applies its own time-to-live, you must explicitly disable caching for the proxied path.
-
-Caching stale HTML causes visitors to load a page that references JavaScript and CSS files from an older deployment. Those files no longer exist, so the page fails to hydrate and may display an error.
-
-<Warning>
-Don't cache HTML responses from Fern. Static assets (`/_next/static/*`) are served directly by Fern's CDN with long-lived cache headers and don't pass through your proxy.
-</Warning>
-
-### Provider-specific caching
-
-<Tabs>
-<Tab title="Cloudflare">
-
-Cloudflare respects the origin's `Cache-Control` header by default for proxied (orange-cloud) records. No additional configuration is needed unless you have **Page Rules** or **Cache Rules** that override caching for your domain.
-
-To verify, check that no Page Rule sets "Cache Level: Cache Everything" for the `/docs*` path. If one exists, either remove it or add a more specific rule for `/docs*` with "Cache Level: Bypass."
-
-For Workers, the example in the [Routing](#routing) section already passes through the origin's headers without modification.
-
-</Tab>
-<Tab title="AWS CloudFront">
-
-Use the AWS managed `CachingDisabled` cache policy on the `/docs*` behavior. This policy sets `min-TTL`, `max-TTL`, and `default-TTL` to `0`, so CloudFront always fetches a fresh response from Fern.
-
-If you use a custom cache policy instead, set all time-to-live (TTL) values to `0`:
-
-| Setting | Value |
-|---|---|
-| Minimum time-to-live | `0` |
-| Maximum time-to-live | `0` |
-| Default time-to-live | `0` |
-
-<Warning>
-CloudFront ignores `CDN-Cache-Control` and `Surrogate-Control` headers. It only reads the standard `Cache-Control` header. A custom cache policy with a non-zero default time-to-live caches responses regardless of the origin's `Cache-Control: max-age=0` directive.
-</Warning>
-
-</Tab>
-<Tab title="Netlify">
-
-Netlify respects the origin's `Cache-Control` header for rewrite-proxied responses. No additional configuration is needed.
-
-</Tab>
-<Tab title="Vercel">
-
-Vercel respects the origin's `Cache-Control` header for rewrite destinations. No additional configuration is needed.
-
-</Tab>
-<Tab title="Nginx">
-
-Add cache-control directives to the `/docs` location block to prevent Nginx from caching responses (or from being cached by downstream proxies that ignore the origin header):
-
-```nginx
-location /docs {
-    proxy_pass https://app.buildwithfern.com;
-    # ... other proxy_set_header directives ...
-
-    # Do not cache HTML
-    proxy_no_cache 1;
-    proxy_cache_bypass 1;
-    add_header Cache-Control "public, max-age=0, must-revalidate" always;
-}
-```
-
-</Tab>
-<Tab title="Akamai">
-
-In the rule matching `/docs*`, add a **Caching** behavior:
-
-| Setting | Value |
-|---|---|
-| Caching Option | No Store |
-
-Alternatively, set "Honor Origin Cache-Control" to **Yes** so Akamai respects Fern's `Cache-Control: public, max-age=0, must-revalidate` header.
-
-</Tab>
-<Tab title="Caddy">
-
-Caddy doesn't cache responses by default. No additional configuration is needed unless you have explicitly enabled caching with a `cache` directive or external module.
-
-</Tab>
-</Tabs>
+<Note>
+Caddy doesn't cache responses by default, so no extra caching configuration is needed unless you've explicitly enabled caching with a `cache` directive or external module.
+</Note>
+</Accordion>
+</AccordionGroup>
 
 ## Verify your setup
 
-After configuring your proxy, confirm that requests are routed correctly and responses aren't cached.
+Run these checks against your live subpath:
 
 ```bash
 # Check that the page loads and x-fern-host is recognized
@@ -319,4 +299,4 @@ curl -sI https://mydomain.com/docs | grep -i cache-control
 curl -sI https://mydomain.com/docs | grep -i "^age:"
 ```
 
-If the `age` header is present and non-zero, your proxy is serving a cached response. Review the [Caching](#caching) section for your provider.
+If the `age` header is present and non-zero, your proxy is serving a cached response. Revisit your provider's configuration to ensure HTML caching is disabled.

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -144,25 +144,11 @@ In `vercel.json`:
   "rewrites": [
     {
       "source": "/docs",
-      "destination": "https://app.buildwithfern.com/docs",
-      "has": [
-        {
-          "type": "header",
-          "key": "x-fern-host",
-          "value": "mydomain.com"
-        }
-      ]
+      "destination": "https://app.buildwithfern.com/docs"
     },
     {
       "source": "/docs/:path*",
-      "destination": "https://app.buildwithfern.com/docs/:path*",
-      "has": [
-        {
-          "type": "header",
-          "key": "x-fern-host",
-          "value": "mydomain.com"
-        }
-      ]
+      "destination": "https://app.buildwithfern.com/docs/:path*"
     }
   ]
 }
@@ -187,9 +173,27 @@ module.exports = {
 };
 ```
 </Step>
-<Step title="Pass `x-fern-host` via middleware (Next.js only)">
+<Step title="Set `x-fern-host` via middleware">
 
-Vercel forwards the `Host` header automatically, but Next.js rewrites don't propagate `x-fern-host` from the rewrite config. Add a [middleware function](https://vercel.com/docs/functions/middleware) that sets `x-fern-host` on requests under `/docs`.
+Vercel rewrites don't provide a way to add custom request headers to the upstream. Add a [middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware) file to set `x-fern-host` on proxied requests:
+
+```ts middleware.ts
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-fern-host", "mydomain.com");
+
+  return NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+}
+
+export const config = {
+  matcher: ["/docs", "/docs/:path*"],
+};
+```
 </Step>
 </Steps>
 
@@ -266,7 +270,7 @@ Alternatively, set **Honor Origin Cache-Control** to **Yes** so Akamai respects 
 
 ```caddyfile
 mydomain.com {
-    handle_path /docs* {
+    handle /docs* {
         reverse_proxy https://app.buildwithfern.com {
             header_up Host app.buildwithfern.com
             header_up x-fern-host mydomain.com

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -135,64 +135,28 @@ Netlify rewrites with `status = 200` act as a reverse proxy — the visitor's br
 <Accordion title="Vercel">
 
 <Steps>
-<Step title="Configure rewrites">
+<Step title="Add a route with a transform">
 
-In `vercel.json`:
+Use a [route with a transform rule](https://vercel.com/changelog/transform-rules-are-now-available-in-vercel-json) to rewrite the path and set `x-fern-host` in one step:
 
 ```json vercel.json
 {
-  "rewrites": [
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "routes": [
     {
-      "source": "/docs",
-      "destination": "https://app.buildwithfern.com/docs"
-    },
-    {
-      "source": "/docs/:path*",
-      "destination": "https://app.buildwithfern.com/docs/:path*"
+      "src": "/docs(/.*)?",
+      "dest": "https://app.buildwithfern.com/docs$1",
+      "transforms": [
+        {
+          "type": "request.headers",
+          "op": "set",
+          "target": { "key": "x-fern-host" },
+          "args": "mydomain.com"
+        }
+      ]
     }
   ]
 }
-```
-
-For Next.js, use `next.config.js` rewrites instead:
-
-```js next.config.js
-module.exports = {
-  async rewrites() {
-    return [
-      {
-        source: "/docs",
-        destination: "https://app.buildwithfern.com/docs",
-      },
-      {
-        source: "/docs/:path*",
-        destination: "https://app.buildwithfern.com/docs/:path*",
-      },
-    ];
-  },
-};
-```
-</Step>
-<Step title="Set `x-fern-host` via middleware">
-
-Vercel rewrites don't provide a way to add custom request headers to the upstream. Add a [middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware) file to set `x-fern-host` on proxied requests:
-
-```ts middleware.ts
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
-
-export function middleware(request: NextRequest) {
-  const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-fern-host", "mydomain.com");
-
-  return NextResponse.next({
-    request: { headers: requestHeaders },
-  });
-}
-
-export const config = {
-  matcher: ["/docs", "/docs/:path*"],
-};
 ```
 </Step>
 </Steps>

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -8,7 +8,7 @@ When you host Fern docs on a [subpath](/learn/docs/preview-publish/setting-up-yo
 A working reverse proxy does two things:
 
 1. **Routes requests** from your subpath to Fern's origin, with the `x-fern-host` header set so Fern identifies your site.
-2. **Disables caching** of HTML responses so visitors always receive the latest deployment.
+2. **Disables caching** of HTML responses so visitors always receive the current deployment.
 
 ## Routing
 
@@ -81,7 +81,7 @@ CloudFront automatically sets the `Host` header to the origin domain.
 - Cache policy: `CachingDisabled` (AWS managed policy)
 - Origin request policy: `AllViewer` (forwards all headers, query strings, and cookies)
 
-If you need fine-grained control instead of `CachingDisabled`, create a custom cache policy with TTL values set to `0` and forward the `Host` and `x-fern-host` headers.
+If you need fine-grained control instead of `CachingDisabled`, create a custom cache policy with time-to-live (TTL) values set to `0` and forward the `Host` and `x-fern-host` headers.
 
 </Tab>
 <Tab title="Netlify">
@@ -181,7 +181,7 @@ location /docs {
 ```
 
 <Warning>
-Nginx does not natively support [Brotli](https://github.com/google/brotli) decompression. The `Accept-Encoding` override above prevents HTTP/2 transfer errors caused by Fern's default Brotli-compressed responses.
+Nginx doesn't natively support [Brotli](https://github.com/google/brotli) decompression. The `Accept-Encoding` override above prevents HTTP/2 transfer errors caused by Fern's default Brotli-compressed responses.
 </Warning>
 
 </Tab>
@@ -221,12 +221,12 @@ mydomain.com {
 
 ## Caching
 
-Fern sets `Cache-Control: public, max-age=0, must-revalidate` on HTML responses, which tells your proxy not to cache page content. Most providers respect this header by default. However, if your provider overrides origin cache headers or applies a default TTL, you must explicitly disable caching for the proxied path.
+Fern sets `Cache-Control: public, max-age=0, must-revalidate` on HTML responses, which tells your proxy not to cache page content. Most providers respect this header by default. However, if your provider overrides origin cache headers or applies its own time-to-live, you must explicitly disable caching for the proxied path.
 
 Caching stale HTML causes visitors to load a page that references JavaScript and CSS files from an older deployment. Those files no longer exist, so the page fails to hydrate and may display an error.
 
 <Warning>
-Do not cache HTML responses from Fern. Static assets (`/_next/static/*`) are served directly by Fern's CDN with long-lived cache headers and do not pass through your proxy.
+Don't cache HTML responses from Fern. Static assets (`/_next/static/*`) are served directly by Fern's CDN with long-lived cache headers and don't pass through your proxy.
 </Warning>
 
 ### Provider-specific caching
@@ -245,16 +245,16 @@ For Workers, the example in the [Routing](#routing) section already passes throu
 
 Use the AWS managed `CachingDisabled` cache policy on the `/docs*` behavior. This policy sets `min-TTL`, `max-TTL`, and `default-TTL` to `0`, so CloudFront always fetches a fresh response from Fern.
 
-If you use a custom cache policy instead, set all TTL values to `0`:
+If you use a custom cache policy instead, set all time-to-live (TTL) values to `0`:
 
 | Setting | Value |
 |---|---|
-| Minimum TTL | `0` |
-| Maximum TTL | `0` |
-| Default TTL | `0` |
+| Minimum time-to-live | `0` |
+| Maximum time-to-live | `0` |
+| Default time-to-live | `0` |
 
 <Warning>
-CloudFront ignores `CDN-Cache-Control` and `Surrogate-Control` headers. It only reads the standard `Cache-Control` header. A custom cache policy with a non-zero `default-TTL` will cache responses regardless of the origin's `Cache-Control: max-age=0` directive.
+CloudFront ignores `CDN-Cache-Control` and `Surrogate-Control` headers. It only reads the standard `Cache-Control` header. A custom cache policy with a non-zero default time-to-live caches responses regardless of the origin's `Cache-Control: max-age=0` directive.
 </Warning>
 
 </Tab>
@@ -298,14 +298,14 @@ Alternatively, set "Honor Origin Cache-Control" to **Yes** so Akamai respects Fe
 </Tab>
 <Tab title="Caddy">
 
-Caddy does not cache responses by default. No additional configuration is needed unless you have explicitly enabled caching with a `cache` directive or external module.
+Caddy doesn't cache responses by default. No additional configuration is needed unless you have explicitly enabled caching with a `cache` directive or external module.
 
 </Tab>
 </Tabs>
 
 ## Verify your setup
 
-After configuring your proxy, confirm that requests are routed correctly and responses are not cached.
+After configuring your proxy, confirm that requests are routed correctly and responses aren't cached.
 
 ```bash
 # Check that the page loads and x-fern-host is recognized

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -1,0 +1,322 @@
+---
+title: Reverse proxy setup
+description: Configure a reverse proxy to serve Fern docs from a subpath on your domain, with provider-specific instructions for routing and caching.
+---
+
+When you host Fern docs on a [subpath](/learn/docs/preview-publish/setting-up-your-domain) like `mydomain.com/docs`, your infrastructure must proxy requests from that path to Fern's origin. Subdomain setups (`docs.mydomain.com`) use a CNAME record instead and don't require a reverse proxy.
+
+A working reverse proxy does two things:
+
+1. **Routes requests** from your subpath to Fern's origin, with the `x-fern-host` header set so Fern identifies your site.
+2. **Disables caching** of HTML responses so visitors always receive the latest deployment.
+
+## Routing
+
+Your proxy must forward all requests under your docs subpath to Fern's origin at `app.buildwithfern.com`, preserving the original path. Set two headers on every proxied request:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `x-fern-host` | Your bare domain (e.g. `mydomain.com`) | Tells Fern which docs site to serve |
+| `Host` | `app.buildwithfern.com` | Routes the request to Fern's origin |
+
+<Note>
+The `x-fern-host` value is the bare domain without the subpath. For `mydomain.com/docs`, set `x-fern-host: mydomain.com` — not `mydomain.com/docs`.
+</Note>
+
+### Provider-specific routing
+
+<Tabs>
+<Tab title="Cloudflare Workers">
+
+Create a [Cloudflare Worker](https://developers.cloudflare.com/workers/) that intercepts requests to your docs subpath and proxies them to Fern.
+
+```js
+const FERN_ORIGIN = "https://app.buildwithfern.com";
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    // Only proxy requests under /docs
+    if (!url.pathname.startsWith("/docs")) {
+      return fetch(request);
+    }
+
+    const targetUrl = new URL(url.pathname + url.search, FERN_ORIGIN);
+
+    const headers = new Headers(request.headers);
+    headers.set("x-fern-host", url.hostname);
+    headers.set("Host", "app.buildwithfern.com");
+
+    return fetch(targetUrl.toString(), {
+      method: request.method,
+      headers,
+      body: request.body,
+      redirect: "manual",
+    });
+  },
+};
+```
+
+Attach the Worker to a route pattern like `mydomain.com/docs/*` in the Cloudflare dashboard under **Workers Routes**.
+
+</Tab>
+<Tab title="AWS CloudFront">
+
+Add a second origin and behavior to your CloudFront distribution.
+
+**1. Create an origin** pointing to `app.buildwithfern.com` (HTTPS only, port 443).
+
+**2. Add a custom origin header:**
+
+| Header name | Value |
+|---|---|
+| `x-fern-host` | `mydomain.com` |
+
+CloudFront automatically sets the `Host` header to the origin domain.
+
+**3. Create a cache behavior** for the path pattern `/docs*`:
+
+- Origin: the Fern origin created above
+- Cache policy: `CachingDisabled` (AWS managed policy)
+- Origin request policy: `AllViewer` (forwards all headers, query strings, and cookies)
+
+If you need fine-grained control instead of `CachingDisabled`, create a custom cache policy with TTL values set to `0` and forward the `Host` and `x-fern-host` headers.
+
+</Tab>
+<Tab title="Netlify">
+
+Add a rewrite rule in your `netlify.toml` or `_redirects` file. Netlify rewrites proxy the request server-side and return the upstream response directly.
+
+```toml netlify.toml
+[[redirects]]
+  from = "/docs/*"
+  to = "https://app.buildwithfern.com/docs/:splat"
+  status = 200
+  force = true
+
+  [redirects.headers]
+    x-fern-host = "mydomain.com"
+```
+
+<Note>
+Netlify rewrites with `status = 200` act as a reverse proxy. The visitor's browser sees your domain while the content comes from Fern.
+</Note>
+
+</Tab>
+<Tab title="Vercel">
+
+Configure rewrites in your `vercel.json` (or `next.config.js` if using Next.js). Vercel rewrites proxy the request and serve the response from your domain.
+
+```json vercel.json
+{
+  "rewrites": [
+    {
+      "source": "/docs",
+      "destination": "https://app.buildwithfern.com/docs",
+      "has": [
+        {
+          "type": "header",
+          "key": "x-fern-host",
+          "value": "mydomain.com"
+        }
+      ]
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "https://app.buildwithfern.com/docs/:path*",
+      "has": [
+        {
+          "type": "header",
+          "key": "x-fern-host",
+          "value": "mydomain.com"
+        }
+      ]
+    }
+  ]
+}
+```
+
+For Next.js, use `next.config.js` rewrites instead:
+
+```js next.config.js
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/docs",
+        destination: "https://app.buildwithfern.com/docs",
+      },
+      {
+        source: "/docs/:path*",
+        destination: "https://app.buildwithfern.com/docs/:path*",
+      },
+    ];
+  },
+};
+```
+
+<Note>
+Vercel rewrites automatically forward the `Host` header. To pass `x-fern-host`, you may need a middleware function. See Vercel's [middleware documentation](https://vercel.com/docs/functions/middleware) for details.
+</Note>
+
+</Tab>
+<Tab title="Nginx">
+
+Add a `location` block that proxies your docs subpath to Fern.
+
+```nginx
+location /docs {
+    proxy_pass https://app.buildwithfern.com;
+    proxy_set_header Host app.buildwithfern.com;
+    proxy_set_header x-fern-host mydomain.com;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_ssl_server_name on;
+
+    # Prevent encoding issues with Brotli responses
+    proxy_set_header Accept-Encoding "gzip, deflate";
+}
+```
+
+<Warning>
+Nginx does not natively support [Brotli](https://github.com/google/brotli) decompression. The `Accept-Encoding` override above prevents HTTP/2 transfer errors caused by Fern's default Brotli-compressed responses.
+</Warning>
+
+</Tab>
+<Tab title="Akamai">
+
+Configure a **Site Delivery** or **Ion** property to proxy your docs subpath.
+
+**1. Add a rule** matching the path `/docs*`:
+
+- **Origin Server**: `app.buildwithfern.com`
+- **Forward Host Header**: Origin Hostname
+
+**2. Add a Modify Outgoing Request Header behavior** to set:
+
+| Action | Header name | Value |
+|---|---|---|
+| Add | `x-fern-host` | `mydomain.com` |
+
+**3. Set the caching behavior** (see [Caching](#caching) below).
+
+</Tab>
+<Tab title="Caddy">
+
+```caddyfile
+mydomain.com {
+    handle_path /docs* {
+        reverse_proxy https://app.buildwithfern.com {
+            header_up Host app.buildwithfern.com
+            header_up x-fern-host mydomain.com
+        }
+    }
+}
+```
+
+</Tab>
+</Tabs>
+
+## Caching
+
+Fern sets `Cache-Control: public, max-age=0, must-revalidate` on HTML responses, which tells your proxy not to cache page content. Most providers respect this header by default. However, if your provider overrides origin cache headers or applies a default TTL, you must explicitly disable caching for the proxied path.
+
+Caching stale HTML causes visitors to load a page that references JavaScript and CSS files from an older deployment. Those files no longer exist, so the page fails to hydrate and may display an error.
+
+<Warning>
+Do not cache HTML responses from Fern. Static assets (`/_next/static/*`) are served directly by Fern's CDN with long-lived cache headers and do not pass through your proxy.
+</Warning>
+
+### Provider-specific caching
+
+<Tabs>
+<Tab title="Cloudflare">
+
+Cloudflare respects the origin's `Cache-Control` header by default for proxied (orange-cloud) records. No additional configuration is needed unless you have **Page Rules** or **Cache Rules** that override caching for your domain.
+
+To verify, check that no Page Rule sets "Cache Level: Cache Everything" for the `/docs*` path. If one exists, either remove it or add a more specific rule for `/docs*` with "Cache Level: Bypass."
+
+For Workers, the example in the [Routing](#routing) section already passes through the origin's headers without modification.
+
+</Tab>
+<Tab title="AWS CloudFront">
+
+Use the AWS managed `CachingDisabled` cache policy on the `/docs*` behavior. This policy sets `min-TTL`, `max-TTL`, and `default-TTL` to `0`, so CloudFront always fetches a fresh response from Fern.
+
+If you use a custom cache policy instead, set all TTL values to `0`:
+
+| Setting | Value |
+|---|---|
+| Minimum TTL | `0` |
+| Maximum TTL | `0` |
+| Default TTL | `0` |
+
+<Warning>
+CloudFront ignores `CDN-Cache-Control` and `Surrogate-Control` headers. It only reads the standard `Cache-Control` header. A custom cache policy with a non-zero `default-TTL` will cache responses regardless of the origin's `Cache-Control: max-age=0` directive.
+</Warning>
+
+</Tab>
+<Tab title="Netlify">
+
+Netlify respects the origin's `Cache-Control` header for rewrite-proxied responses. No additional configuration is needed.
+
+</Tab>
+<Tab title="Vercel">
+
+Vercel respects the origin's `Cache-Control` header for rewrite destinations. No additional configuration is needed.
+
+</Tab>
+<Tab title="Nginx">
+
+Add cache-control directives to the `/docs` location block to prevent Nginx from caching responses (or from being cached by downstream proxies that ignore the origin header):
+
+```nginx
+location /docs {
+    proxy_pass https://app.buildwithfern.com;
+    # ... other proxy_set_header directives ...
+
+    # Do not cache HTML
+    proxy_no_cache 1;
+    proxy_cache_bypass 1;
+    add_header Cache-Control "public, max-age=0, must-revalidate" always;
+}
+```
+
+</Tab>
+<Tab title="Akamai">
+
+In the rule matching `/docs*`, add a **Caching** behavior:
+
+| Setting | Value |
+|---|---|
+| Caching Option | No Store |
+
+Alternatively, set "Honor Origin Cache-Control" to **Yes** so Akamai respects Fern's `Cache-Control: public, max-age=0, must-revalidate` header.
+
+</Tab>
+<Tab title="Caddy">
+
+Caddy does not cache responses by default. No additional configuration is needed unless you have explicitly enabled caching with a `cache` directive or external module.
+
+</Tab>
+</Tabs>
+
+## Verify your setup
+
+After configuring your proxy, confirm that requests are routed correctly and responses are not cached.
+
+```bash
+# Check that the page loads and x-fern-host is recognized
+curl -sI https://mydomain.com/docs | head -20
+
+# Verify Cache-Control on the HTML response
+curl -sI https://mydomain.com/docs | grep -i cache-control
+# Expected: cache-control: public, max-age=0, must-revalidate
+
+# Verify the page is not cached by your proxy (age should be 0 or absent)
+curl -sI https://mydomain.com/docs | grep -i "^age:"
+```
+
+If the `age` header is present and non-zero, your proxy is serving a cached response. Review the [Caching](#caching) section for your provider.

--- a/fern/products/docs/pages/preview-publish/setting-up-your-domain.mdx
+++ b/fern/products/docs/pages/preview-publish/setting-up-your-domain.mdx
@@ -78,7 +78,7 @@ Once Fern has completed your setup, you'll be able to access your documentation 
 
 <Markdown src="/snippets/team-plan.mdx"/>
 
-To host your documentation on a subpath like `mydomain.com/docs`, you need to edit your `docs.yml` configuration and then get provider-specific instructions for setting up the subpath. Common providers include Cloudflare, AWS Route53 and Cloudfront, Netlify, and Vercel.
+To host your documentation on a subpath like `mydomain.com/docs`, you need to edit your `docs.yml` configuration and set up a [reverse proxy](/learn/docs/preview-publish/reverse-proxy) that routes requests to Fern.
 
 <Steps>
 <Step title="Configure the `url` in `docs.yml`">
@@ -133,7 +133,7 @@ proxy_set_header Accept-Encoding "gzip,deflate";
 </Accordion>
 <Accordion title="Root domain">
 
-To host your documentation on a root domain like `mydomain.com`, you need to edit your `docs.yml` configuration and then get provider-specific instructions for setting up the domain. Common providers include Cloudflare, AWS Route53 and Cloudfront, Netlify, and Vercel.
+To host your documentation on a root domain like `mydomain.com`, you need to edit your `docs.yml` configuration and configure DNS records.
 
 <Steps>
 <Step title="Configure the `url` in `docs.yml`">

--- a/fern/products/docs/pages/preview-publish/setting-up-your-domain.mdx
+++ b/fern/products/docs/pages/preview-publish/setting-up-your-domain.mdx
@@ -78,7 +78,7 @@ Once Fern has completed your setup, you'll be able to access your documentation 
 
 <Markdown src="/snippets/team-plan.mdx"/>
 
-To host your documentation on a subpath like `mydomain.com/docs`, you need to edit your `docs.yml` configuration and set up a [reverse proxy](/learn/docs/preview-publish/reverse-proxy) that routes requests to Fern.
+To host your documentation on a subpath like `mydomain.com/docs`, you need to edit your `docs.yml` configuration and set up a reverse proxy on your infrastructure.
 
 <Steps>
 <Step title="Configure the `url` in `docs.yml`">
@@ -106,6 +106,11 @@ instances:
 </CodeBlock>
 
 [Here's an example.](https://github.com/fern-api/fern/blob/7d8631c6119787a8aaccb4ba49837e73c985db28/fern/docs.yml#L1-L3)
+</Step>
+
+<Step title="Set up a reverse proxy">
+
+A subpath can't be routed with DNS alone — your infrastructure has to forward requests from `mydomain.com/docs` to Fern's origin with the `x-fern-host` header set to your bare domain. Follow the [reverse proxy setup instructions](/learn/docs/preview-publish/reverse-proxy) for your provider (Cloudflare Workers, AWS CloudFront, Netlify, Vercel, Nginx, Akamai, or Caddy).
 </Step>
 
 <Step title="Contact Fern">


### PR DESCRIPTION
## Summary

Adds a new documentation page explaining how to configure a reverse proxy for serving Fern docs from a subpath (e.g. `mydomain.com/docs`). Covers:

1. **Routing** — How to set `x-fern-host` and `Host` headers so Fern identifies the correct docs site
2. **Caching** — How to disable HTML caching on the reverse proxy to prevent stale deployment issues (the root cause of the ChunkLoadError bug we just fixed in fern-platform)

Provider-specific instructions for: **Cloudflare Workers**, **AWS CloudFront**, **Netlify**, **Vercel**, **Nginx**, **Akamai**, and **Caddy**.

Also updates the existing "Setting up your domain" page to cross-reference the new reverse proxy page from the subpath setup section.

## Review & Testing Checklist for Human

- [ ] Verify the new page renders correctly at `/learn/docs/preview-publish/reverse-proxy` in the preview deployment
- [ ] Confirm all provider tabs render properly (7 tabs in Routing section, 7 tabs in Caching section)
- [ ] Check that the cross-reference link from the subpath accordion on the "Setting up your domain" page resolves correctly
- [ ] Review the Cloudflare Workers and CloudFront examples — these are the most common customer setups and should be technically accurate
- [ ] Verify the `x-fern-host` header documentation matches current Fern behavior (header value is bare domain without subpath)

### Notes

The origin URL used in all examples is `app.buildwithfern.com`, which is the production Fern docs origin. The `x-fern-host` header behavior is documented in `packages/fern-docs/bundle/src/proxy.ts` and `packages/commons/docs-server/src/xfernhost/edge.ts` in the fern-platform repo.

Link to Devin session: https://app.devin.ai/sessions/5705640d594a45858652bac81f125c9d
Requested by: @thesandlord