### PR TITLE
fix: update CloudFront reverse proxy to use AllViewerExceptHostHeader

### DIFF
--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -124,7 +124,7 @@ CloudFront evaluates behaviors in order. Ensure your `/docs*` behavior appears *
 </Steps>
 
 <Warning>
-CloudFront ignores `CDN-Cache-Control` and `Surrogate-Control` — only the standard `Cache-Control` header is read. If you use a custom cache policy instead of `CachingDisabled`, set the default, minimum, and maximum TTL to `0`. A non-zero default TTL caches HTML responses regardless of Fern's `Cache-Control: max-age=0` directive, which causes pages to break after Fern deploys an update.
+CloudFront ignores `CDN-Cache-Control` and `Surrogate-Control` — only the standard `Cache-Control` header is read. If you use a custom cache policy instead of `CachingDisabled`, set the default, minimum, and maximum TTL to `0`. A non-zero default TTL caches HTML responses regardless of Fern's `Cache-Control: max-age=0` directive, which can cause stale content and errors.
 </Warning>
 </Accordion>
 

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -82,28 +82,49 @@ The Worker forwards Fern's `Cache-Control` header, so caching works automaticall
 <Steps>
 <Step title="Add a Fern origin">
 
-Add an origin to your CloudFront distribution pointing to `app.buildwithfern.com` (HTTPS only, port 443). Add a custom origin header:
+In your CloudFront distribution, go to **Origins** and create a new origin:
+
+| Setting | Value |
+|---|---|
+| **Origin domain** | `app.buildwithfern.com` |
+| **Protocol** | HTTPS only |
+| **HTTPS port** | 443 |
+| **Minimum origin SSL protocol** | TLSv1.2 |
+
+Under **Add custom header**, add:
 
 | Header name | Value |
 |---|---|
 | `x-fern-host` | `mydomain.com` |
 
-CloudFront automatically sets the `Host` header to the origin domain.
+Replace `mydomain.com` with your bare domain (without the subpath).
 </Step>
-<Step title="Create a cache behavior for `/docs*`">
+<Step title="Create a cache behavior for your docs path">
 
-Set the behavior to:
+Go to **Behaviors** and create a new behavior:
 
-- **Origin**: the Fern origin you just created
-- **Cache policy**: `CachingDisabled` (AWS managed policy)
-- **Origin request policy**: `AllViewer` (forwards all headers, query strings, and cookies)
+| Setting | Value |
+|---|---|
+| **Path pattern** | `/docs*` |
+| **Origin** | The Fern origin you just created |
+| **Viewer protocol policy** | Redirect HTTP to HTTPS |
+| **Cache policy** | `CachingDisabled` (AWS managed) |
+| **Origin request policy** | `AllViewerExceptHostHeader` (AWS managed) |
 
-To use a custom cache policy instead of `CachingDisabled`, set min, max, and default TTL to `0` and forward `Host` and `x-fern-host`.
+`AllViewerExceptHostHeader` forwards all viewer headers, query strings, and cookies to the origin while letting CloudFront set the `Host` header to `app.buildwithfern.com`. This is required — Fern's origin uses the `Host` header for routing and rejects requests with an unrecognized host.
+
+<Warning>
+Do not use the `AllViewer` origin request policy. It forwards the viewer's `Host` header (your domain) instead of the origin's, which causes Fern's origin to return errors or raw React Server Component payloads instead of HTML.
+</Warning>
+</Step>
+<Step title="Verify the behavior order">
+
+CloudFront evaluates behaviors in order. Ensure your `/docs*` behavior appears **above** the default (`*`) behavior so docs requests are routed to Fern's origin rather than your primary site.
 </Step>
 </Steps>
 
 <Warning>
-CloudFront ignores `CDN-Cache-Control` and `Surrogate-Control` — only the standard `Cache-Control` header is read. A custom cache policy with a non-zero default TTL caches responses regardless of Fern's `Cache-Control: max-age=0` directive.
+CloudFront ignores `CDN-Cache-Control` and `Surrogate-Control` — only the standard `Cache-Control` header is read. If you use a custom cache policy instead of `CachingDisabled`, set the default, minimum, and maximum TTL to `0`. A non-zero default TTL caches HTML responses regardless of Fern's `Cache-Control: max-age=0` directive, which causes pages to break after Fern deploys an update.
 </Warning>
 </Accordion>
 
@@ -256,8 +277,9 @@ Caddy doesn't cache responses by default, so no extra caching configuration is n
 Run these checks against your live subpath:
 
 ```bash
-# Check that the page loads and x-fern-host is recognized
-curl -sI https://mydomain.com/docs | head -20
+# Confirm the page returns HTML (not an error or RSC payload)
+curl -sI https://mydomain.com/docs | grep -i content-type
+# Expected: content-type: text/html; charset=utf-8
 
 # Verify Cache-Control on the HTML response
 curl -sI https://mydomain.com/docs | grep -i cache-control
@@ -266,5 +288,7 @@ curl -sI https://mydomain.com/docs | grep -i cache-control
 # Verify the page is not cached by your proxy (age should be 0 or absent)
 curl -sI https://mydomain.com/docs | grep -i "^age:"
 ```
+
+If `content-type` is `text/x-component` instead of `text/html`, your proxy is forwarding the viewer's `Host` header to Fern's origin. Ensure the `Host` header sent to the origin is `app.buildwithfern.com`.
 
 If the `age` header is present and non-zero, your proxy is serving a cached response. Revisit your provider's configuration to ensure HTML caching is disabled.


### PR DESCRIPTION
## Summary

Fixes the AWS CloudFront reverse proxy instructions to prevent Fern's origin from returning raw React Server Component (RSC) payloads instead of HTML.

**Root cause**: The previous instructions recommended `AllViewer` as the origin request policy, which forwards the viewer's `Host` header (e.g., `fyno.io`) to Vercel. Vercel uses `Host` for deployment routing and doesn't recognize the customer's domain, returning `DEPLOYMENT_NOT_FOUND` errors or RSC payloads instead of HTML.

**Fix**: Use `AllViewerExceptHostHeader` instead — this forwards all viewer headers except `Host`, letting CloudFront set it to `app.buildwithfern.com` (the origin domain) as required.

Changes:
- Replace `AllViewer` → `AllViewerExceptHostHeader` origin request policy
- Add detailed origin configuration (TLS version, protocol, SSL settings)
- Add a step to verify cache behavior ordering
- Add an explicit warning against using `AllViewer`
- Expand the caching warning with more detail
- Add RSC content-type check to the verification section

## Review & Testing Checklist for Human
- [ ] Verify `AllViewerExceptHostHeader` is the correct AWS managed origin request policy name (it is — [AWS docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html))
- [ ] Confirm the updated instructions render correctly on the preview site
- [ ] Test with a real CloudFront distribution if possible — verify `curl -sI https://yourdomain.com/docs` returns `content-type: text/html` (not `text/x-component`)

### Notes
Triggered by a customer (fyno.io) experiencing raw RSC payloads from their CloudFront setup.

Link to Devin session: https://app.devin.ai/sessions/64d575f1063a466a8b81666eef178600
Requested by: @thesandlord