### PR TITLE
docs: add note about refined Okta SAML SSO URL format

### DIFF
--- a/fern/products/dashboard/pages/sso.mdx
+++ b/fern/products/dashboard/pages/sso.mdx
@@ -42,6 +42,22 @@ SSO setup requires working with Fern to exchange configuration values (like call
 
       <Step title="Send Fern your IdP metadata">
         From the **Sign-On** tab, copy the Metadata URL and X.509 certificate. Send them back to Fern. Fern will enable the connection and run a test login with you.
+
+        <Note title="SSO URL format">
+          Okta may provide a Metadata URL in the form:
+
+          ```
+          https://<your-tenant>.okta.com/app/<app-id>/sso/saml/metadata
+          ```
+
+          In recent configurations, the SSO URL used by Fern follows a refined format that inserts `/{email_domain}_fern_1/` between `/app` and the app ID, and drops `/metadata` from the end:
+
+          ```
+          https://<your-tenant>.okta.com/app/{email_domain}_fern_1/<app-id>/sso/saml
+          ```
+
+          If you run into issues, try the original Metadata URL format for troubleshooting.
+        </Note>
       </Step>
 
       <Step title="Disable IdP-initiated login">

--- a/fern/translations/zh/products/dashboard/pages/sso.mdx
+++ b/fern/translations/zh/products/dashboard/pages/sso.mdx
@@ -43,6 +43,22 @@ SSO 设置需要与 Fern 合作交换配置值（如回调 URL 和实体 ID）�
 
       <Step title="向 Fern 发送您的身份提供商元数据">
         从 **Sign-On** 选项卡中，复制元数据 URL 和 X.509 证书。将它们发送回 Fern。Fern 将启用连接并与您一起运行测试登录。
+
+        <Note title="SSO URL 格式">
+          Okta 可能会提供以下格式的元数据 URL：
+
+          ```
+          https://<your-tenant>.okta.com/app/<app-id>/sso/saml/metadata
+          ```
+
+          在最近的配置中，Fern 使用的 SSO URL 采用改进格式，在 `/app` 和应用 ID 之间插入 `/{email_domain}_fern_1/`，并删除末尾的 `/metadata`：
+
+          ```
+          https://<your-tenant>.okta.com/app/{email_domain}_fern_1/<app-id>/sso/saml
+          ```
+
+          如果遇到问题，请尝试使用原始元数据 URL 格式进行故障排除。
+        </Note>
       </Step>
 
       <Step title="禁用身份提供商发起的登录">


### PR DESCRIPTION
## Summary

Adds a `<Note>` to the Okta SAML setup step ("Send Fern your IdP metadata") explaining that recent configurations use a refined SSO URL format:

```diff
- https://<your-tenant>.okta.com/app/<app-id>/sso/saml/metadata
+ https://<your-tenant>.okta.com/app/{email_domain}_fern_1/<app-id>/sso/saml
```

The note inserts `/{email_domain}_fern_1/` between `/app` and the app ID, and drops `/metadata`. The original format is preserved as a fallback for troubleshooting.

Both the English and Chinese (`zh`) translations are updated.

Link to Devin session: https://app.devin.ai/sessions/f11adadc654c41ed8fa3827d4a6ff82c
Requested by: @dvdaruri-art