### PR TITLE
Use ChangelogTags markers for June 10 changelog entries

### DIFF
--- a/fern/products/docs/pages/changelog/2026-06-10.mdx
+++ b/fern/products/docs/pages/changelog/2026-06-10.mdx
@@ -1,8 +1,5 @@
----
-tags: ["ai"]
----
-
 ## `fern-docs` agent skill
+<ChangelogTags>ai</ChangelogTags>
 
 You can now install the `fern-docs` [agent skill](https://www.skills.sh) to teach coding agents like Claude Code, Cursor, and Copilot how to work with Fern Docs. The skill covers `docs.yml` configuration, navigation, MDX pages, components, and changelog entries, with task-specific references that agents load on demand.
 
@@ -13,12 +10,14 @@ npx skills add fern-api/skills --skill fern-docs
 <Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/ai-features/agent-skills">Read the docs</Button>
 
 ## Host agent skills from your docs site
+<ChangelogTags>ai, configuration</ChangelogTags>
 
 Fern docs sites can now serve author-supplied [Agent Skills](https://www.skills.sh) at the standard `/.well-known/skills/` and `/.well-known/agent-skills/` endpoints. Place your skill bundle under `fern/.well-known/agent-skills/` and the CLI uploads it during `fern generate --docs`. Users install with `npx skills add https://<your-domain>`.
 
 <Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/ai-features/host-skills">Read the docs</Button>
 
 ## "Install skills" page action
+<ChangelogTags>ai, configuration, docs.yml</ChangelogTags>
 
 You can now add an "Install skills" button to the page action bar via `page-actions.options.skills` in `docs.yml`. The button opens a modal showing a copyable install command, the list of available skills, and a link to the skill source. The modal fetches the site's served well-known manifest on first open, so the skill list stays in sync with what `npx skills add` installs.
 

--- a/fern/products/docs/pages/changelog/2026-06-23.mdx
+++ b/fern/products/docs/pages/changelog/2026-06-23.mdx
@@ -1,0 +1,20 @@
+## Changelog timeline redesign
+<ChangelogTags>components</ChangelogTags>
+
+Changelog pages now render as a compact, date-grouped timeline of entry cards, replacing the previous layout that stacked full-height entries inline. A search bar at the top lets readers find entries by keyword. The query syncs to the `?q=` URL parameter, so filtered views are shareable.
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/configuration/changelogs">Read the docs</Button>
+
+## Per-entry changelog tags
+<ChangelogTags>analytics, dashboard</ChangelogTags>
+
+Changelog entries with multiple releases under separate headings can tag each heading independently using the `<ChangelogTags>` component:
+
+```mdx
+## New dashboard analytics
+<ChangelogTags>analytics, dashboard</ChangelogTags>
+```
+
+Tags on individual entry pages are clickable and link back to the timeline with that tag pre-selected as a filter.
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/configuration/changelogs#per-entry-tags">Read the docs</Button>


### PR DESCRIPTION
The June 10 docs changelog has three same-day releases in one file, so they previously shared the file-level `tags: ["ai"]` frontmatter. This adds a `<ChangelogTags>` marker under each H2 so every release carries its own tags on its card, the entry page, and the tag-filter list (changelog redesign, fern-platform #12385). Tags reuse the existing lowercase vocabulary: `ai`; `ai, configuration`; and `ai, configuration, docs.yml`. The redundant file-level `tags` frontmatter is removed since each section now includes `ai`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->