### PR TITLE
Add missing API property CSS selectors to reference page

### DIFF
--- a/fern/products/docs/pages/customization/css-selectors.mdx
+++ b/fern/products/docs/pages/customization/css-selectors.mdx
@@ -2236,6 +2236,30 @@ API property constraint.
 ```
 
 </Accordion>
+
+<Accordion title=".fern-api-property-optional">
+
+"Optional" label on non-required properties. Inherits styles from `.fern-api-property-meta`.
+
+```css Example: Hide the "Optional" label
+.fern-api-property-optional {
+  display: none;
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-api-property-required">
+
+"Required" label on required properties.
+
+```css Default CSS
+.fern-api-property-required {
+  color: var(--red-a11);
+}
+```
+
+</Accordion>
 </AccordionGroup>
 
 ## Utility components

--- a/fern/products/docs/pages/customization/css-selectors.mdx
+++ b/fern/products/docs/pages/customization/css-selectors.mdx
@@ -2260,6 +2260,42 @@ API property constraint.
 ```
 
 </Accordion>
+
+<Accordion title=".fern-api-property-type">
+
+API property type label (e.g. "string", "integer"). Inherits styles from `.fern-api-property-meta`.
+
+```css Example: Customize type label color
+.fern-api-property-type {
+  color: var(--accent-a11);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-api-property-default">
+
+Default value display for a property.
+
+```css Example: Style default value
+.fern-api-property-default code {
+  color: var(--accent-a11);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-api-property-readonly">
+
+"Read only" label on read-only properties. Inherits styles from `.fern-api-property-meta`.
+
+```css Example: Hide the "Read only" label
+.fern-api-property-readonly {
+  display: none;
+}
+```
+
+</Accordion>
 </AccordionGroup>
 
 ## Utility components


### PR DESCRIPTION
## Summary\n\nAdds 5 missing `.fern-api-property-*` selectors to the [CSS selectors reference](https://fern-preview-devin-1781115713-add-optional-css-selector.docs.buildwithfern.com/learn/docs/customization/css-selectors-reference) page under the API Reference components section:\n\n- `.fern-api-property-optional` — \"Optional\" label on non-required properties\n- `.fern-api-property-required` — \"Required\" label on required properties\n- `.fern-api-property-type` — type label (e.g. \"string\", \"integer\")\n- `.fern-api-property-default` — default value display\n- `.fern-api-property-readonly` — \"Read only\" label\n\nThese selectors already exist in the docs rendering code (`fern-platform`) but were missing from the reference page. Users can now discover them and use custom CSS to hide or restyle these labels — e.g.:\n\n```css\n.fern-api-property-optional {\n  display: none;\n}\n```

Link to Devin session: https://app.devin.ai/sessions/c279f5a5c8514804bb588ce76043ee5d
Requested by: @thesandlord