### PR TITLE
docs: document API catalog auth and RBAC visibility

### DIFF
--- a/fern/products/docs/pages/ai/api-catalog.mdx
+++ b/fern/products/docs/pages/ai/api-catalog.mdx
@@ -13,6 +13,14 @@ curl -s https://buildwithfern.com/learn/.well-known/api-catalog | jq .
 
 For sites with a basepath like `/docs`, the catalog lives under that basepath (e.g. `https://example.com/docs/.well-known/api-catalog`).
 
+## Visibility
+
+The catalog mirrors what the viewer can see:
+
+- Sites with [authentication](/learn/docs/authentication/overview) configured return an empty catalog (`{"linkset": []}`) to unauthenticated requests.
+- API references hidden from the viewer through [role-based access control](/learn/docs/authentication/features/rbac) are excluded.
+- References hidden via `hidden: true` (or with all endpoints hidden) are excluded.
+
 ## Response format
 
 The endpoint returns a [Linkset document](https://www.rfc-editor.org/rfc/rfc9264) listing each visible API. Each entry contains:

--- a/fern/products/docs/pages/changelog/2026-06-12.mdx
+++ b/fern/products/docs/pages/changelog/2026-06-12.mdx
@@ -1,5 +1,5 @@
 ---
-tags: ["ai"]
+tags: ["ai", "security"]
 ---
 
 ## Removed `llms-full.txt`
@@ -9,3 +9,9 @@ The `llms-full.txt` endpoint has been removed from Fern Docs sites. This file co
 If you previously relied on `llms-full.txt`, use `llms.txt` to discover page URLs and fetch individual pages as needed.
 
 <Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/ai-features/llms-txt">Read the docs</Button>
+
+## API catalog respects site authentication and RBAC
+
+The `/.well-known/api-catalog` endpoint now mirrors what the viewer can see. Sites with authentication configured return an empty catalog to unauthenticated requests, and API references hidden through role-based access control no longer appear in the catalog.
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/ai-features/api-catalog">Read the docs</Button>


### PR DESCRIPTION
## Summary
fern-api/fern-platform#12108 changed `/.well-known/api-catalog` to respect site authentication (empty catalog for unauthenticated requests on gated sites) and RBAC (role-hidden API references excluded). This adds a "Visibility" section to the API catalog page documenting all three exclusion rules (auth, RBAC, `hidden: true`) and a changelog entry for 2026-06-12.

Link to Devin session: https://app.devin.ai/sessions/57a08bb2c0044ab1be6ab853a8716d0d
Requested by: @kgowru