### PR TITLE
fix: refactor local generation and quickstart for consistency

### DIFF
--- a/fern/products/cli-generator/cli-generator.yml
+++ b/fern/products/cli-generator/cli-generator.yml
@@ -22,7 +22,7 @@ navigation:
       - page: Publishing
         path: ./publishing.mdx
         slug: publishing
-      - page: Local generation
+      - page: Self-hosted generation
         path: ./local-generation.mdx
         slug: local-generation
       - page: Configuration reference

--- a/fern/products/cli-generator/configuration.mdx
+++ b/fern/products/cli-generator/configuration.mdx
@@ -60,7 +60,7 @@ config:
 
 ### `output`
 
-Configures where to publish the generated CLI. The CLI generator supports `npm` and `local-file-system` output locations. For the full publishing workflow (OIDC auth, CI builds, Homebrew tap), see [Publishing](/learn/cli-generator/get-started/publishing). For Docker-based generation on your own machine, see [Local generation](/learn/cli-generator/get-started/local-generation).
+Configures where to publish the generated CLI. The CLI generator supports `npm` and `local-file-system` output locations. For the full publishing workflow (OIDC auth, CI builds, Homebrew tap), see [Publishing](/learn/cli-generator/get-started/publishing). For Docker-based generation on your own machine, see [Self-hosted generation](/learn/cli-generator/get-started/local-generation).
 
 <AccordionGroup>
 <Accordion title="npm">

--- a/fern/products/cli-generator/local-generation.mdx
+++ b/fern/products/cli-generator/local-generation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Local generation
+title: Self-hosted generation
 description: Run CLI generation on your own machine using Docker instead of Fern's cloud infrastructure.
 availability: beta
 ---
