### PR TITLE
Remove Fern-hosted registry URL from public docs

### DIFF
--- a/fern/products/cli-api-reference/cli-changelog/2026-03-27.mdx
+++ b/fern/products/cli-api-reference/cli-changelog/2026-03-27.mdx
@@ -8,9 +8,9 @@ preventing use of unauthenticated endpoints like signup or signin.
 
 ## 4.47.0
 **`(feat):`** Add `fern sdk preview` command for publishing preview SDK packages.
-Generates an SDK via Docker and publishes it to the Fern preview
-registry (`npm.buildwithfern.com`). Outputs an `npm install` alias
-command so consumers can test the preview with zero import changes.
+Generates an SDK via Docker and publishes it to a preview registry.
+Outputs an `npm install` alias command so consumers can test the
+preview with zero import changes.
 
 ```bash
 fern sdk preview --group my-sdk


### PR DESCRIPTION
## Summary

Removes the explicit `npm.buildwithfern.com` URL from the CLI changelog entry for `fern sdk preview` (v4.47.0). The Fern-hosted registry is an internal implementation detail that should not be advertised to external users. The feature description now refers generically to "a preview registry" instead.

Link to Devin session: https://app.devin.ai/sessions/da9fa1ed5f814c6687dd831fe72a2b37
Requested by: @dannysheridan