### PR TITLE
docs: document x-fern-global-parameters extension and CLI generator support

### DIFF
--- a/fern/products/api-def/api-def.yml
+++ b/fern/products/api-def/api-def.yml
@@ -60,6 +60,8 @@ navigation:
             path: ./openapi/extensions/explorer.mdx
           - page: Global headers
             path: ./openapi/extensions/global-headers.mdx
+          - page: Global parameters
+            path: ./openapi/extensions/global-parameters.mdx
           - page: Ignoring elements
             path: ./openapi/extensions/ignore.mdx
           - page: SDK method names

--- a/fern/products/api-def/openapi/extensions/global-parameters.mdx
+++ b/fern/products/api-def/openapi/extensions/global-parameters.mdx
@@ -33,7 +33,7 @@ x-fern-global-parameters:
 ### Fields
 
 <ParamField path="name" type="string" required={true}>
-  The canonical identifier for the parameter. It is the base for the generated flag or constructor argument, and the key operations use to [opt in](#apply-to-specific-operations).
+  The canonical identifier for the parameter. It's the base for the generated flag or constructor argument, and the key operations use to [opt in](#apply-to-specific-operations).
 </ParamField>
 
 <ParamField path="in" type="string" default="body">

--- a/fern/products/api-def/openapi/extensions/global-parameters.mdx
+++ b/fern/products/api-def/openapi/extensions/global-parameters.mdx
@@ -17,7 +17,7 @@ x-fern-global-parameters:
   - name: currency
     in: body
     target: config.currency
-    env: CHANNEL3_CURRENCY
+    env: ACME_CURRENCY
     default: USD
     optional: true
     apply: auto
@@ -25,7 +25,7 @@ x-fern-global-parameters:
   - name: region
     in: path
     target: regionId
-    env: CHANNEL3_REGION
+    env: ACME_REGION
     default: us
     apply: explicit
 ```

--- a/fern/products/api-def/openapi/extensions/global-parameters.mdx
+++ b/fern/products/api-def/openapi/extensions/global-parameters.mdx
@@ -1,0 +1,106 @@
+---
+title: Global parameters
+headline: Global parameters (OpenAPI)
+description: Declare parameters set once at the client level and injected into every relevant request using the `x-fern-global-parameters` extension
+---
+
+A **global parameter** is a value set once — at the SDK client level or the CLI config level — and injected into every relevant request, instead of being passed on every call. Per-call values always win over the global value.
+
+Global parameters differ from [global headers](/learn/api-definitions/openapi/extensions/global-headers): a global header is always a header, while a global parameter can target a header, query parameter, path parameter, or a field in the request body.
+
+## Declare global parameters
+
+Use the `x-fern-global-parameters` extension at the root of your spec. Each entry declares one parameter:
+
+```yaml title="openapi.yml"
+x-fern-global-parameters:
+  - name: currency
+    in: body
+    target: config.currency
+    env: CHANNEL3_CURRENCY
+    default: USD
+    optional: true
+    apply: auto
+    docs: The currency code used for pricing.
+  - name: region
+    in: path
+    target: regionId
+    env: CHANNEL3_REGION
+    default: us
+    apply: explicit
+```
+
+### Fields
+
+<ParamField path="name" type="string" required={true}>
+  The canonical identifier for the parameter. It is the base for the generated flag or constructor argument, and the key operations use to [opt in](#apply-to-specific-operations).
+</ParamField>
+
+<ParamField path="in" type="string" default="body">
+  Where the value is injected on the wire: `body`, `query`, `header`, or `path`.
+</ParamField>
+
+<ParamField path="target" type="string">
+  The wire-level injection target. For `body`, a dotted path into the request body (for example, `config.currency`). For `query`, `header`, and `path`, the parameter or header name. Defaults to `name`.
+</ParamField>
+
+<ParamField path="type" type="string" default="string">
+  The value type: `string`, `integer`, `double`, or `boolean`.
+</ParamField>
+
+<ParamField path="env" type="string">
+  An environment variable the value falls back to when the caller doesn't provide one.
+</ParamField>
+
+<ParamField path="default" type="any">
+  A client-side default used when neither the caller nor the environment variable supplies a value. [`x-fern-default`](/learn/api-definitions/openapi/extensions/default-values) takes precedence over `default`.
+</ParamField>
+
+<ParamField path="optional" type="boolean" default="false">
+  Whether the parameter can be omitted. A required parameter with no value, default, or environment variable produces an error.
+</ParamField>
+
+<ParamField path="apply" type="string" default="explicit">
+  How the parameter applies to operations. `explicit` applies only to operations that [opt in](#apply-to-specific-operations); `auto` applies to every operation whose request contains the target.
+</ParamField>
+
+<ParamField path="parameter-name" type="string">
+  An SDK/CLI-facing alias. When set, this name is used for the generated flag or constructor argument instead of `name`.
+</ParamField>
+
+## Apply to specific operations
+
+When a parameter uses `apply: explicit` (the default), it applies only to operations that opt in with the per-operation `x-fern-global-parameter` extension. List the parameter names to include. The value accepts a single string or a list:
+
+```yaml title="openapi.yml" {4-6,12}
+paths:
+  /v1/products/{regionId}/search:
+    post:
+      x-fern-global-parameter:
+        - region
+        - currency
+      operationId: searchProducts
+      # ...
+  /v1/products/{regionId}/{productId}:
+    get:
+      x-fern-global-parameter: region
+      operationId: getProduct
+      # ...
+```
+
+Each name must match a parameter declared in `x-fern-global-parameters`. A parameter with `apply: auto` is injected into every operation whose request contains its target, with no opt-in required.
+
+## Resolution order
+
+At runtime, the value is resolved from the first available source, in order:
+
+1. The per-call value (a per-operation parameter or an explicit request field) — this always wins.
+2. The CLI flag or constructor argument.
+3. The environment variable (`env`).
+4. The client-side default (`x-fern-default`, then `default`).
+
+For a `body` parameter with a nested `target`, a value the caller already supplies at that path is never overwritten.
+
+## Generated CLI behavior
+
+The [CLI generator](/learn/cli-generator/get-started/openapi-extensions#global-parameters) registers each global parameter as a top-level flag (with its `env` fallback and `default`) and injects the resolved value at the declared location for every applicable command.

--- a/fern/products/api-def/openapi/extensions/overview.md
+++ b/fern/products/api-def/openapi/extensions/overview.md
@@ -26,6 +26,7 @@ The table below shows all available extensions and links to detailed documentati
 | [`x-fern-examples`](./request-response-examples) | Associate request and response examples |
 | [`x-fern-explorer`](./api-explorer-control) | Control API Explorer (playground) availability globally or per endpoint |
 | [`x-fern-global-headers`](./global-headers) | Configure headers used across all endpoints |
+| [`x-fern-global-parameters`](./global-parameters) | Configure parameters set once and injected into every relevant request |
 | [`x-fern-header`](/api-definitions/openapi/authentication#apikey-security-scheme) | Customize API key header authentication parameter names and environment variables |
 | [`x-fern-idempotent`](./idempotency) | Mark an endpoint as idempotent |
 | [`x-fern-idempotency-headers`](./idempotency) | Configure idempotency headers for safe request retries |

--- a/fern/products/cli-generator/openapi-extensions.mdx
+++ b/fern/products/cli-generator/openapi-extensions.mdx
@@ -135,7 +135,7 @@ x-fern-global-parameters:
   - name: currency
     in: body
     target: config.currency
-    env: CHANNEL3_CURRENCY
+    env: ACME_CURRENCY
     default: USD
     apply: auto
 ```
@@ -144,14 +144,14 @@ The value resolves from the first available source: the CLI flag, then the envir
 
 ```bash
 # CLI flag takes priority
-channel3 products search --currency EUR
+acme products search --currency EUR
 
 # Otherwise falls back to the environment variable
-export CHANNEL3_CURRENCY=EUR
-channel3 products search
+export ACME_CURRENCY=EUR
+acme products search
 
 # Otherwise sends the default (USD)
-channel3 products search
+acme products search
 ```
 
 An `apply: auto` parameter applies to every command whose request contains the target; an `apply: explicit` parameter applies only to operations that opt in with `x-fern-global-parameter`.

--- a/fern/products/cli-generator/openapi-extensions.mdx
+++ b/fern/products/cli-generator/openapi-extensions.mdx
@@ -124,6 +124,40 @@ Produces `--api-version` instead of `--x-api-version`.
 
 See [Customize parameter names](/learn/api-definitions/openapi/extensions/parameter-names) for more details.
 
+## Global parameters
+
+### `x-fern-global-parameters`
+
+Registers a value that's configured once and injected into every applicable command, rather than passed on each invocation. Each declared parameter becomes a top-level `--<flag-name>` flag with its environment-variable fallback and client-side default, injected at the declared location (`body`, `query`, `header`, or `path`).
+
+```yaml title="openapi.yml"
+x-fern-global-parameters:
+  - name: currency
+    in: body
+    target: config.currency
+    env: CHANNEL3_CURRENCY
+    default: USD
+    apply: auto
+```
+
+The value resolves from the first available source: the CLI flag, then the environment variable, then the default. A per-operation parameter with the same target overrides the global.
+
+```bash
+# CLI flag takes priority
+channel3 products search --currency EUR
+
+# Otherwise falls back to the environment variable
+export CHANNEL3_CURRENCY=EUR
+channel3 products search
+
+# Otherwise sends the default (USD)
+channel3 products search
+```
+
+An `apply: auto` parameter applies to every command whose request contains the target; an `apply: explicit` parameter applies only to operations that opt in with `x-fern-global-parameter`.
+
+See [Global parameters](/learn/api-definitions/openapi/extensions/global-parameters) for the full field reference and resolution order.
+
 ## Pagination
 
 ### `x-fern-pagination`


### PR DESCRIPTION
## Summary

Documents the `x-fern-global-parameters` feature on the public docs site, covering both shipped phases: the OpenAPI extension (parsing) and its consumption by the CLI generator.

A **global parameter** is a value set once (at the client/CLI level) and injected into every relevant request instead of being passed per call — think a global `currency` set via flag, env var, or default. It generalizes [global headers](/learn/api-definitions/openapi/extensions/global-headers) to any wire location (body/query/header/path).

### Changes

- **New canonical page** `api-def/openapi/extensions/global-parameters.mdx` — the full reference: the `x-fern-global-parameters` declaration and its fields (`name`, `in`, `target`, `type`, `env`, `default`, `optional`, `apply`, `parameter-name`), the per-operation `x-fern-global-parameter` opt-in, and the resolution order (per-call > flag/arg > env > default).
- **Nav** — added "Global parameters" under API Definitions → OpenAPI → Extensions, right after "Global headers".
- **Extensions overview table** — added an `x-fern-global-parameters` row.
- **CLI generator → OpenAPI extensions page** — new "Global parameters" section showing flag/env/default resolution with a concrete CLI example, cross-linking to the canonical page.

Cross-references follow the canonical-home pattern: the extension page owns the full explanation; the CLI page links to it.

### Notes for reviewer

- All internal links were constructed from the YAML nav config (product slug `api-definitions`, section `extensions`; CLI product `cli-generator`, section `get-started`), not disk paths.
- Content is derived from the shipped implementation (fern#16848 for parsing, fern#16885 for CLI generation).

Link to Devin session: https://app.devin.ai/sessions/319fc43b72a241148ea408e965654d9f
Requested by: @Swimburger