@@ -8,7 +8,7 @@ availability: beta
 The CLI generator is in early access. [Reach out](https://buildwithfern.com/book-demo?type=cli) to get started.
 </Note>
 
-By default, `fern generate` [runs the CLI generator on Fern's cloud infrastructure](/learn/cli-generator/get-started/quickstart). Pass `--local` to run generation on your own machine instead. No API definition data leaves your machine: the only network calls are organization verification and pulling the Docker image (if not cached). This suits organizations with strict security or compliance requirements, or iterating on configuration without pushing to a remote.
+By default, `fern generate` [runs the CLI generator on Fern's cloud infrastructure](/learn/cli-generator/get-started/quickstart). Pass `--local` to run generation on your own machine instead. No API definition data leaves your machine: the only network calls are organization verification and pulling the Docker image (if not cached). This suits organizations with strict security or compliance requirements that need to keep their spec off Fern's infrastructure.
 
 ## Comparison with cloud generation
 
@@ -29,36 +29,15 @@ By default, `fern generate` [runs the CLI generator on Fern's cloud infrastructu
 
 ## Setup
 
+<Info>
+This page assumes you've completed the [Quickstart](/learn/cli-generator/get-started/quickstart), so your `generators.yml` already writes to a [`local-file-system`](/learn/cli-generator/get-started/configuration#output) output path. Adding `--local` runs that same configuration through Docker instead of Fern's cloud.
+</Info>
+
 <Steps>
-
-<Step title="Configure output to local file system">
-
-Set the output location in `generators.yml` to `local-file-system`:
-
-```yaml title="generators.yml" {7-8}
-api:
-  specs:
-    - openapi: openapi.yml
-default-group: cli
-groups:
-  cli:
-    generators:
-      - name: fern-cli-generator
-        version: 0.6.1
-        output:
-          location: local-file-system
-          path: ../my-cli
-        config:
-          binaryName: my-cli
-```
-
-The `path` is relative to the `fern/` directory. This example writes the generated Rust project to `../my-cli` (a sibling directory).
-
-</Step>
 
 <Step title="Set your Fern token">
 
-Local generation still requires a network call to verify your organization. Generate a token with `fern token` or from the [Fern Dashboard](/learn/dashboard/configuration/api-keys), then export it:
+Self-hosted generation still requires a network call to verify your organization. Generate a token with `fern token` or from the [Fern Dashboard](/learn/dashboard/configuration/api-keys), then export it:
 
 ```bash
 export FERN_TOKEN=<your-token>

--- a/fern/products/cli-generator/overview.mdx
+++ b/fern/products/cli-generator/overview.mdx
@@ -29,7 +29,7 @@ Building a CLI by hand is a multi-quarter project — commands, auth, pagination
 Generate a CLI from an OpenAPI spec or a GraphQL introspection schema.
 </Info>
 
-The CLI generator plugs into the same Fern workflow as your Docs and SDKs. When your spec changes, Fern opens a PR against your CLI repo with the generated source. On release, Fern automatically [publishes the CLI](/learn/cli-generator/get-started/publishing) to npm, Homebrew, and GitHub Releases so your users can install it with their package manager of choice. The CLI stays in sync with your Docs and SDKs, and you never need to write CLI code by hand. For organizations that need to keep generation on their own infrastructure, the generator also supports [local generation via Docker](/learn/cli-generator/get-started/local-generation).
+The CLI generator plugs into the same Fern workflow as your Docs and SDKs. When your spec changes, Fern opens a PR against your CLI repo with the generated source. On release, Fern automatically [publishes the CLI](/learn/cli-generator/get-started/publishing) to npm, Homebrew, and GitHub Releases so your users can install it with their package manager of choice. The CLI stays in sync with your Docs and SDKs, and you never need to write CLI code by hand. For organizations that need to keep generation on their own infrastructure, the generator also supports [self-hosted generation via Docker](/learn/cli-generator/get-started/local-generation).
 
 The output is a single statically linked Rust binary. Users drop it onto their PATH and run it. There's no language runtime and no dependencies.
 

--- a/fern/products/cli-generator/publishing.mdx
+++ b/fern/products/cli-generator/publishing.mdx
@@ -8,13 +8,13 @@ availability: beta
 The CLI generator is in early access. [Reach out](https://buildwithfern.com/book-demo?type=cli) to get started.
 </Note>
 
-Publish your generated CLI to npm, Homebrew, and GitHub Releases. After following the steps on this page, each tagged release builds cross-platform binaries and publishes them automatically. For iterating locally before publishing, see [Local generation](/learn/cli-generator/get-started/local-generation).
+Publish your generated CLI to npm, Homebrew, and GitHub Releases. After following the steps on this page, each tagged release builds cross-platform binaries and publishes them automatically. To keep generation on your own infrastructure, you can [self-host the generator](/learn/cli-generator/get-started/local-generation) instead of using Fern's cloud.
 
 <Info>
 This page assumes that you have:
 
 * An initialized `fern` folder with `generators.yml` configured for the CLI generator. See [Quickstart](/learn/cli-generator/get-started/quickstart).
-* A GitHub repository for the generated CLI source.
+* An existing GitHub repository for the generated CLI source, with the [Fern GitHub App](https://github.com/apps/fern-api) installed on it.
 </Info>
 
 ## Configure output location
@@ -79,6 +79,8 @@ groups:
           repository: my-org/my-cli
           mode: release
 ```
+
+The `repository` owner is independent of your Fern organization (the `--organization` value passed to `fern init`). Point it at the GitHub user or organization that owns the target repository.
 
 | Mode | Behavior |
 | --- | --- |

--- a/fern/products/cli-generator/quickstart.mdx
+++ b/fern/products/cli-generator/quickstart.mdx
@@ -11,7 +11,7 @@ The CLI generator is in early access. [Reach out](https://buildwithfern.com/book
 This guide walks through generating a CLI from an OpenAPI spec and running it via Fern's cloud generation. By the end you will have a compiled binary that [maps every API endpoint to a subcommand](/learn/cli-generator/get-started/openapi-extensions#command-structure), with [authentication](/learn/cli-generator/get-started/authentication), [output formatting](/learn/cli-generator/get-started/features#output-formatting), and [pagination](/learn/cli-generator/get-started/features#pagination) wired up from your spec.
 
 <Tip>
-  You can alternatively [run CLI generation locally](/learn/cli-generator/get-started/local-generation), best for organizations with strict security or compliance requirements, or iterating on configuration without pushing to a remote. 
+  To generate entirely on your own machine without sending your spec to Fern, [run generation locally](/learn/cli-generator/get-started/local-generation) with `--local`.
 </Tip>
 
 ## Prerequisites
@@ -50,15 +50,17 @@ api:
 default-group: cli
 groups:
   cli:
-    generators:
+    generators:go
       - name: fern-cli-generator
         version: 0.6.1
-        github:
-          repo: my-org/my-cli
-          mode: release
+        output:
+          location: local-file-system
+          path: ../my-cli
         config:
           binaryName: my-cli
 ```
+
+The `path` is relative to the `fern/` directory, so this writes the generated Rust project to a sibling `my-cli/` directory. To ship the CLI to npm, Homebrew, or GitHub Releases instead of building it locally, configure a [publishing target](/learn/cli-generator/get-started/publishing).
 </Step>
 
 <Step title="Generate the CLI">
@@ -89,3 +91,14 @@ The `--help` output shows the full command tree: top-level commands derived from
 </Step>
 
 </Steps>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Publish your CLI" icon="regular rocket" href="/learn/cli-generator/get-started/publishing">
+    Ship to npm, Homebrew, and GitHub Releases with automated cross-platform builds and CI.
+  </Card>
+  <Card title="Self-hosted generation" icon="regular laptop" href="/learn/cli-generator/get-started/local-generation">
+    Generate on your own machine with Docker, keeping your spec off Fern's infrastructure.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Changes

**Quickstart** — fixed an internal contradiction where Step 3 configured GitHub
`mode: release` (pushes to a remote) but Step 5 ran a local `cargo build`.
- Step 3 now uses `local-file-system` output at `../my-cli`, matching the build step.
- Reframed the top Tip toward `--local`; added a Next steps section linking
  Publishing and Self-hosted generation.

**Publishing** — now the single home for GitHub setup.
- Added the missing prerequisites to the `<Info>` box: the target repo must exist
  and have the [Fern GitHub App](https://github.com/apps/fern-api) installed.
- Noted that `github.repository`'s owner is independent of the `fern init
  --organization` value.

**Self-hosted generation** (renamed from "Local generation")
- Retitled to match the SDK's "Self-hosted SDKs" convention and to avoid confusion
  with `local-file-system` output. Slug unchanged (`/local-generation`), so no URLs break.
- Dropped the duplicated output-config step (now in the quickstart); page focuses on
  the `--local` Docker flow, the cloud-vs-local comparison, and private registries.
- Fixed the intro: `--local` is for keeping specs off Fern's infrastructure
  (security/compliance), not "iterating without pushing" — that's a property of
  local-file-system output.

Updated cross-references in `overview.mdx`, `configuration.mdx`, and `publishing.mdx`.