### PR TITLE
JUST TESTING DONT MERGE

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -161,6 +161,7 @@ layout:
   header-height: 75px
   searchbar-placement: header
   tabs-placement: header
+  changelog-layout: classic
 
 theme:
   page-actions: toolbar

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -161,10 +161,9 @@ layout:
   header-height: 75px
   searchbar-placement: header
   tabs-placement: header
-  changelog-layout: timeline
+  changelog-layout: classic
 
 theme:
-  body: canvas
   page-actions: toolbar
   footer-nav: minimal
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -161,9 +161,10 @@ layout:
   header-height: 75px
   searchbar-placement: header
   tabs-placement: header
-  changelog-layout: classic
+  changelog-layout: timeline
 
 theme:
+  body: canvas
   page-actions: toolbar
   footer-nav: minimal
 

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "fern",
-  "version": "5.51.2"
+  "version": "5.54.0"
 }


### PR DESCRIPTION
Sets `layout.changelog-layout: classic` in `fern/docs.yml` to render the legacy stacked changelog layout instead of the default `timeline` layout.

Note: `changelog-layout` requires Fern CLI ≥ 5.52.0; this repo currently pins `5.51.2` in `fern.config.json`, so the version may need bumping for `fern check` to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/docs/pull/5992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->