### PR TITLE
docs: add changelog entry for llms-full.txt removal

### DIFF
--- a/fern/products/docs/pages/changelog/2026-06-12.mdx
+++ b/fern/products/docs/pages/changelog/2026-06-12.mdx
@@ -1,0 +1,11 @@
+---
+tags: ["ai"]
+---
+
+## Removed `llms-full.txt`
+
+The `llms-full.txt` endpoint has been removed from Fern Docs sites. This file concatenated every page into a single document, but in practice it saw little use compared to `llms.txt` and individual `.md` page URLs. It also exceeded most model context windows and added significant serving overhead on every request.
+
+If you previously relied on `llms-full.txt`, use `llms.txt` to discover page URLs and fetch individual pages as needed.
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/ai-features/llms-txt">Read the docs</Button>


### PR DESCRIPTION
## Summary

Adds a 2026-06-12 changelog entry documenting the removal of `llms-full.txt` from Fern Docs sites. Reasons: exceeded most model context windows, added heavy serving overhead, and saw little use compared to `llms.txt` and per-page `.md` URLs.

Link to Devin session: https://app.devin.ai/sessions/a66966d41bb649b2ac27abf5ed91b562
Requested by: @dannysheridan