### PR TITLE
docs: rename fernapi/fern-cli to fernapi/fern-cli-generator and bump to 0.6.1

### DIFF
--- a/fern/products/cli-generator/quickstart.mdx
+++ b/fern/products/cli-generator/quickstart.mdx
@@ -47,8 +47,8 @@ default-group: cli
 groups:
   cli:
     generators:
-      - name: fernapi/fern-cli
-        version: 0.4.0
+      - name: fernapi/fern-cli-generator
+        version: 0.6.1
         github:
           repo: my-org/my-cli
           mode: release


### PR DESCRIPTION
## Summary

Updates the CLI generator quickstart example to reflect the Docker image rename from `fernapi/fern-cli` to `fernapi/fern-cli-generator` (per https://github.com/fern-api/fern/pull/16201) and bumps the minimum version from `0.4.0` to `0.6.1`.

Only the generators.yml code example in `fern/products/cli-generator/quickstart.mdx` needed updating. Changelog entries referencing the old name were left as-is since they are historical records (and the 2026-06-03 changelog already documents the rename).

Link to Devin session: https://app.devin.ai/sessions/e7208d0312404f66bfaa336ebbba4b32
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->