### PR TITLE
docs: remove llms-full.txt references across documentation

### DIFF
--- a/fern/products/docs/pages/ai/llms-txt/analytics-integration.mdx
+++ b/fern/products/docs/pages/ai/llms-txt/analytics-integration.mdx
@@ -3,7 +3,7 @@ title: Analytics and integration
 description: Track LLM traffic to your docs in the Fern Dashboard and surface llms.txt endpoints to readers with buttons and navbar links.
 ---
 
-`llms.txt` and `llms-full.txt` are generated automatically for your site, but how readers and AI tools discover them is up to you. Track usage in the Fern Dashboard and surface endpoints directly in your docs.
+`llms.txt` is generated automatically for your site, but discovery is up to you. Track usage in the Fern Dashboard and surface endpoints directly in your docs.
 
 ## Track LLM traffic
 
@@ -17,10 +17,10 @@ To make endpoints discoverable to human readers, add buttons or navigation links
 
 <AccordionGroup>
 <Accordion title="Add a button for SDK docs">
-Add a button to your SDK docs that links to the `llms-full.txt` for your API Reference. Use `lang` to filter code examples to one language, and `excludeSpec=true` to exclude the raw OpenAPI specification.
+Add a button to your SDK docs that links to `llms.txt` for your API Reference. Use `lang` to filter code examples to one language, and `excludeSpec=true` to exclude the raw OpenAPI specification.
 
 ```jsx Markdown
-<Button href="/api-reference/llms-full.txt?lang=python&excludeSpec=true" target="_blank">
+<Button href="/api-reference/llms.txt?lang=python&excludeSpec=true" target="_blank">
   Open Python API Reference for LLMs
 </Button>
 ```
@@ -28,8 +28,8 @@ Add a button to your SDK docs that links to the `llms-full.txt` for your API Ref
 This gives users a clean, language-specific output they can feed to AI tools when writing code.
 </Accordion>
 
-<Accordion title="Add a dropdown for llms-full.txt">
-Add a dropdown in your navbar that links to different filtered versions of `llms-full.txt`, making it easy for users to access LLM-optimized documentation for their preferred language.
+<Accordion title="Add a dropdown for llms.txt">
+Add a dropdown in your navbar that links to different filtered versions of `llms.txt`, making it easy for users to access LLM-optimized documentation for their preferred language.
 
 ```yaml docs.yml
 navbar-links:
@@ -38,13 +38,13 @@ navbar-links:
     icon: fa-solid fa-robot
     links:
       - text: Full docs
-        href: /llms-full.txt
+        href: /llms.txt
       - text: Python SDK
-        href: /api-reference/llms-full.txt?lang=python&excludeSpec=true
+        href: /api-reference/llms.txt?lang=python&excludeSpec=true
       - text: TypeScript SDK
-        href: /api-reference/llms-full.txt?lang=typescript&excludeSpec=true
+        href: /api-reference/llms.txt?lang=typescript&excludeSpec=true
       - text: Go SDK
-        href: /api-reference/llms-full.txt?lang=go&excludeSpec=true
+        href: /api-reference/llms.txt?lang=go&excludeSpec=true
 ```
 </Accordion>
 </AccordionGroup>

--- a/fern/products/docs/pages/ai/llms-txt/customize-llms-txt.mdx
+++ b/fern/products/docs/pages/ai/llms-txt/customize-llms-txt.mdx
@@ -11,7 +11,7 @@ Within pages, use `<llms-only>` and `<llms-ignore>` tags to control what content
 
 ### Content for AI only
 
