### PR TITLE
fix: follow same-host redirects through upstream in Cloudflare Worker template

### DIFF
--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -59,9 +59,28 @@ export default {
     const proxiedRequest = new Request(upstreamUrl, request);
     proxiedRequest.headers.set("x-fern-host", FERN_HOST);
 
-    return fetch(proxiedRequest, { redirect: "manual" });
+    const response = await fetch(proxiedRequest, { redirect: "manual" });
+
+    if (isRedirect(response)) {
+      const location = response.headers.get("Location");
+      if (location) {
+        const redirectUrl = new URL(location, request.url);
+        if (redirectUrl.hostname === url.hostname) {
+          redirectUrl.hostname = "app.buildwithfern.com";
+          const redirectReq = new Request(redirectUrl, request);
+          redirectReq.headers.set("x-fern-host", FERN_HOST);
+          return fetch(redirectReq);
+        }
+      }
+    }
+
+    return response;
   },
 };
+
+function isRedirect(response) {
+  return [301, 302, 303, 307, 308].includes(response.status);
+}
 ```
 
 Replace `SUBPATH` and `FERN_HOST` with your subpath and bare domain.

--- a/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
+++ b/fern/products/docs/pages/preview-publish/reverse-proxy.mdx
@@ -59,7 +59,7 @@ export default {
     const proxiedRequest = new Request(upstreamUrl, request);
     proxiedRequest.headers.set("x-fern-host", FERN_HOST);
 
-    return fetch(proxiedRequest);
+    return fetch(proxiedRequest, { redirect: "manual" });
   },
 };
 ```


### PR DESCRIPTION
## Summary

When a client sends `Accept: text/markdown`, Fern responds with a 303 redirect to a `.md` URL on the same custom domain. The Worker's `fetch()` auto-follows that redirect, but since the target is the Worker's own hostname, Cloudflare's same-host fetch protection blocks it → 522 on every markdown request.

Simply returning the 303 to the client (`redirect: "manual"`) doesn't fully solve the problem — LLMs (Claude, etc.) often don't follow redirects at all.

The updated template catches redirects with `redirect: "manual"`, checks if the Location points back to the Worker's own domain, and re-fetches through the upstream (`app.buildwithfern.com`) with `x-fern-host` set — returning the final markdown response directly to the client without requiring it to follow any redirects.

```js
const response = await fetch(proxiedRequest, { redirect: "manual" });
if (isRedirect(response)) {
  const location = response.headers.get("Location");
  if (location) {
    const redirectUrl = new URL(location, request.url);
    if (redirectUrl.hostname === url.hostname) {
      redirectUrl.hostname = "app.buildwithfern.com";
      const redirectReq = new Request(redirectUrl, request);
      redirectReq.headers.set("x-fern-host", FERN_HOST);
      return fetch(redirectReq);
    }
  }
}
return response;
```

Link to Devin session: https://app.devin.ai/sessions/49bbb208d33742988ca95f25c6ae50f6
Requested by: @dvdaruri-art