### PR TITLE
Fix double space in README contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,6 @@ If you want to **add a new page or make a large structural change**:
 - [File an issue in GitHub](https://github.com/fern-api/docs/issues) and assign [@devalog](https://github.com/devalog). We'll review your issue to make sure your proposed page fits with Fern's overall documentation strategy and isn't duplicating any ongoing work. 
 
 For **all other changes**:
--  Submit a PR directly with your suggested changes. A Fern docs member will review and confirm.
+- Submit a PR directly with your suggested changes. A Fern docs member will review and confirm.
 
 If you see something that is wrong or outdated in the documentation but don't know how to fix it, [file an issue](https://github.com/fern-api/docs/issues) or reach out to [@devalog](https://github.com/devalog).


### PR DESCRIPTION
Removes a stray double space after the list dash in the "Getting changes reviewed" section of the README, making it consistent with the surrounding bullet formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5735" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->