-`<llms-only>` content appears only on the LLM-serving endpoints that external agents (like Claude, ChatGPT, or Cursor) fetch directly: `/llms.txt`, `/llms-full.txt`, and each page's [`.md`/`.mdx` source](/learn/docs/ai-features/markdown). It's hidden from every human-facing surface, including the rendered page, [Copy page](/learn/docs/configuration/site-level-settings#page-actions-configuration), the search widget, and [Ask Fern](/learn/docs/ai-features/ask-fern/overview).
+`<llms-only>` content appears only on the LLM-serving endpoints that external agents (like Claude, ChatGPT, or Cursor) fetch directly: `/llms.txt` and each page's [`.md`/`.mdx` source](/learn/docs/ai-features/markdown). It's hidden from every human-facing surface, including the rendered page, [Copy page](/learn/docs/configuration/site-level-settings#page-actions-configuration), the search widget, and [Ask Fern](/learn/docs/ai-features/ask-fern/overview).
 
 Use `<llms-only>` for:
 - Technical context that's verbose but helpful for AI, like implementation details or architecture notes
@@ -20,7 +20,7 @@ Use `<llms-only>` for:
 
 ### Content for humans only
 
-`<llms-ignore>` content appears on every human-facing surface, including the rendered page, [Copy page](/learn/docs/configuration/site-level-settings#page-actions-configuration), the search widget, and [Ask Fern](/learn/docs/ai-features/ask-fern/overview) (which indexes and can cite it like any other page content). It's stripped from the LLM-serving endpoints (`/llms.txt`, `/llms-full.txt`, and each page's `.md`/`.mdx` source).
+`<llms-ignore>` content appears on every human-facing surface, including the rendered page, [Copy page](/learn/docs/configuration/site-level-settings#page-actions-configuration), the search widget, and [Ask Fern](/learn/docs/ai-features/ask-fern/overview) (which indexes and can cite it like any other page content). It's stripped from the LLM-serving endpoints (`/llms.txt` and each page's `.md`/`.mdx` source).
 
 Use `<llms-ignore>` for:
 - Marketing CTAs or promotional content
@@ -83,12 +83,12 @@ To preview and debug what AI sees for any page, you can append `.md` or `.mdx` t
 
 ## Filter endpoint output
 
-Filter `llms.txt` and `llms-full.txt` output with the `lang` and `excludeSpec` query parameters to reduce token usage. Parameters can also be combined.
+Filter `llms.txt` output with the `lang` and `excludeSpec` query parameters to reduce token usage. Parameters can also be combined.
 
 ```txt Example
 /llms.txt?lang=python
-/llms-full.txt?excludeSpec=true
-/llms-full.txt?lang=python&excludeSpec=true
+/llms.txt?excludeSpec=true
+/llms.txt?lang=python&excludeSpec=true
 ```
 
 <ParamField path="lang" type="'node' | 'python' | 'java' | 'ruby' | 'go' | 'csharp' | 'swift'">
@@ -101,7 +101,7 @@ Filter `llms.txt` and `llms-full.txt` output with the `lang` and `excludeSpec` q
 
 ## Exclude whole pages
 
-You can exclude whole pages from LLM endpoints (`llms.txt` and `llms-full.txt`) by [adding `noindex: true`](/learn/docs/seo/setting-seo-metadata#noindex) to the page's frontmatter. Pages marked `noindex` aren't indexed by search engines but remain visible in your sidebar navigation and can still be accessed directly by URL. To also hide a page from navigation, see [Hiding content](/learn/docs/customization/hiding-content).
+You can exclude whole pages from LLM endpoints (`llms.txt`) by [adding `noindex: true`](/learn/docs/seo/setting-seo-metadata#noindex) to the page's frontmatter. Pages marked `noindex` aren't indexed by search engines but remain visible in your sidebar navigation and can still be accessed directly by URL. To also hide a page from navigation, see [Hiding content](/learn/docs/customization/hiding-content).
 
 ```mdx docs/pages/internal-notes.mdx
 ---
@@ -112,16 +112,13 @@ noindex: true
 
 ## Serve custom files
 
-To serve your own `llms.txt` or `llms-full.txt` instead of the auto-generated versions, point to your files under the [`agents` key in `docs.yml`](/learn/docs/configuration/site-level-settings#agents-configuration):
+To serve your own `llms.txt` instead of the auto-generated version, point to your file under the [`agents` key in `docs.yml`](/learn/docs/configuration/site-level-settings#agents-configuration):
 
 ```yaml docs.yml
 agents:
   llms-txt: ./path/to/llms.txt
-  llms-full-txt: ./path/to/llms-full.txt
 ```
 
-Paths are relative to the `docs.yml` file. The CLI validates that each file exists and uploads it as part of your docs deployment. Your custom files are served at the root-level `/llms.txt` and `/llms-full.txt` endpoints. Nested paths (e.g., `/api-reference/llms.txt`) continue to use the auto-generated output.
-
-You can provide one or both files. Any file you don't specify falls back to the auto-generated version.
+The path is relative to the `docs.yml` file. The CLI validates that the file exists and uploads it as part of your docs deployment. Your custom file is served at the root-level `/llms.txt` endpoint. Nested paths (e.g., `/api-reference/llms.txt`) continue to use the auto-generated output.
 
 To control *which* crawlers reach your site rather than *what* they receive, serve a [custom `robots.txt`](/learn/docs/seo/robots-txt) instead.

--- a/fern/products/docs/pages/ai/llms-txt/directives.mdx
+++ b/fern/products/docs/pages/ai/llms-txt/directives.mdx
@@ -6,10 +6,10 @@ description: Configure the default directive prepended to every page served to A
 Every page served to AI agents is automatically prepended with a default directive that tells agents how to navigate your documentation programmatically:
 
 ```text title="Default page directive" wordWrap
-For clean Markdown of any page, append .md to the page URL. For a complete documentation index, see https://docs.example.com/llms.txt. For full documentation content, see https://docs.example.com/llms-full.txt.
+For clean Markdown of any page, append .md to the page URL. For a complete documentation index, see https://docs.example.com/llms.txt.
 ```
 
-The URLs in the directive are generated from your site's domain and basepath. The directive is injected after the frontmatter metadata section but before the page body, so agents see it first even if they truncate the rest of the page. It applies to individual page Markdown (`.md`/`.mdx` URLs) and to each page section within `llms-full.txt`, and human-facing documentation is unaffected.
+The URLs in the directive are generated from your site's domain and basepath. The directive is injected after the frontmatter metadata section but before the page body, so agents see it first even if they truncate the rest of the page. It applies to individual page Markdown (`.md`/`.mdx` URLs), and human-facing documentation is unaffected.
 
 ## Customize agent directives
 

--- a/fern/products/docs/pages/ai/llms-txt/overview.mdx
+++ b/fern/products/docs/pages/ai/llms-txt/overview.mdx
@@ -1,11 +1,11 @@
 ---
-title: "`llms.txt` and `llms-full.txt`"
-description: Fern automatically generates llms.txt and llms-full.txt Markdown files so AI tools can discover and index your documentation.
+title: "`llms.txt`"
+description: Fern automatically generates an llms.txt Markdown file so AI tools can discover and index your documentation.
 ---
 
-[`llms.txt`](https://llmstxt.org/) is a standard for exposing website content to AI developer tools. Fern implements this standard, automatically generating and maintaining `llms.txt` and `llms-full.txt` Markdown files so AI tools can discover and index your documentation. For single pages, agents can also fetch [Markdown directly](/learn/docs/ai-features/markdown).
+[`llms.txt`](https://llmstxt.org/) is a standard for exposing website content to AI developer tools. Fern implements this standard, automatically generating and maintaining an `llms.txt` Markdown file so AI tools can discover and index your documentation. For single pages, agents can also fetch [Markdown directly](/learn/docs/ai-features/markdown).
 
-`llms.txt` and `llms-full.txt` are root-level files Fern serves to non-human consumers, alongside [`robots.txt`](/learn/docs/seo/robots-txt). `robots.txt` decides which crawlers reach your site and what AI training signals you broadcast; `llms.txt` and `llms-full.txt` shape what AI agents receive once they do.
+`llms.txt` is a root-level file Fern serves to non-human consumers, alongside [`robots.txt`](/learn/docs/seo/robots-txt). `robots.txt` decides which crawlers reach your site and what AI training signals you broadcast; `llms.txt` shapes what AI agents receive once they do.
 
 <Frame>
   <img
@@ -15,21 +15,17 @@ description: Fern automatically generates llms.txt and llms-full.txt Markdown fi
   />
 </Frame>
 
-## Generated files
+## What `llms.txt` contains
 
-Fern generates two files for LLMs:
+`llms.txt` contains a lightweight summary of your documentation site with each page distilled into a one-sentence description and URL. For sites with API endpoints, it also links to your [OpenAPI specification](/learn/docs/developer-tools/openapi-spec) as a standalone, machine-readable file so AI tools can parse your full API schema directly. For sites with WebSocket channels, it also links to your [AsyncAPI specification](/learn/docs/developer-tools/asyncapi-spec).
 
-- **`llms.txt`** contains a lightweight summary of your documentation site with each page distilled into a one-sentence description and URL. For sites with API endpoints, it also links to your [OpenAPI specification](/learn/docs/developer-tools/openapi-spec) as a standalone, machine-readable file so AI tools can parse your full API schema directly. For sites with WebSocket channels, it also links to your [AsyncAPI specification](/learn/docs/developer-tools/asyncapi-spec).
+`llms.txt` is available at any level of your documentation hierarchy (`/llms.txt`, `/docs/llms.txt`, `/docs/ai-features/llms.txt`, etc.).
 
-- **`llms-full.txt`** contains complete documentation content including the full text of all pages. For API documentation, this includes your complete API Reference with resolved OpenAPI specifications and SDK code examples for enabled languages.
-
-Both files are available at any level of your documentation hierarchy (`/llms.txt`, `/llms-full.txt`, `/docs/llms.txt`, `/docs/ai-features/llms-full.txt`, etc.).
-
-Examples: [Eleven Labs llms.txt](https://elevenlabs.io/docs/llms.txt), [Cash App llms-full.txt](https://developers.cash.app/llms-full.txt).
+Example: [Eleven Labs llms.txt](https://elevenlabs.io/docs/llms.txt).
 
 ## Page descriptions
 
-Both files include page descriptions pulled from [frontmatter](/learn/docs/configuration/page-level-settings). Fern uses the `description` field if present, otherwise falls back to `subtitle`.
+`llms.txt` includes page descriptions pulled from [frontmatter](/learn/docs/configuration/page-level-settings). Fern uses the `description` field if present, otherwise falls back to `subtitle`.
 
 ```mdx title="Frontmatter"
 ---
@@ -42,9 +38,7 @@ The output format depends on whether you're requesting an individual page or a s
 <Tabs>
 <Tab title="Individual pages">
 
-Both `llms.txt` and `llms-full.txt` return the same format:
-
-```txt title=".../page/llms.txt and .../page/llms-full.txt"
+```txt title=".../page/llms.txt"
 # Fern Docs
 
 > Build beautiful documentation websites with Fern.
@@ -52,19 +46,9 @@ Both `llms.txt` and `llms-full.txt` return the same format:
 </Tab>
 <Tab title="Section">
 
-The two files differ:
-
-<CodeBlocks>
 ```txt title=".../section/llms.txt"
 - [Fern Docs](https://example.com/docs): Build beautiful documentation websites with Fern.
 ```
-
-```txt title=".../section/llms-full.txt"
-# Fern Docs
-
-> Build beautiful documentation websites with Fern.
-```
-</CodeBlocks>
 </Tab>
 </Tabs>
 

--- a/fern/products/docs/pages/ai/llms-txt/overview.mdx
+++ b/fern/products/docs/pages/ai/llms-txt/overview.mdx
@@ -23,6 +23,10 @@ description: Fern automatically generates an llms.txt Markdown file so AI tools 
 
 Example: [Eleven Labs llms.txt](https://elevenlabs.io/docs/llms.txt).
 
+<Note>
+Fern doesn't generate `llms-full.txt`. Full-site concatenation exceeded most model context windows, added heavy serving overhead, and saw little use compared to `llms.txt` combined with per-page [Markdown access](/learn/docs/ai-features/markdown). Use `llms.txt` to discover pages and fetch them individually.
+</Note>
+
 ## Page descriptions
 
 `llms.txt` includes page descriptions pulled from [frontmatter](/learn/docs/configuration/page-level-settings). Fern uses the `description` field if present, otherwise falls back to `subtitle`.

--- a/fern/products/docs/pages/ai/markdown.mdx
+++ b/fern/products/docs/pages/ai/markdown.mdx
@@ -1,6 +1,6 @@
 ---
 title: Markdown access
-description: Access your documentation as Markdown — through per-page URLs, `llms.txt`, and `llms-full.txt` — for AI agents and tooling.
+description: Access your documentation as Markdown — through per-page URLs and `llms.txt` — for AI agents and tooling.
 ---
 
 
@@ -13,9 +13,9 @@ Fern serves clean Markdown for any documentation page — including API Referenc
   />
 </Frame>
 
-The same Markdown is used everywhere — single pages, `llms.txt`, and `llms-full.txt` — and respects the same `<llms-only>` and `<llms-ignore>` content controls.
+The same Markdown is used everywhere — single pages and `llms.txt` — and respects the same `<llms-only>` and `<llms-ignore>` content controls.
 
-A [default per-page directive](/learn/docs/ai-features/agent-directives) is automatically prepended to every page's Markdown output when served to AI agents, pointing them to your `.md` URLs, `llms.txt`, and `llms-full.txt`. You can [override or disable this directive](/learn/docs/configuration/site-level-settings#agents-configuration) in `docs.yml`. The directive is only visible to agents — human-facing documentation is unaffected.
+A [default per-page directive](/learn/docs/ai-features/agent-directives) is automatically prepended to every page's Markdown output when served to AI agents, pointing them to your `.md` URLs and `llms.txt`. You can [override or disable this directive](/learn/docs/configuration/site-level-settings#agents-configuration) in `docs.yml`. The directive is only visible to agents — human-facing documentation is unaffected.
 
 ## Interactive components in Markdown output
 
@@ -23,7 +23,7 @@ Interactive components such as [`<EndpointRequestSnippet>`](/learn/docs/writing-
 
 ## Accessing protected docs
 
-On sites with [authentication](/learn/docs/authentication/overview) enabled, agents must include a JWT on every Markdown request — whether for an individual page, `llms.txt`, or `llms-full.txt`. Exchange your [Fern API key](/learn/cli-api/cli-reference/commands#fern-token) for a [JWT](/learn/docs/fern-api-reference/get-jwt):
+On sites with [authentication](/learn/docs/authentication/overview) enabled, agents must include a JWT on every Markdown request — whether for an individual page or `llms.txt`. Exchange your [Fern API key](/learn/cli-api/cli-reference/commands#fern-token) for a [JWT](/learn/docs/fern-api-reference/get-jwt):
 
 ```bash Get a JWT
 curl https://docs.example.com/api/fern-docs/get-jwt \

--- a/fern/products/docs/pages/ai/mcp-server.mdx
+++ b/fern/products/docs/pages/ai/mcp-server.mdx
@@ -30,5 +30,5 @@ Both buttons are enabled by default on sites with Ask Fern. For other clients (C
 
 ## Other ways agents can access your docs
 
-In addition to MCP, agents can fetch documentation directly over HTTP. Fern serves clean Markdown via [per-page URLs, `llms.txt`, and `llms-full.txt`](/learn/docs/ai-features/markdown) — including on authenticated sites.
+In addition to MCP, agents can fetch documentation directly over HTTP. Fern serves clean Markdown via [per-page URLs and `llms.txt`](/learn/docs/ai-features/markdown) — including on authenticated sites.
 

--- a/fern/products/docs/pages/ai/mcp-server.mdx
+++ b/fern/products/docs/pages/ai/mcp-server.mdx
@@ -30,5 +30,5 @@ Both buttons are enabled by default on sites with Ask Fern. For other clients (C
 
 ## Other ways agents can access your docs
 
-In addition to MCP, agents can fetch documentation directly over HTTP. Fern serves clean Markdown via [per-page URLs and `llms.txt`](/learn/docs/ai-features/markdown) — including on authenticated sites.
+Agents can also fetch documentation directly over HTTP. Fern serves clean Markdown via [per-page URLs and `llms.txt`](/learn/docs/ai-features/markdown) — including on authenticated sites.
 

--- a/fern/products/docs/pages/ai/overview.mdx
+++ b/fern/products/docs/pages/ai/overview.mdx
@@ -40,7 +40,7 @@ AI helps keep your documentation current. Fern Writer is a Slack-based technical
 
 ## Optimize for AI
 
-Your site is automatically optimized for AI tools and search engines. Fern hosts `llms.txt` and `llms-full.txt` files so LLMs can index your documentation efficiently, serves Markdown instead of HTML to AI agents, and exposes a standards-based API catalog for automated discovery. These features reduce token consumption and help agents process your content faster.
+Your site is automatically optimized for AI tools and search engines. Fern hosts an `llms.txt` file so LLMs can index your documentation efficiently, serves Markdown instead of HTML to AI agents, and exposes a standards-based API catalog for automated discovery. These features reduce token consumption and help agents process your content faster.
 
 <CardGroup cols={2}>
   <Card title="Markdown access" icon="file-code" href="/learn/docs/ai-features/markdown" />

--- a/fern/products/docs/pages/getting-started/self-service-setup.mdx
+++ b/fern/products/docs/pages/getting-started/self-service-setup.mdx
@@ -12,7 +12,7 @@ Prefer to set things up manually using the CLI? See the [Quickstart](/learn/docs
 
 ## What gets created
 
-When you complete the self-service workflow, Fern publishes your documentation to a brand-new site and creates a GitHub repository containing your site configuration (`docs.yml`), Markdown pages, and any API specifications. Your repo includes a `CLAUDE.md` file pre-populated with Fern documentation in [llms-full.txt format](/learn/docs/ai/llms-txt), giving AI coding assistants context for working with Fern.
+When you complete the self-service workflow, Fern publishes your documentation to a brand-new site and creates a GitHub repository containing your site configuration (`docs.yml`), Markdown pages, and any API specifications. Your repo includes a `CLAUDE.md` file pre-populated with Fern documentation in [`llms.txt` format](/learn/docs/ai-features/llms-txt), giving AI coding assistants context for working with Fern.
 
 The setup process also creates and configures:
 

--- a/fern/products/docs/pages/navigation/frontmatter.mdx
+++ b/fern/products/docs/pages/navigation/frontmatter.mdx
@@ -99,7 +99,7 @@ navigation:
 ## Subtitle
 
 <ParamField path="subtitle" type="string" required={false}>
-  Renders as a subtitle on the page. If `description` is not set, `subtitle` is also used as the meta description tag and in [`llms.txt` and `llms-full.txt`](/learn/docs/ai-features/llms-txt#page-descriptions).
+  Renders as a subtitle on the page. If `description` is not set, `subtitle` is also used as the meta description tag and in [`llms.txt`](/learn/docs/ai-features/llms-txt#page-descriptions).
 </ParamField>
 
 For example, scroll to the top of this page you're visiting now and you'll see the subtitle "Set titles, add meta descriptions, and more".
@@ -165,7 +165,7 @@ The key difference is:
 ## Meta description
 
 <ParamField path="description" type="string" required={false}>
-  Set the [meta description](https://web.dev/learn/html/metadata#description) for a page. Like the page title, the meta description is important for SEO. It impacts the text that search engines display about your page in search results snippets. It can also influence search engine indexing and ranking. For more information, see [Google's guidelines for meta descriptions](https://developers.google.com/search/docs/appearance/snippet#meta-descriptions). The description is also used in [`llms.txt` and `llms-full.txt`](/learn/docs/ai-features/llms-txt#page-descriptions).
+  Set the [meta description](https://web.dev/learn/html/metadata#description) for a page. Like the page title, the meta description is important for SEO. It impacts the text that search engines display about your page in search results snippets. It can also influence search engine indexing and ranking. For more information, see [Google's guidelines for meta descriptions](https://developers.google.com/search/docs/appearance/snippet#meta-descriptions). The description is also used in [`llms.txt`](/learn/docs/ai-features/llms-txt#page-descriptions).
 </ParamField>
 
 <CodeBlock title="Example meta description">

--- a/fern/products/docs/pages/navigation/site-level-settings.mdx
+++ b/fern/products/docs/pages/navigation/site-level-settings.mdx
@@ -1216,19 +1216,18 @@ ai-search:
 
 ## Agents configuration
 
-Configure directives and custom files for [AI agent consumption](/learn/docs/ai-features/llms-txt). By default, Fern auto-generates `llms.txt` and `llms-full.txt` and prepends a directive to every page served to AI agents. Use the `agents` key to customize this behavior:
+Configure directives and custom files for [AI agent consumption](/learn/docs/ai-features/llms-txt). By default, Fern auto-generates `llms.txt` and prepends a directive to every page served to AI agents. Use the `agents` key to customize this behavior:
 
 ```yaml docs.yml
 agents:
   page-directive: "For a complete page index, fetch https://docs.example.com/llms.txt"
   page-description-source: description
   llms-txt: ./path/to/llms.txt
-  llms-full-txt: ./path/to/llms-full.txt
   robots-txt: ./path/to/robots.txt
 ```
 
 <ParamField path="agents.page-directive" type="string" required={false} toc={true}>
-  Text prepended to each page's Markdown output when served to AI agents. The directive is injected after the frontmatter metadata section but before the page body. Human-facing documentation is unaffected. When not set, a default directive is used that points agents to your site's `.md` URLs, `llms.txt`, and `llms-full.txt`. Set to an empty string to disable the directive entirely.
+  Text prepended to each page's Markdown output when served to AI agents. The directive is injected after the frontmatter metadata section but before the page body. Human-facing documentation is unaffected. When not set, a default directive is used that points agents to your site's `.md` URLs and `llms.txt`. Set to an empty string to disable the directive entirely.
 </ParamField>
 
 <ParamField path="agents.page-description-source" type="'description' | 'subtitle'" required={false} default="description" toc={true}>
@@ -1237,10 +1236,6 @@ agents:
 
 <ParamField path="agents.llms-txt" type="string" required={false} toc={true}>
   Path to a custom `llms.txt` file, relative to `docs.yml`. When set, this file is served at the root-level `/llms.txt` endpoint instead of the auto-generated version. Nested paths continue to use the auto-generated output.
-</ParamField>
-
-<ParamField path="agents.llms-full-txt" type="string" required={false} toc={true}>
-  Path to a custom `llms-full.txt` file, relative to `docs.yml`. When set, this file is served at the root-level `/llms-full.txt` endpoint instead of the auto-generated version. Nested paths continue to use the auto-generated output.
 </ParamField>
 
 <ParamField path="agents.robots-txt" type="string" required={false} toc={true}>

--- a/fern/products/docs/pages/resources/stainless-comparison.mdx
+++ b/fern/products/docs/pages/resources/stainless-comparison.mdx
@@ -78,7 +78,7 @@ Stainless offers RAG-based search. Fern provides additional AI features includin
 | **AI chatbot** | ✅ [Ask Fern](/learn/docs/ai-features/ask-fern/overview) with Claude, [guidance documents](/learn/docs/ai-features/ask-fern/guidance), and custom knowledge sources | ✅ RAG-based Q&A |
 | **AI analytics** | ✅ [Content gap identification](/learn/docs/ai-features/ask-fern/overview) and insights | ❌ None |
 | **Search** | ✅ Vector search with faceting by language, product, version | ⚠️ Metadata-driven with basic faceting |
-| **LLM-friendly format** | ✅ [/llms.txt and /llms-full.txt](/learn/docs/ai-features/llms-txt) | ✅ .md extension on URLs |
+| **LLM-friendly format** | ✅ [/llms.txt](/learn/docs/ai-features/llms-txt) | ✅ .md extension on URLs |
 <br/>
 </Accordion>
 

--- a/fern/products/docs/pages/seo/robots-txt.mdx
+++ b/fern/products/docs/pages/seo/robots-txt.mdx
@@ -8,7 +8,7 @@ By default, Fern serves an auto-generated `robots.txt` at the root of your docum
 `robots.txt` is advisory: compliant crawlers honor your `Disallow` and `Allow` directives, but bots that ignore the protocol still reach those paths. For content that must stay private, [use authentication](/learn/docs/authentication/overview).
 
 <Note>
-  `robots.txt` decides which crawlers can reach your site and what AI training signals you broadcast. Its companions, [`llms.txt` and `llms-full.txt`](/learn/docs/ai-features/llms-txt), shape what AI agents receive once they crawl.
+  `robots.txt` decides which crawlers can reach your site and what AI training signals you broadcast. Its companion, [`llms.txt`](/learn/docs/ai-features/llms-txt), shapes what AI agents receive once they crawl.
 </Note>
 
 ## Configuration

--- a/fern/translations/zh/products/docs/pages/ai/llms-txt/analytics-integration.mdx
+++ b/fern/translations/zh/products/docs/pages/ai/llms-txt/analytics-integration.mdx
@@ -4,7 +4,7 @@ description: 在 Fern Dashboard 中跟踪对您文档的 LLM 流量，并通过�
 sidebar-title: 分析和集成
 ---
 
-`llms.txt` 和 `llms-full.txt` 会自动为您的站点生成，但读者和 AI 工具如何发现它们取决于您。在 Fern Dashboard 中跟踪使用情况，并在您的文档中直接展示端点。
+`llms.txt` 会自动为您的站点生成，但发现方式取决于您。在 Fern Dashboard 中跟踪使用情况，并在您的文档中直接展示端点。
 
 ## 跟踪 LLM 流量
 
@@ -18,10 +18,10 @@ sidebar-title: 分析和集成
 
 <AccordionGroup>
 <Accordion title="为 SDK 文档添加按钮">
-为您的 SDK 文档添加一个按钮，链接到您 API Reference 的 `llms-full.txt`。使用 `lang` 将代码示例过滤为一种语言，使用 `excludeSpec=true` 排除原始 OpenAPI 规范。
+为您的 SDK 文档添加一个按钮，链接到您 API Reference 的 `llms.txt`。使用 `lang` 将代码示例过滤为一种语言，使用 `excludeSpec=true` 排除原始 OpenAPI 规范。
 
 ```jsx Markdown
-<Button href="/api-reference/llms-full.txt?lang=python&excludeSpec=true" target="_blank">
+<Button href="/api-reference/llms.txt?lang=python&excludeSpec=true" target="_blank">
   为 LLM 打开 Python API Reference
 </Button>
 ```
@@ -29,8 +29,8 @@ sidebar-title: 分析和集成
 这为用户提供了一个干净的、特定语言的输出，他们可以在编写代码时将其提供给 AI 工具。
 </Accordion>
 
-<Accordion title="为 llms-full.txt 添加下拉菜单">
-在导航栏中添加一个下拉菜单，链接到 `llms-full.txt` 的不同过滤版本，让用户轻松访问其偏好语言的 LLM 优化文档。
+<Accordion title="为 llms.txt 添加下拉菜单">
+在导航栏中添加一个下拉菜单，链接到 `llms.txt` 的不同过滤版本，让用户轻松访问其偏好语言的 LLM 优化文档。
 
 ```yaml docs.yml
 navbar-links:
@@ -39,13 +39,13 @@ navbar-links:
     icon: fa-solid fa-robot
     links:
       - text: 完整文档
-        href: /llms-full.txt
+        href: /llms.txt
       - text: Python SDK
-        href: /api-reference/llms-full.txt?lang=python&excludeSpec=true
+        href: /api-reference/llms.txt?lang=python&excludeSpec=true
       - text: TypeScript SDK
-        href: /api-reference/llms-full.txt?lang=typescript&excludeSpec=true
+        href: /api-reference/llms.txt?lang=typescript&excludeSpec=true
       - text: Go SDK
-        href: /api-reference/llms-full.txt?lang=go&excludeSpec=true
+        href: /api-reference/llms.txt?lang=go&excludeSpec=true
 ```
 </Accordion>
 </AccordionGroup>

--- a/fern/translations/zh/products/docs/pages/ai/llms-txt/customize-llms-txt.mdx
+++ b/fern/translations/zh/products/docs/pages/ai/llms-txt/customize-llms-txt.mdx
@@ -11,7 +11,7 @@ description: 使用 noindex 排除页面、使用 llms-only 和 llms-ignore 标�
 
 ### 仅供 AI 使用的内容
 
-`<llms-only>` 内容仅出现在外部代理（如 Claude、ChatGPT 或 Cursor）直接获取的 LLM 服务端点上：`/llms.txt`、`/llms-full.txt`，以及每个页面的 [`.md`/`.mdx` 源文件](/learn/docs/ai-features/markdown)。它在所有面向人类的界面中都是隐藏的，包括渲染页面、[复制页面](/learn/docs/configuration/site-level-settings#page-actions-configuration)、搜索小部件和 [Ask Fern](/learn/docs/ai-features/ask-fern/overview)。
+`<llms-only>` 内容仅出现在外部代理（如 Claude、ChatGPT 或 Cursor）直接获取的 LLM 服务端点上：`/llms.txt` 以及每个页面的 [`.md`/`.mdx` 源文件](/learn/docs/ai-features/markdown)。它在所有面向人类的界面中都是隐藏的，包括渲染页面、[复制页面](/learn/docs/configuration/site-level-settings#page-actions-configuration)、搜索小部件和 [Ask Fern](/learn/docs/ai-features/ask-fern/overview)。
 
 使用 `<llms-only>` 适用于：
 - 对 AI 有用但冗长的技术上下文，如实现细节或架构说明
@@ -20,7 +20,7 @@ description: 使用 noindex 排除页面、使用 llms-only 和 llms-ignore 标�
 
 ### 仅供人类使用的内容
 
-`<llms-ignore>` 内容出现在所有面向人类的界面上，包括渲染页面、[复制页面](/learn/docs/configuration/site-level-settings#page-actions-configuration)、搜索小部件和 [Ask Fern](/learn/docs/ai-features/ask-fern/overview)（它会索引并可以像任何其他页面内容一样引用它）。它会从 LLM 服务端点（`/llms.txt`、`/llms-full.txt` 和每个页面的 `.md`/`.mdx` 源文件）中被去除。
+`<llms-ignore>` 内容出现在所有面向人类的界面上，包括渲染页面、[复制页面](/learn/docs/configuration/site-level-settings#page-actions-configuration)、搜索小部件和 [Ask Fern](/learn/docs/ai-features/ask-fern/overview)（它会索引并可以像任何其他页面内容一样引用它）。它会从 LLM 服务端点（`/llms.txt` 和每个页面的 `.md`/`.mdx` 源文件）中被去除。
 
 使用 `<llms-ignore>` 适用于：
 - 营销 CTA 或促销内容
@@ -83,12 +83,12 @@ Replace `my-org/fern-docs` with your desired owner and repository name. Use `--p
 
 ## 过滤端点输出
 
-使用 `lang` 和 `excludeSpec` 查询参数过滤 `llms.txt` 和 `llms-full.txt` 输出，以减少令牌使用量。参数也可以组合使用。
+使用 `lang` 和 `excludeSpec` 查询参数过滤 `llms.txt` 输出，以减少令牌使用量。参数也可以组合使用。
 
 ```txt 示例
 /llms.txt?lang=python
-/llms-full.txt?excludeSpec=true
-/llms-full.txt?lang=python&excludeSpec=true
+/llms.txt?excludeSpec=true
+/llms.txt?lang=python&excludeSpec=true
 ```
 
 <ParamField path="lang" type="'node' | 'python' | 'java' | 'ruby' | 'go' | 'csharp' | 'swift'">
@@ -101,7 +101,7 @@ Replace `my-org/fern-docs` with your desired owner and repository name. Use `--p
 
 ## 排除整个页面
 
-您可以通过[在页面的 frontmatter 中添加 `noindex: true`](/learn/docs/seo/setting-seo-metadata#noindex) 来从 LLM 端点（`llms.txt` 和 `llms-full.txt`）排除整个页面。标记为 `noindex` 的页面不会被搜索引擎索引，但在您的侧边栏导航中仍然可见，并且仍可以通过 URL 直接访问。要同时从导航中隐藏页面，请参阅[隐藏内容](/learn/docs/customization/hiding-content)。
+您可以通过[在页面的 frontmatter 中添加 `noindex: true`](/learn/docs/seo/setting-seo-metadata#noindex) 来从 LLM 端点（`llms.txt`）排除整个页面。标记为 `noindex` 的页面不会被搜索引擎索引，但在您的侧边栏导航中仍然可见，并且仍可以通过 URL 直接访问。要同时从导航中隐藏页面，请参阅[隐藏内容](/learn/docs/customization/hiding-content)。
 
 ```mdx docs/pages/internal-notes.mdx
 ---
@@ -112,16 +112,13 @@ noindex: true
 
 ## 提供自定义文件
 
-要提供您自己的 `llms.txt` 或 `llms-full.txt` 而不是自动生成的版本，请在 [`docs.yml` 中的 `agents` 键下](/learn/docs/configuration/site-level-settings#agents-configuration)指向您的文件：
+要提供您自己的 `llms.txt` 而不是自动生成的版本，请在 [`docs.yml` 中的 `agents` 键下](/learn/docs/configuration/site-level-settings#agents-configuration)指向您的文件：
 
 ```yaml docs.yml
 agents:
   llms-txt: ./path/to/llms.txt
-  llms-full-txt: ./path/to/llms-full.txt
 ```
 
-路径相对于 `docs.yml` 文件。CLI 验证每个文件是否存在并将其作为您的文档部署的一部分上传。您的自定义文件在根级别的 `/llms.txt` 和 `/llms-full.txt` 端点提供。嵌套路径（例如 `/api-reference/llms.txt`）继续使用自动生成的输出。
-
-您可以提供其中一个或两个文件。您未指定的任何文件都回退到自动生成的版本。
+路径相对于 `docs.yml` 文件。CLI 验证文件是否存在并将其作为您的文档部署的一部分上传。您的自定义文件在根级别的 `/llms.txt` 端点提供。嵌套路径（例如 `/api-reference/llms.txt`）继续使用自动生成的输出。
 
 要控制*哪些*爬虫访问您的站点而不是*它们接收什么*，请改为提供[自定义 `robots.txt`](/learn/docs/seo/robots-txt)。

--- a/fern/translations/zh/products/docs/pages/ai/llms-txt/directives.mdx
+++ b/fern/translations/zh/products/docs/pages/ai/llms-txt/directives.mdx
@@ -7,10 +7,10 @@ sidebar-title: 智能体指令
 提供给 AI agents 的每个页面都会自动预置一个默认指令，告诉 agents 如何以编程方式导航您的文档：
 
 ```text title="默认页面指令" wordWrap
-For clean Markdown of any page, append .md to the page URL. For a complete documentation index, see https://docs.example.com/llms.txt. For full documentation content, see https://docs.example.com/llms-full.txt.
+For clean Markdown of any page, append .md to the page URL. For a complete documentation index, see https://docs.example.com/llms.txt.
 ```
 
-指令中的 URL 是根据您网站的域名和基础路径生成的。指令在前言元数据部分之后但页面正文之前注入，因此即使 agents 截断页面的其余部分，它们也会首先看到指令。它适用于单个页面 Markdown（`.md`/`.mdx` URLs）和 `llms-full.txt` 中的每个页面部分，面向人类的文档不受影响。
+指令中的 URL 是根据您网站的域名和基础路径生成的。指令在前言元数据部分之后但页面正文之前注入，因此即使 agents 截断页面的其余部分，它们也会首先看到指令。它适用于单个页面 Markdown（`.md`/`.mdx` URLs），面向人类的文档不受影响。
 
 ## 自定义 agent 指令
 

--- a/fern/translations/zh/products/docs/pages/ai/llms-txt/overview.mdx
+++ b/fern/translations/zh/products/docs/pages/ai/llms-txt/overview.mdx
@@ -1,11 +1,11 @@
 ---
-title: "`llms.txt` 和 `llms-full.txt`"
-description: Fern 自动生成 llms.txt 和 llms-full.txt Markdown 文件，以便 AI 工具可以发现和索引您的文档。
+title: "`llms.txt`"
+description: Fern 自动生成 llms.txt Markdown 文件，以便 AI 工具可以发现和索引您的文档。
 ---
 
-[`llms.txt`](https://llmstxt.org/) 是一个向 AI 开发者工具公开网站内容的标准。Fern 实现了这个标准，自动生成和维护 `llms.txt` 和 `llms-full.txt` Markdown 文件，以便 AI 工具可以发现和索引您的文档。对于单个页面，代理还可以[直接获取 Markdown](/learn/docs/ai-features/markdown)。
+[`llms.txt`](https://llmstxt.org/) 是一个向 AI 开发者工具公开网站内容的标准。Fern 实现了这个标准，自动生成和维护 `llms.txt` Markdown 文件，以便 AI 工具可以发现和索引您的文档。对于单个页面，代理还可以[直接获取 Markdown](/learn/docs/ai-features/markdown)。
 
-`llms.txt` 和 `llms-full.txt` 是 Fern 为非人类消费者提供的根级文件，与 [`robots.txt`](/learn/docs/seo/robots-txt) 一起提供。`robots.txt` 决定哪些爬虫可以访问您的网站以及您广播什么 AI 训练信号；`llms.txt` 和 `llms-full.txt` 塑造 AI 代理一旦访问后会收到什么内容。
+`llms.txt` 是 Fern 为非人类消费者提供的根级文件，与 [`robots.txt`](/learn/docs/seo/robots-txt) 一起提供。`robots.txt` 决定哪些爬虫可以访问您的网站以及您广播什么 AI 训练信号；`llms.txt` 塑造 AI 代理一旦访问后会收到什么内容。
 
 <Frame>
   <img
@@ -15,21 +15,21 @@ description: Fern 自动生成 llms.txt 和 llms-full.txt Markdown 文件，以�
   />
 </Frame>
 
-## 生成的文件
+## `llms.txt` 的内容
 
-Fern 为 LLM 生成两个文件：
+`llms.txt` 包含您的文档站点的轻量级摘要，每个页面都被提炼成一句话描述和 URL。对于包含 API 端点的站点，它还链接到您的 [OpenAPI 规范](/learn/docs/developer-tools/openapi-spec)作为独立的、机器可读的文件，以便 AI 工具可以直接解析您的完整 API 模式。对于包含 WebSocket 通道的站点，它还链接到您的 [AsyncAPI 规范](/learn/docs/developer-tools/asyncapi-spec)。
 
-- **`llms.txt`** 包含您的文档站点的轻量级摘要，每个页面都被提炼成一句话描述和 URL。对于包含 API 端点的站点，它还链接到您的 [OpenAPI 规范](/learn/docs/developer-tools/openapi-spec)作为独立的、机器可读的文件，以便 AI 工具可以直接解析您的完整 API 模式。对于包含 WebSocket 通道的站点，它还链接到您的 [AsyncAPI 规范](/learn/docs/developer-tools/asyncapi-spec)。
+`llms.txt` 在您的文档层次结构的任何级别都可用（`/llms.txt`、`/docs/llms.txt`、`/docs/ai-features/llms.txt` 等）。
 
-- **`llms-full.txt`** 包含完整的文档内容，包括所有页面的全文。对于 API 文档，这包括您的完整 API 参考，其中包含已解析的 OpenAPI 规范和启用语言的 SDK 代码示例。
+示例：[Eleven Labs llms.txt](https://elevenlabs.io/docs/llms.txt)。
 
-这两个文件在您的文档层次结构的任何级别都可用（`/llms.txt`、`/llms-full.txt`、`/docs/llms.txt`、`/docs/ai-features/llms-full.txt` 等）。
-
-示例：[Eleven Labs llms.txt](https://elevenlabs.io/docs/llms.txt)，[Cash App llms-full.txt](https://developers.cash.app/llms-full.txt)。
+<Note>
+Fern 不生成 `llms-full.txt`。全站拼接超出了大多数模型的上下文窗口，增加了大量服务开销，且与 `llms.txt` 结合逐页 [Markdown 访问](/learn/docs/ai-features/markdown) 相比使用率很低。使用 `llms.txt` 发现页面并单独获取。
+</Note>
 
 ## 页面描述
 
-两个文件都包含从[前置内容](/learn/docs/configuration/page-level-settings)中提取的页面描述。Fern 使用 `description` 字段（如果存在），否则回退到 `subtitle`。
+`llms.txt` 包含从[前置内容](/learn/docs/configuration/page-level-settings)中提取的页面描述。Fern 使用 `description` 字段（如果存在），否则回退到 `subtitle`。
 
 ```mdx title="前置内容"
 ---
@@ -42,9 +42,7 @@ subtitle: 使用 Fern 构建精美的文档网站。
 <Tabs>
 <Tab title="单个页面">
 
-`llms.txt` 和 `llms-full.txt` 返回相同的格式：
-
-```txt title=".../page/llms.txt 和 .../page/llms-full.txt"
+```txt title=".../page/llms.txt"
 # Fern Docs
 
 > 使用 Fern 构建精美的文档网站。
@@ -52,19 +50,9 @@ subtitle: 使用 Fern 构建精美的文档网站。
 </Tab>
 <Tab title="部分">
 
-这两个文件有所不同：
-
-<CodeBlocks>
 ```txt title=".../section/llms.txt"
 - [Fern Docs](https://example.com/docs): 使用 Fern 构建精美的文档网站。
 ```
-
-```txt title=".../section/llms-full.txt"
-# Fern Docs
-
-> 使用 Fern 构建精美的文档网站。
-```
-</CodeBlocks>
 </Tab>
 </Tabs>
 

--- a/fern/translations/zh/products/docs/pages/ai/markdown.mdx
+++ b/fern/translations/zh/products/docs/pages/ai/markdown.mdx
@@ -1,7 +1,7 @@
 ---
 title: Markdown 访问
 sidebar-title: Markdown 访问
-description: 通过单页 URL、`llms.txt` 和 `llms-full.txt` 以 Markdown 形式访问您的文档，便于 AI 代理和工具使用。
+description: 通过单页 URL 和 `llms.txt` 以 Markdown 形式访问您的文档，便于 AI 代理和工具使用。
 ---
 
 
@@ -14,13 +14,13 @@ Fern 会以干净的 Markdown 形式提供任意文档页面（包括 API 参考
   />
 </Frame>
 
-同一份 Markdown 在所有场景中通用——单页、`llms.txt` 和 `llms-full.txt`——并遵循相同的 `<llms-only>` 与 `<llms-ignore>` 内容控制规则。
+同一份 Markdown 在所有场景中通用——单页和 `llms.txt`——并遵循相同的 `<llms-only>` 与 `<llms-ignore>` 内容控制规则。
 
-每个页面在向 AI 代理输出 Markdown 时，都会自动附加一个 [默认的逐页指令](/learn/docs/ai-features/agent-directives)，引导它们访问您的 `.md` URL、`llms.txt` 和 `llms-full.txt`。您可以在 `docs.yml` 中 [覆盖或停用该指令](/learn/docs/configuration/site-level-settings#agents-configuration)。该指令仅对代理可见，不会影响面向用户的文档展示。
+每个页面在向 AI 代理输出 Markdown 时，都会自动附加一个 [默认的逐页指令](/learn/docs/ai-features/agent-directives)，引导它们访问您的 `.md` URL 和 `llms.txt`。您可以在 `docs.yml` 中 [覆盖或停用该指令](/learn/docs/configuration/site-level-settings#agents-configuration)。该指令仅对代理可见，不会影响面向用户的文档展示。
 
 ## 访问受保护的文档
 
-在启用了 [身份验证](/learn/docs/authentication/overview) 的站点上，无论代理请求的是单个页面、`llms.txt` 还是 `llms-full.txt`，每次请求都必须携带 JWT。请使用您的 [Fern token](/learn/cli-api/cli-reference/commands#fern-token) 换取一个 [JWT](/learn/docs/fern-api-reference/get-jwt)：
+在启用了 [身份验证](/learn/docs/authentication/overview) 的站点上，无论代理请求的是单个页面还是 `llms.txt`，每次请求都必须携带 JWT。请使用您的 [Fern token](/learn/cli-api/cli-reference/commands#fern-token) 换取一个 [JWT](/learn/docs/fern-api-reference/get-jwt)：
 
 ```bash 获取 JWT
 curl https://docs.example.com/api/fern-docs/get-jwt \

--- a/fern/translations/zh/products/docs/pages/ai/overview.mdx
+++ b/fern/translations/zh/products/docs/pages/ai/overview.mdx
@@ -41,7 +41,7 @@ AI 帮助保持您的文档实时更新。Fern Writer 是一个基于 Slack 的�
 
 ## 为 AI 优化
 
-您的站点会针对 AI 工具和搜索引擎进行自动优化。Fern 托管 `llms.txt` 和 `llms-full.txt` 文件，便于 LLM 高效索引您的文档，并向 AI 代理返回 Markdown 而非 HTML。这些功能可减少 token 消耗，帮助代理更快处理您的内容。
+您的站点会针对 AI 工具和搜索引擎进行自动优化。Fern 托管 `llms.txt` 文件，便于 LLM 高效索引您的文档，并向 AI 代理返回 Markdown 而非 HTML。这些功能可减少 token 消耗，帮助代理更快处理您的内容。
 
 <CardGroup cols={2}>
   <Card title="`llms.txt`" icon="file-text" href="/learn/docs/ai-features/llms-txt" />

--- a/fern/translations/zh/products/docs/pages/getting-started/self-service-setup.mdx
+++ b/fern/translations/zh/products/docs/pages/getting-started/self-service-setup.mdx
@@ -13,7 +13,7 @@ sidebar-title: 自助设置
 
 ## 创建的内容
 
-当您完成自助服务工作流程时，Fern 会将您的文档发布到全新的站点，并创建一个包含站点配置（`docs.yml`）、Markdown 页面和任何 API 规范的 GitHub 仓库。您的仓库包含一个预填充的 `CLAUDE.md` 文件，其中包含 [llms-full.txt 格式](/learn/docs/ai/llms-txt)的 Fern 文档，为 AI 编程助手提供使用 Fern 的上下文。
+当您完成自助服务工作流程时，Fern 会将您的文档发布到全新的站点，并创建一个包含站点配置（`docs.yml`）、Markdown 页面和任何 API 规范的 GitHub 仓库。您的仓库包含一个预填充的 `CLAUDE.md` 文件，其中包含 [`llms.txt` 格式](/learn/docs/ai-features/llms-txt)的 Fern 文档，为 AI 编程助手提供使用 Fern 的上下文。
 
 设置过程还会创建和配置：
 

--- a/fern/translations/zh/products/docs/pages/navigation/frontmatter.mdx
+++ b/fern/translations/zh/products/docs/pages/navigation/frontmatter.mdx
@@ -100,7 +100,7 @@ navigation:
 ## 副标题
 
 <ParamField path="subtitle" type="string" required={false}>
-  在页面上渲染为副标题。如果未设置 `description`，则 `subtitle` 也用作元描述标签和 [`llms.txt` 和 `llms-full.txt`](/learn/docs/ai-features/llms-txt#page-descriptions) 中。
+  在页面上渲染为副标题。如果未设置 `description`，则 `subtitle` 也用作元描述标签和 [`llms.txt`](/learn/docs/ai-features/llms-txt#page-descriptions) 中。
 </ParamField>
 
 例如，滚动到您现在正在访问的页面顶部，您将看到副标题"使用前置事项设置标题、描述、路径、布局和可见性"。
@@ -166,7 +166,7 @@ slug: email  # 结果为 /email（忽略导航结构）
 ## 元描述
 
 <ParamField path="description" type="string" required={false}>
-  设置页面的 [元描述](https://web.dev/learn/html/metadata#description)。与页面标题一样，元描述对 SEO 很重要。它影响搜索引擎在搜索结果片段中显示的关于您页面的文本。它还可以影响搜索引擎的索引和排名。有关更多信息，请参见 [Google 的元描述指南](https://developers.google.com/search/docs/appearance/snippet#meta-descriptions)。描述还用于 [`llms.txt` 和 `llms-full.txt`](/learn/docs/ai-features/llms-txt#page-descriptions)。
+  设置页面的 [元描述](https://web.dev/learn/html/metadata#description)。与页面标题一样，元描述对 SEO 很重要。它影响搜索引擎在搜索结果片段中显示的关于您页面的文本。它还可以影响搜索引擎的索引和排名。有关更多信息，请参见 [Google 的元描述指南](https://developers.google.com/search/docs/appearance/snippet#meta-descriptions)。描述还用于 [`llms.txt`](/learn/docs/ai-features/llms-txt#page-descriptions)。
 </ParamField>
 
 <CodeBlock title="元描述示例">

--- a/fern/translations/zh/products/docs/pages/resources/stainless-comparison.mdx
+++ b/fern/translations/zh/products/docs/pages/resources/stainless-comparison.mdx
@@ -79,7 +79,7 @@ Stainless 提供基于 RAG 的搜索。Fern 提供额外的 AI 功能，包括[�
 | **AI 聊天机器人** | ✅ [Ask Fern](/learn/docs/ai-features/ask-fern/overview) 搭配 Claude，[指导文档](/learn/docs/ai-features/ask-fern/guidance)和自定义知识来源 | ✅ 基于 RAG 的问答 |
 | **AI 分析** | ✅ [内容缺口识别](/learn/docs/ai-features/ask-fern/overview)和洞察 | ❌ 无 |
 | **搜索** | ✅ 向量搜索，按语言、产品、版本分面 | ⚠️ 元数据驱动，基础分面 |
-| **LLM 友好格式** | ✅ [/llms.txt 和 /llms-full.txt](/learn/docs/ai-features/llms-txt) | ✅ URL 上的 .md 扩展名 |
+| **LLM 友好格式** | ✅ [/llms.txt](/learn/docs/ai-features/llms-txt) | ✅ URL 上的 .md 扩展名 |
 <br/>
 </Accordion>
 

--- a/fern/translations/zh/products/docs/pages/seo/robots-txt.mdx
+++ b/fern/translations/zh/products/docs/pages/seo/robots-txt.mdx
@@ -8,7 +8,7 @@ description: 在您的文档站点根目录提供自定义 robots.txt 来控制�
 `robots.txt` 只是建议性的：合规的爬虫会遵循您的 `Disallow` 和 `Allow` 指令，但忽略协议的机器人仍然可以访问这些路径。对于必须保持私有的内容，[请使用身份验证](/learn/docs/authentication/overview)。
 
 <Note>
-  `robots.txt` 决定哪些爬虫可以访问您的站点以及您广播什么 AI 训练信号。它的配套文件 [`llms.txt` 和 `llms-full.txt`](/learn/docs/ai-features/llms-txt) 则影响 AI 代理爬取后接收到的内容。
+  `robots.txt` 决定哪些爬虫可以访问您的站点以及您广播什么 AI 训练信号。它的配套文件 [`llms.txt`](/learn/docs/ai-features/llms-txt) 则影响 AI 代理爬取后接收到的内容。
 </Note>
 
 ## 配置


### PR DESCRIPTION
## Summary

Removes all `llms-full.txt` references from docs following its removal from Fern Docs sites. Updates 12 English pages and 9 Chinese translation files.

Key changes:

- `llms-txt/overview.mdx`: Title → `` `llms.txt` ``, consolidated "Generated files" into "What `llms.txt` contains", added `<Note>` explaining why `llms-full.txt` isn't generated (context window limits, serving overhead, low usage).
- `llms-txt/customize-llms-txt.mdx`: Removed `llms-full.txt` from endpoint lists, query param examples, and custom-file config. Dropped the `llms-full-txt` YAML key.
- `site-level-settings.mdx`: Removed `agents.llms-full-txt` ParamField and its YAML example line.
- `llms-txt/analytics-integration.mdx`: Button/dropdown examples now use `llms.txt` URLs.
- Other pages (`markdown.mdx`, `directives.mdx`, `overview.mdx`, `mcp-server.mdx`, `robots-txt.mdx`, `frontmatter.mdx`, `self-service-setup.mdx`, `stainless-comparison.mdx`): Stripped `llms-full.txt` from inline mentions.
- Chinese translations (`translations/zh/`): Matching updates across 9 non-changelog files including translated `<Note>`.

Historical changelog entries (EN and ZH) left as-is.

Link to Devin session: https://app.devin.ai/sessions/a66966d41bb649b2ac27abf5ed91b562
Requested by: @dannysheridan