### PR TITLE
docs: document resumable SSE streams and automatic reconnection

### DIFF
--- a/fern/products/api-def/ferndef/endpoints/sse.mdx
+++ b/fern/products/api-def/ferndef/endpoints/sse.mdx
@@ -69,6 +69,28 @@ types:
 
 Generated SDKs expose each event's [metadata — event ID, event type, and retry interval](/learn/sdks/deep-dives/sse-metadata) to your end users.
 
+### Resumable streams
+
+Set `resumable: true` on `response-stream` to opt an SSE endpoint into [automatic reconnection](/learn/sdks/deep-dives/sse-metadata#automatic-reconnection). When the connection drops mid-stream, the generated SDK reconnects and resends the last event ID in the `Last-Event-ID` header, so a server that supports that header resumes where the stream left off.
+
+```yaml title="chat.yml" {10}
+service:
+  base-path: /chat
+  endpoints:
+    stream:
+      method: POST
+      path: ""
+      response-stream:
+        type: Chat
+        format: sse
+        resumable: true
+
+types:
+  Chat:
+    properties:
+      text: string
+```
+
 ## `Stream` parameter
 
 It has become common practice for endpoints to have a `stream` parameter that 

--- a/fern/products/api-def/openapi/endpoints/sse.mdx
+++ b/fern/products/api-def/openapi/endpoints/sse.mdx
@@ -90,6 +90,38 @@ paths:
 # ... responses and schemas
 ```
 
+### Resumable streams
+
+Set `resumable: true` to opt an SSE endpoint into [automatic reconnection](/learn/sdks/deep-dives/sse-metadata#automatic-reconnection). When the connection drops mid-stream, the generated SDK reconnects and resends the last event ID in the `Last-Event-ID` header, so a server that supports that header resumes where the stream left off.
+
+```yaml title="openapi.yml" {4-7}
+paths:
+  /logs:
+    post:
+      x-fern-streaming:
+        format: sse
+        terminator: "[DONE]"
+        resumable: true
+# ... responses and schemas
+```
+
+Configure a [`terminator`](#terminator-message) alongside `resumable`. The terminator marks a stream as complete, letting the SDK distinguish a finished stream from a dropped connection so it reconnects only on genuine drops.
+
+`resumable` is inheritable. Set it at the document level to apply to every SSE endpoint, and override it on individual operations:
+
+```yaml title="openapi.yml"
+x-fern-streaming:
+  resumable: true # applies to all SSE endpoints
+
+paths:
+  /logs:
+    post:
+      x-fern-streaming:
+        format: sse
+        resumable: false # overrides the document default
+# ... responses and schemas
+```
+
 ## `Stream` parameter
 
 It has become common practice for endpoints to have a `stream` parameter that 

--- a/fern/products/sdks/capabilities.mdx
+++ b/fern/products/sdks/capabilities.mdx
@@ -257,7 +257,7 @@ Fern SDKs include the following capabilities:
 - **Retries with backoff**: Automatically retry failed requests with exponential backoff. [Learn more](/sdks/deep-dives/retries-with-backoff)
 - **Webhook signature verification**: Verify the signature of incoming webhook requests. [Learn more](/learn/sdks/deep-dives/webhook-signature-verification)
 - **Idempotency headers**: Built-in protection against duplicate submissions. [Learn more](/sdks/deep-dives/idempotency)
-- **Server-sent events**: Stream JSON data from your server to your client, with opt-in access to [SSE metadata](/learn/sdks/deep-dives/sse-metadata) (event ID, event type, retry). [Learn more](/learn/sdks/deep-dives/sse-metadata)
+- **Server-sent events**: Stream JSON data from your server to your client, with opt-in access to [SSE metadata](/learn/sdks/deep-dives/sse-metadata) (event ID, event type, retry) and [automatic reconnection](/learn/sdks/deep-dives/sse-metadata#automatic-reconnection) for resumable endpoints. [Learn more](/learn/sdks/deep-dives/sse-metadata)
 - **Testing**: Auto-generated and handwritten tests for your SDK. [Learn more](/sdks/deep-dives/testing)
 - **Code snippets**: No longer depend on manually written code snippets. [Learn more](/docs/api-references/sdk-snippets)
 - **Augment with custom code**: Extend the generated SDK with additional functionality. [Learn more](/sdks/overview/custom-code)

--- a/fern/products/sdks/deep-dives/sse-metadata.mdx
+++ b/fern/products/sdks/deep-dives/sse-metadata.mdx
@@ -51,3 +51,50 @@ Each event exposes the parsed data alongside its protocol fields. Default iterat
 ## Stream resumption
 
 The event ID is useful for resuming a stream via the standard `Last-Event-ID` header: store the last received ID as you iterate, then pass it back to the server on reconnection. This requires server-side support for the `Last-Event-ID` header.
+
+## Automatic reconnection
+
+Mark an SSE endpoint [`resumable`](/learn/api-definitions/openapi/endpoints/sse#resumable-streams) in your API definition (`x-fern-streaming.resumable: true` in OpenAPI, or `response-stream.resumable: true` in a Fern Definition) to have the SDK handle resumption for you. On a mid-stream drop, the SDK reconnects transparently, resending the last dispatched event ID in the `Last-Event-ID` header so iteration continues without gaps. No manual event-ID tracking is required.
+
+Reconnection honors the server's `retry:` directive for the reconnect delay, falling back to a 1-second default and capped at 30 seconds. The SDK retries up to 5 consecutive times by default; the counter resets whenever an event is received. Configure a [terminator](/learn/api-definitions/openapi/endpoints/sse#terminator-message) on the endpoint so the SDK can tell a completed stream from a dropped connection.
+
+Both the attempt cap and an on/off toggle are configurable per client and per request:
+
+<CodeBlocks>
+  <CodeBlock title="TypeScript">
+    ```ts {2}
+    const stream = await client.plants.stream({ query: "fern" }, {
+      stream: { reconnectionEnabled: true, maxReconnectionAttempts: 3 }
+    });
+    ```
+  </CodeBlock>
+  <CodeBlock title="Python">
+    ```python {3-4}
+    stream = client.plants.stream(
+      query="fern",
+      stream_reconnection_enabled=True,
+      max_stream_reconnection_attempts=3,
+    )
+    ```
+  </CodeBlock>
+  <CodeBlock title="Go">
+    ```go {4}
+    stream := client.Plants.Stream(
+      ctx,
+      &PlantRequest{Query: "fern"},
+      option.WithMaxStreamReconnectAttempts(3), // or option.WithoutStreamReconnection()
+    )
+    ```
+  </CodeBlock>
+  <CodeBlock title="C#">
+    ```csharp {2}
+    var stream = await client.Plants.StreamAsync(new PlantRequest { Query = "fern" }, new RequestOptions {
+      MaxStreamReconnectAttempts = 3 // set DisableStreamReconnection = true to turn off
+    });
+    ```
+  </CodeBlock>
+</CodeBlocks>
+
+<Note>
+Automatic reconnection requires TypeScript SDK generator version 3.77.0+, Python 5.15.0+, Go 1.42.0+, or C# 2.71.0+.
+</Note>


### PR DESCRIPTION
## Summary

The `resumable` flag on SSE endpoints (and the SDK auto-reconnection it enables) shipped across TypeScript, Python, Go, and C#, but nothing on the specs side or in the SDK deep-dives documented it. This adds that coverage.

**Specs side** — documents the `resumable` field on both API-definition formats:
- OpenAPI SSE page: new "Resumable streams" section covering `x-fern-streaming.resumable: true`, its interaction with `terminator`, and document-level vs. operation-level inheritance/override.
- Fern Definition SSE page: new "Resumable streams" section covering `response-stream.resumable: true`.

**Generators side** — the `sse-metadata` deep-dive previously described only *manual* stream resumption. Adds an "Automatic reconnection" section documenting the opt-in behavior (reconnect with `Last-Event-ID`, honor server `retry:` with a 1s default / 30s cap, 5-attempt consecutive cap with reset-on-progress) and the per-SDK request options:

| SDK | Toggle | Attempt cap |
|-----|--------|-------------|
| TypeScript | `stream.reconnectionEnabled` | `stream.maxReconnectionAttempts` |
| Python | `stream_reconnection_enabled` | `max_stream_reconnection_attempts` |
| Go | `option.WithoutStreamReconnection()` | `option.WithMaxStreamReconnectAttempts(n)` |
| C# | `DisableStreamReconnection` | `MaxStreamReconnectAttempts` |

**Cross-references** — the SDK capabilities SSE bullet now links to the automatic-reconnection section; the spec pages and deep-dive link to each other.

Vale passes with no new alerts (the remaining suggestions are pre-existing `simply`/`easily` hedges on untouched lines).

## Follow-up (not in this PR)

`x-fern-discriminator-context` (used for protocol- vs. data-level SSE union discrimination) is a supported extension that appears undocumented. Left out here since it's a separate, non-reconnection concern — happy to document it in a follow-up if wanted.


Link to Devin session: https://app.devin.ai/sessions/e8bc7dce89d141feadc89b5f948721aa
Requested by: @Swimburger