### PR TITLE
docs: remove Pro SDK tier references to match current pricing

### DIFF
--- a/fern/products/api-def/openapi/auth.mdx
+++ b/fern/products/api-def/openapi/auth.mdx
@@ -235,8 +235,8 @@ auth-schemes:
 </Accordion>
 <Accordion title="OAuth client credentials">
 
-<Warning title="Pro and Enterprise feature">
-This feature is available on [Pro and Enterprise plans](https://buildwithfern.com/pricing). Contact support@buildwithfern.com to get started.
+<Warning title="Enterprise feature">
+This feature is available on the [Enterprise plan](https://buildwithfern.com/pricing). Contact support@buildwithfern.com to get started.
 </Warning>
 
 ```yaml title="generators.yml"

--- a/fern/products/api-def/pages/project-structure.mdx
+++ b/fern/products/api-def/pages/project-structure.mdx
@@ -136,8 +136,8 @@ groups:
 
 ### Combined SDKs from multiple APIs
 
-<Warning title="Pro and Enterprise feature">
-    This feature is available only for the [Pro and Enterprise plans](https://buildwithfern.com/pricing). You can merge up to five APIs into a single SDK on the Pro plan, and unlimited APIs on the Enterprise plan. To get started, reach out to support@buildwithfern.com.
+<Warning title="Enterprise feature">
+    This feature is available only for the [Enterprise plan](https://buildwithfern.com/pricing). To get started, reach out to support@buildwithfern.com.
 </Warning>
 
 Use this approach when you want to merge multiple APIs into a single SDK package, with optional namespacing to organize them. This works for both distinct APIs and versioned APIs, though it increases package size as all APIs are bundled together.

--- a/fern/products/dashboard/pages/permissions.mdx
+++ b/fern/products/dashboard/pages/permissions.mdx
@@ -87,5 +87,4 @@ Your [plan](https://buildwithfern.com/pricing) determines how many members you c
 | Plan       | Team members |
 | ---------- | ------------ |
 | Hobby      | 2            |
-| Pro        | 5            |
 | Enterprise | Custom       |

--- a/fern/products/dashboard/pages/permissions.mdx
+++ b/fern/products/dashboard/pages/permissions.mdx
@@ -87,4 +87,5 @@ Your [plan](https://buildwithfern.com/pricing) determines how many members you c
 | Plan       | Team members |
 | ---------- | ------------ |
 | Hobby      | 2            |
+| Team       | 5            |
 | Enterprise | Custom       |

--- a/fern/products/docs/pages/ai/overview.mdx
+++ b/fern/products/docs/pages/ai/overview.mdx
@@ -8,7 +8,7 @@ Your documentation site comes with automatic optimizations for AI tools, plus fe
 
 <Anchor id="ai-credits">
 <Tip title="AI credits">
-  AI features are usage-based and consume credits. Every [plan](https://buildwithfern.com/pricing) includes a monthly credit allowance: Hobby plans get 250 credits, Pro plans get 1,000 credits, and Enterprise plans get a custom amount.
+  AI features are usage-based and consume credits. Every [plan](https://buildwithfern.com/pricing) includes a monthly credit allowance: Hobby plans get 250 credits and Enterprise plans get a custom amount.
 
   | Feature | Credits |
   | --- | --- |

--- a/fern/products/docs/pages/ai/overview.mdx
+++ b/fern/products/docs/pages/ai/overview.mdx
@@ -8,7 +8,7 @@ Your documentation site comes with automatic optimizations for AI tools, plus fe
 
 <Anchor id="ai-credits">
 <Tip title="AI credits">
-  AI features are usage-based and consume credits. Every [plan](https://buildwithfern.com/pricing) includes a monthly credit allowance: Hobby plans get 250 credits and Enterprise plans get a custom amount.
+  AI features are usage-based and consume credits. Every [plan](https://buildwithfern.com/pricing) includes a monthly credit allowance: Hobby plans get 250 credits, Team plans get 1,000 credits, and Enterprise plans get a custom amount.
 
   | Feature | Credits |
   | --- | --- |

--- a/fern/snippets/pro-plan.mdx
+++ b/fern/snippets/pro-plan.mdx
@@ -1,3 +1,3 @@
-<Warning title="Pro and Enterprise feature">
-    This feature is available only for the [Pro and Enterprise plans](https://buildwithfern.com/pricing). To get started, reach out to support@buildwithfern.com.
+<Warning title="Enterprise feature">
+    This feature is available only for the [Enterprise plan](https://buildwithfern.com/pricing). To get started, reach out to support@buildwithfern.com.
 </Warning>

--- a/fern/snippets/team-or-pro-plan.mdx
+++ b/fern/snippets/team-or-pro-plan.mdx
@@ -1,3 +1,3 @@
-<Warning title="Team, Pro, and Enterprise feature">
-    This feature is available only for the [Team (Docs), Pro (SDKs), and Enterprise plans](https://buildwithfern.com/pricing). To get started, reach out to support@buildwithfern.com.
+<Warning title="Team and Enterprise feature">
+    This feature is available only for the [Team (Docs) and Enterprise plans](https://buildwithfern.com/pricing). To get started, reach out to support@buildwithfern.com.
 </Warning>

--- a/fern/translations/zh/products/api-def/pages/project-structure.mdx
+++ b/fern/translations/zh/products/api-def/pages/project-structure.mdx
@@ -134,8 +134,8 @@ groups:
 
 ### 从多个 API 合并 SDK
 
-<Warning title="Pro 和 Enterprise 功能">
-    此功能仅适用于 [Pro 和 Enterprise 计划](https://buildwithfern.com/pricing)。您可以在 Pro 计划中将多达五个 API 合并到单个 SDK 中，在 Enterprise 计划中可以合并无限数量的 API。要开始使用，请联系 support@buildwithfern.com。
+<Warning title="Enterprise 功能">
+    此功能仅适用于 [Enterprise 计划](https://buildwithfern.com/pricing)。要开始使用，请联系 support@buildwithfern.com。
 </Warning>
 
 当您希望将多个 API 合并到单个 SDK 包中，并可选择使用命名空间来组织它们时，请使用此方法。这适用于不同的 API 和版本化 API，但会增加包大小，因为所有 API 都打包在一起。

--- a/fern/translations/zh/products/dashboard/pages/permissions.mdx
+++ b/fern/translations/zh/products/dashboard/pages/permissions.mdx
@@ -86,5 +86,4 @@ description: 管理您组织的 Dashboard 和 CLI 访问权限。
 | 套餐      | 团队成员 |
 | -------- | ------- |
 | Hobby    | 2       |
-| Pro      | 5       |
 | Enterprise | 自定义  |

--- a/fern/translations/zh/products/dashboard/pages/permissions.mdx
+++ b/fern/translations/zh/products/dashboard/pages/permissions.mdx
@@ -86,4 +86,5 @@ description: 管理您组织的 Dashboard 和 CLI 访问权限。
 | 套餐      | 团队成员 |
 | -------- | ------- |
 | Hobby    | 2       |
+| Team     | 5       |
 | Enterprise | 自定义  |

--- a/fern/translations/zh/products/docs/pages/ai/overview.mdx
+++ b/fern/translations/zh/products/docs/pages/ai/overview.mdx
@@ -9,7 +9,7 @@ description: Fern AI 功能帮助用户即时找到答案，自动更新内容�
 
 <Anchor id="ai-credits">
 <Tip title="AI 额度">
-  AI 功能按使用量计费并消耗额度。每个 [套餐](https://buildwithfern.com/pricing) 都包含每月额度配额：Hobby 套餐获得 250 额度，Enterprise 套餐获得自定义额度。
+  AI 功能按使用量计费并消耗额度。每个 [套餐](https://buildwithfern.com/pricing) 都包含每月额度配额：Hobby 套餐获得 250 额度，Team 套餐获得 1,000 额度，Enterprise 套餐获得自定义额度。
 
   | 功能 | 额度 |
   | --- | --- |

--- a/fern/translations/zh/products/docs/pages/ai/overview.mdx
+++ b/fern/translations/zh/products/docs/pages/ai/overview.mdx
@@ -9,7 +9,7 @@ description: Fern AI 功能帮助用户即时找到答案，自动更新内容�
 
 <Anchor id="ai-credits">
 <Tip title="AI 额度">
-  AI 功能按使用量计费并消耗额度。每个 [套餐](https://buildwithfern.com/pricing) 都包含每月额度配额：Hobby 套餐获得 250 额度，Pro 套餐获得 1,000 额度，Enterprise 套餐获得自定义额度。
+  AI 功能按使用量计费并消耗额度。每个 [套餐](https://buildwithfern.com/pricing) 都包含每月额度配额：Hobby 套餐获得 250 额度，Enterprise 套餐获得自定义额度。
 
   | 功能 | 额度 |
   | --- | --- |


### PR DESCRIPTION
## Summary

SDK pricing now lists only **Hobby** and **Enterprise** tiers — the Pro tier has been removed. This PR updates all documentation references to match. Where "Pro" referred to the Docs product, it's replaced with **Team** (the current Docs tier).

Changes across 9 files (English + Chinese translations):

- **Shared snippets**: `pro-plan.mdx` now says "Enterprise feature"; `team-or-pro-plan.mdx` now says "Team and Enterprise feature" (removed "Pro (SDKs)")
- **project-structure.mdx**: Combined SDKs warning updated from "Pro and Enterprise" to "Enterprise"
- **auth.mdx**: OAuth client credentials warning updated from "Pro and Enterprise" to "Enterprise"
- **permissions.mdx**: Replaced "Pro | 5" with "Team | 5" in the team-members-by-plan table
- **ai/overview.mdx**: Replaced "Pro plans get 1,000 credits" with "Team plans get 1,000 credits"

The snippet changes propagate to ~25 pages that include `pro-plan.mdx` or `team-or-pro-plan.mdx`.

## Review & Testing Checklist for Human

- [ ] Verify "Team plans get 1,000 credits" is accurate on the [AI features page](https://buildwithfern.com/learn/docs/ai-features/overview)
- [ ] Verify "Team | 5" team members is accurate on the [permissions page](https://buildwithfern.com/learn/dashboard/configuration/permissions)

### Notes

- References to "Font Awesome Pro", "Cursor Pro tier", and "Source Code Pro" font are unrelated to Fern pricing and were left unchanged
- The snippet filenames (`pro-plan.mdx`, `team-or-pro-plan.mdx`) are now slightly misleading but still functional — a rename could be done as a follow-up if desired

Link to Devin session: https://app.devin.ai/sessions/d6120a7977524dd0b9ee8ecbe1644804
Requested by: @cdonel707