### PR TITLE
docs: add Netlify rate limiting and proxy timeout guidance to reverse proxy page

### DIFF
--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -146,6 +146,22 @@ In `netlify.toml` (or `_redirects`):
     x-fern-host = "mydomain.com"
 ```
 </Step>
+<Step title="Disable rate limiting for the docs path">
+
+Fern revalidates your docs site by warming page caches with concurrent requests (up to 250 at a time). Netlify's [traffic rules](https://docs.netlify.com/security/secure-access/traffic-rules/) can interpret this as abusive traffic and block the requests, causing revalidation to fail.
+
+If you have rate limiting enabled under **Security** > **Traffic rules** in the Netlify dashboard, add a rule that excludes your docs subpath (`/docs/*`) from rate limiting.
+
+</Step>
+<Step title="Check the proxy timeout">
+
+Fern's revalidation endpoint (`/api/fern-docs/revalidate`) streams a long-running response while warming page caches. Netlify's default proxy timeout for rewrites can terminate this stream before warming completes.
+
+On **Pro** plans and below, the proxy timeout is **26 seconds** — too short for sites with more than a few hundred pages. **Business** and **Enterprise** plans support up to **15 minutes**, which is sufficient for most sites.
+
+If revalidation consistently fails with a "terminated" status, the proxy timeout is the most likely cause. Upgrade to a plan with a longer timeout or contact [Netlify support](https://www.netlify.com/support/) to increase the limit.
+
+</Step>
 </Steps>
 
 <Note>

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -155,11 +155,9 @@ If you have rate limiting enabled under **Security** > **Traffic rules** in the 
 </Step>
 <Step title="Check the proxy timeout">
 
-Fern's revalidation endpoint (`/api/fern-docs/revalidate`) streams a long-running response while warming page caches. Netlify's default proxy timeout for rewrites can terminate this stream before warming completes.
+Fern's revalidation endpoint (`/api/fern-docs/revalidate`) streams a long-running response while warming page caches. Netlify [limits proxy rewrite requests to 26 seconds](https://docs.netlify.com/manage/routing/redirects/rewrites-proxies/#limitations), which can terminate the stream before warming completes on sites with more than a few hundred pages.
 
-On **Pro** plans and below, the proxy timeout is **26 seconds** — too short for sites with more than a few hundred pages. **Business** and **Enterprise** plans support up to **15 minutes**, which is sufficient for most sites.
-
-If revalidation consistently fails with a "terminated" status, the proxy timeout is the most likely cause. Upgrade to a plan with a longer timeout or contact [Netlify support](https://www.netlify.com/support/) to increase the limit.
+If revalidation consistently fails with a "terminated" status, this timeout is the most likely cause. Contact [Netlify support](https://www.netlify.com/support/) to request a timeout increase for your site, or reach out to [Fern support](https://buildwithfern.com/contact) for alternative warming options.
 
 </Step>
 </Steps>

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -148,14 +148,14 @@ In `netlify.toml` (or `_redirects`):
 </Step>
 <Step title="Disable rate limiting for the docs path">
 
-Fern revalidates your docs site by warming page caches with concurrent requests (up to 250 at a time). Netlify's [traffic rules](https://docs.netlify.com/security/secure-access/traffic-rules/) can interpret this as abusive traffic and block the requests, causing revalidation to fail.
+Fern revalidates your docs site by warming page caches with concurrent requests. Netlify's [traffic rules](https://docs.netlify.com/security/secure-access/traffic-rules/) can interpret this as abusive traffic and block the requests, causing revalidation to fail.
 
 If you have rate limiting enabled under **Security** > **Traffic rules** in the Netlify dashboard, add a rule that excludes your docs subpath (`/docs/*`) from rate limiting.
 
 </Step>
 <Step title="Check the proxy timeout">
 
-Fern's revalidation endpoint (`/api/fern-docs/revalidate`) streams a long-running response while warming page caches. Netlify [limits proxy rewrite requests to 26 seconds](https://docs.netlify.com/manage/routing/redirects/rewrites-proxies/#limitations), which can terminate the stream before warming completes on sites with more than a few hundred pages.
+Fern's revalidation endpoint streams a long-running response while warming page caches. Netlify [limits proxy rewrite requests to 26 seconds](https://docs.netlify.com/manage/routing/redirects/rewrites-proxies/#limitations), which can terminate the stream before warming completes on sites with more than a few hundred pages.
 
 If revalidation consistently fails with a "terminated" status, this timeout is the most likely cause. Contact [Netlify support](https://www.netlify.com/support/) to request a timeout increase for your site, or reach out to [Fern support](https://buildwithfern.com/contact) for alternative warming options.
 


### PR DESCRIPTION
## Summary

Adds two new steps to the Netlify section of the reverse proxy setup page:

1. **Disable rate limiting for the docs path** — Fern's revalidation warms page caches with up to 250 concurrent requests, which Netlify's traffic rules can interpret as abusive traffic and block.
2. **Check the proxy timeout** — Netlify [hard-limits proxy rewrites to 26 seconds](https://docs.netlify.com/manage/routing/redirects/rewrites-proxies/#limitations). The revalidation endpoint streams a long-running response that exceeds this on sites with hundreds of pages, causing the stream to terminate mid-warming.

Motivated by `www.astronomer.io/docs` revalidation failures — their Netlify reverse proxy was terminating the warming stream at ~36/1875 URLs.

Link to Devin session: https://app.devin.ai/sessions/7363c79612664f65814d126e131e739d
Requested by: @thesandlord