### PR TITLE
copy: make RBAC and auth language more conversational

### DIFF
--- a/fern/products/docs/pages/authentication/overview.mdx
+++ b/fern/products/docs/pages/authentication/overview.mdx
@@ -1,17 +1,17 @@
 ---
 title: Overview of authentication options
-description: Understand the different authentication options Fern offers
+description: Gate your docs so only the right customers see the right content
 ---
 
 
-Fern offers four ways to authenticate users on your documentation site.
+Fern offers four ways to gate your docs so only the right users see the right content.
 
 <CardGroup cols={2}>
   <Card title="Password protection" icon="fa-duotone fa-lock" href="/learn/docs/authentication/setup/password-protection">
-    A shared password for the entire site or multiple passwords mapped to roles
+    Gate your entire site with a shared password, or map multiple passwords to roles
   </Card>
   <Card title="SSO" icon="fa-duotone fa-user-check" href="/learn/docs/authentication/setup/sso">
-    Corporate credentials for internal docs
+    Put your docs behind your organization's login
   </Card>
   <Card title="JWT" icon="fa-duotone fa-key" href="/learn/docs/authentication/setup/jwt">
     Self-managed auth integrated with your login system

--- a/fern/products/docs/pages/authentication/overview.mdx
+++ b/fern/products/docs/pages/authentication/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: Overview of authentication options
-description: Gate your docs so only the right customers see the right content
+description: Gate your docs so readers only see the content relevant to them.
 ---
 
 
-Fern offers four ways to gate your docs so only the right users see the right content.
+Fern offers four ways to authenticate users on your documentation site:
 
 <CardGroup cols={2}>
   <Card title="Password protection" icon="fa-duotone fa-lock" href="/learn/docs/authentication/setup/password-protection">

--- a/fern/products/docs/pages/authentication/password.mdx
+++ b/fern/products/docs/pages/authentication/password.mdx
@@ -1,6 +1,6 @@
 ---
 title: Password protection
-subtitle: Protect your documentation site with a shared password for simple access control.
+subtitle: Gate your docs with a shared password
 ---
 
 

--- a/fern/products/docs/pages/authentication/rbac.mdx
+++ b/fern/products/docs/pages/authentication/rbac.mdx
@@ -1,16 +1,16 @@
 ---
 title: Role-based access control
