### PR TITLE
JUST TESTING

### DIFF
--- a/fern/products/docs/docs.yml
+++ b/fern/products/docs/docs.yml
@@ -16,6 +16,10 @@ navigation:
         href: https://buildwithfern.com/showcase#docs-customers.alldocs-features
   - changelog: ./pages/changelog
     icon: fa-regular fa-clock-rotate-left
+  - page: Roadmap
+    path: ./pages/roadmap.mdx
+    icon: fa-regular fa-map
+    slug: roadmap
   - section: Configuration
     contents:
       - page: Overview

--- a/fern/products/docs/pages/roadmap.mdx
+++ b/fern/products/docs/pages/roadmap.mdx
@@ -1,0 +1,39 @@
+---
+title: Roadmap
+description: What we're building next for Fern Docs. Targets are directional and may shift as we learn.
+---
+
+
+Here's where Fern Docs is headed. Items are grouped by the quarter we're targeting, soonest first, with anything we haven't dated yet under **Later**. Targets are directional and may change—follow the [changelog](/learn/docs/changelog) for what's already shipped.
+
+<Roadmap>
+  <RoadmapItem title="Visual editing with Fern Editor" status="shipped" target="Q2 2026" tags={["Authoring"]} changelog="/learn/docs/changelog">
+    Edit your docs in a WYSIWYG editor and open a PR without leaving the browser.
+  </RoadmapItem>
+
+  <RoadmapItem title="Roadmap component" status="in-progress" target="Q3 2026" tags={["Components"]} link="https://github.com/fern-api/fern-platform/pull/12644">
+    A forward-looking, quarter-grouped timeline you can author inline on any page—exactly the component rendering this page.
+  </RoadmapItem>
+
+  <RoadmapItem title="Faster local preview" status="in-progress" target="Q3 2026" tags={["Developer experience"]}>
+    Sub-second hot reload for `fern docs dev`, even on large sites.
+  </RoadmapItem>
+
+  <RoadmapItem title="Theming presets" status="planned" target="Q4 2026" tags={["Theming", "Design"]}>
+    Drop-in starting points for light and dark themes, with live preview in the dashboard.
+  </RoadmapItem>
+
+  <RoadmapItem title="Search analytics" status="planned" target="Q4 2026" tags={["Analytics"]}>
+    See top queries and zero-result searches so you know which docs to write next.
+  </RoadmapItem>
+
+  <RoadmapItem title="Localization workflow v2" status="planned" target="2027" tags={["Internationalization"]}>
+    Per-language review states and translation memory for multi-locale sites.
+  </RoadmapItem>
+
+  <RoadmapItem title="Offline & PDF export" status="exploring" tags={["Export"]}>
+    A single-file export of your docs for air-gapped environments. Still early—we're validating demand.
+  </RoadmapItem>
+</Roadmap>
+
+Have something you'd like to see? [Let us know](https://buildwithfern.com/contact).


### PR DESCRIPTION
Adds a **Roadmap** page to the Docs product that uses the `<Roadmap>` / `<RoadmapItem>` components from [fern-platform#12644](https://github.com/fern-api/fern-platform/pull/12644), with a top-level nav entry beside the changelog (slug `/docs/roadmap`). The page is a realistic forward-looking roadmap that exercises the component's features: shipped/in-progress/planned plus a custom status, quarter/year/undated (`Later`) targets, tags, and `link`/`changelog` footer links. `fern check` passes with no new warnings.

Note: the timeline only renders once #12644 ships in the docs bundle; the page is authored correctly and validates today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)