### PR TITLE
fix: product switcher double-highlight on hover in Safari

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -163,6 +163,7 @@ h1, h2, h3 {
     > a[href*="openrpc"],
     > a[href*="grpc"],
     > a[href*="ferndef"] {
+      align-self: start;
       .fern-selection-item-subtitle {
         display: none;
       }

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -129,10 +129,8 @@ h1, h2, h3 {
 
       .fern-selection-item{
         border-radius: 1rem;
-      }
-
-      .fern-selection-item:hover {
-        background-color: transparent;
+        border-color: transparent;
+        outline: none;
       }
 
     }

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -131,6 +131,10 @@ h1, h2, h3 {
         border-radius: 1rem;
       }
 
+      .fern-selection-item:hover {
+        background-color: transparent;
+      }
+
     }
 
     > a[href*="home"] {

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -126,6 +126,7 @@ h1, h2, h3 {
       max-width: 320px;
       margin: -0.75rem;
       position: relative;
+      outline: none;
 
       .fern-selection-item{
         border-radius: 1rem;


### PR DESCRIPTION
## Summary
Three CSS fixes to the product switcher dropdown on buildwithfern.com:

1. **`align-self: start`** on right-column items (OpenAPI, AsyncAPI, OpenRPC, gRPC) — eliminates double-highlight by shrinking hit areas from 74px to 42px so the `translateY` transforms don't cause overlapping hover regions
2. **`outline: none`** on the `<a>` wrapper elements — removes the green focus outline (`rgba(16, 181, 0, 0.255) auto 1px`) applied by Radix's `tabindex` focus management
3. **`border-color: transparent`** on `.fern-selection-item` — ensures no border becomes visible on hover

The green hover background (`bg-(color:--grayscale-a3)`) is preserved — it's intentional.

## Review & Testing Checklist for Human
- [ ] Open the product switcher dropdown in **Safari** and hover over each right-column item (OpenAPI, AsyncAPI, OpenRPC, gRPC) — verify only ONE item highlights at a time (the original double-highlight bug was Safari-specific)
- [ ] Verify the green hover background is visible but no outline/border appears around hovered items
- [ ] Check that left/middle column items (Home, SDKs, Docs, Dashboard, CLI Generator, Fern CLI) still have correct hover behavior

Recommended test: Open the preview URL in Safari, click the "Docs" product switcher, and slowly move your cursor down through OpenAPI → AsyncAPI → OpenRPC → gRPC. Each should highlight individually with a subtle green background fill and no visible outline.

### Notes
- The outline was coming from the `<a>` element (Radix's focus ring via `tabindex="0"`), not from `.fern-selection-item` — this is why the initial fix targeting only the inner element didn't remove it
- Tested in Chrome on Linux; the double-highlight root cause (overlapping CSS Grid hit areas) is browser-agnostic, but Safari may render focus rings differently so Safari verification is recommended

Link to Devin session: https://app.devin.ai/sessions/5019b6dc872e4ed7890a74d2415ccf5c
Requested by: @Ryan-Amirthan