-subtitle: Control who can view your documentation
-description: Learn how to restrict access to your documentation using role-based access control (RBAC)
+subtitle: Show different docs to different customers
+description: Restrict pages by role, team, or pricing tier so each audience sees only what they should.
 ---
 
 <Warning title="Team and Enterprise feature">
   Password-based RBAC is available on the [Team and Enterprise plans](https://buildwithfern.com/pricing). JWT and OAuth-based RBAC require the [Enterprise plan](https://buildwithfern.com/pricing).
 </Warning>
 
-RBAC controls access to pages, sections, and other navigation items based on user roles. It works with [password protection](/learn/docs/authentication/setup/password-protection), [JWT](/learn/docs/authentication/setup/jwt), and [OAuth](/learn/docs/authentication/setup/oauth) authentication.
+RBAC gates pages, sections, and other navigation items by role so each audience sees only the content meant for them. It works with [password protection](/learn/docs/authentication/setup/password-protection), [JWT](/learn/docs/authentication/setup/jwt), and [OAuth](/learn/docs/authentication/setup/oauth) authentication.
 
-RBAC is useful for partner docs, beta features, tiered access, and internal content. You can combine it with [API key injection](/learn/docs/authentication/features/api-key-injection) when using JWT or OAuth authentication. When RBAC is configured, [Ask Fern](/learn/docs/ai-features/ask-fern/overview) automatically respects these permissions. By default, restricted pages are completely hidden from unauthorized users — if you'd like them to be visible but locked instead, let Fern know during setup.
+Use it for partner docs, beta features, tiered pricing content, and internal resources. You can combine it with [API key injection](/learn/docs/authentication/features/api-key-injection) when using JWT or OAuth authentication. When RBAC is configured, [Ask Fern](/learn/docs/ai-features/ask-fern/overview) automatically respects these permissions. By default, restricted pages are completely hidden from unauthorized users — if you'd like them to be visible but locked instead, let Fern know during setup.
 
 ## Setup
 

--- a/fern/products/docs/pages/authentication/sso.mdx
+++ b/fern/products/docs/pages/authentication/sso.mdx
@@ -1,6 +1,6 @@
 ---
 title: Single Sign-On
-subtitle: Secure access to your documentation using corporate credentials
+subtitle: Put your docs behind your organization's login
 ---
 
 
@@ -8,7 +8,7 @@ subtitle: Secure access to your documentation using corporate credentials
 
 SSO lets your team access your docs through your organization's identity provider using SAML 2.0 or OIDC. Like [RBAC](/learn/docs/authentication/features/rbac) and [API key injection](/learn/docs/authentication/features/api-key-injection), SSO uses the [`fern_token`](/learn/docs/authentication/overview#how-authentication-works) cookie to identify authenticated users. SSO unlocks the [Fern Editor](/learn/docs/writing-content/fern-editor) for browser-based editing and [authenticated preview links](/learn/docs/preview-publish/preview-changes#preview-links).
 
-<Note>SSO provides login-based access control but does not support role management or API key injection. For granular access control, use [RBAC](/learn/docs/authentication/features/rbac) instead.</Note>
+<Note>SSO provides login-based access control but doesn't support role management or API key injection. For granular access control, use [RBAC](/learn/docs/authentication/features/rbac) instead.</Note>
 
 ## How it works
 

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -155,7 +155,7 @@ layout: custom
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
           <a className="fern-button minimal normal w-fit gap-1 a-btn" href="/docs/authentication/features/rbac">
-            Control role-based access
+            Gate docs by role
             <img src="./images/arrow-right-black.svg" alt="Arrow right light" className="dark:hidden" noZoom />
             <img src="./images/arrow-right-white.svg" alt="Arrow right light" className="hidden dark:block" noZoom />
           </a>
@@ -399,7 +399,7 @@ A beautiful, interactive documentation website.
 - [AI features](/docs/ai-features/overview)
 - [Fern Editor](/docs/writing-content/fern-editor)
 - [Bring your own API spec](/docs/api-references/generate-api-ref)
-- [Control role-based access](/docs/authentication/features/rbac)
+- [Gate docs by role](/docs/authentication/features/rbac)
 - [Self-host your docs](/docs/self-hosted/overview)
 - [Customers](https://buildwithfern.com/showcase#docs-customers.alldocs-features)
 


### PR DESCRIPTION
## Summary

Aligns docs copy with [marketing-site PR #244](https://github.com/fern-api/marketing-site/pull/244). Shifts RBAC/auth language from technical jargon to outcome-focused framing prospects actually use ("gate your docs," "right customers see the right content").

Changes across 5 files:

- **rbac.mdx** — subtitle: "Control who can view your documentation" → "Show different docs to different customers"; description reworded; intro uses "gates" instead of "controls access"
- **overview.mdx** — description + intro sentence use "gate your docs so only the right users see the right content"; Password card: "Gate your entire site with a shared password"; SSO card: "Put your docs behind your organization's login"
- **sso.mdx** — subtitle: "Secure access to your documentation using corporate credentials" → "Put your docs behind your organization's login"; also fixes pre-existing Vale error (`does not` → `doesn't`)
- **password.mdx** — subtitle: "Protect your documentation site with a shared password for simple access control" → "Gate your docs with a shared password"
- **welcome.mdx** — link text: "Control role-based access" → "Gate docs by role"

Technical setup instructions left unchanged — only subtitles, descriptions, and intro paragraphs updated.

Link to Devin session: https://app.devin.ai/sessions/44345684cd91481b9a53696a9f8925b8
Requested by: @dannysheridan