### PR TITLE
docs: document x-fern-discriminator-context extension

### DIFF
--- a/fern/products/api-def/api-def.yml
+++ b/fern/products/api-def/api-def.yml
@@ -51,6 +51,8 @@ navigation:
             path: ./openapi/extensions/base-path.mdx
           - page: Default values
             path: ./openapi/extensions/default.mdx
+          - page: Discriminator context
+            path: ./openapi/extensions/discriminator-context.mdx
           - page: Enum descriptions, names, and availability
             path: ./openapi/extensions/enums.mdx
             slug: enum-descriptions-and-names

--- a/fern/products/api-def/openapi/endpoints/sse.mdx
+++ b/fern/products/api-def/openapi/endpoints/sse.mdx
@@ -75,6 +75,8 @@ components:
 
 Generated SDKs expose each event's [metadata — event ID, event type, and retry interval](/learn/sdks/deep-dives/sse-metadata) to your end users.
 
+If your SSE endpoint uses the `event` field to discriminate between different event types in a `oneOf`, Fern auto-infers that the discriminator is at the protocol level. Use [`x-fern-discriminator-context`](/learn/api-definitions/openapi/extensions/discriminator-context) to override the inferred value when needed.
+
 ### Terminator message
 
 Some SSE APIs send a standalone terminator message to signal that the stream is complete. For example, 

--- a/fern/products/api-def/openapi/extensions/discriminator-context.mdx
+++ b/fern/products/api-def/openapi/extensions/discriminator-context.mdx
@@ -1,0 +1,103 @@
+---
+title: Discriminator context
+headline: Discriminator context (OpenAPI)
+description: Use `x-fern-discriminator-context` to distinguish protocol-level discriminators (such as SSE event types) from data-level discriminators embedded in the JSON payload.
+---
+
+The `x-fern-discriminator-context` extension tells Fern where a discriminated union's discriminator field lives: inside the data payload (`data`, the default) or at the protocol framing level (`protocol`). This distinction matters for SSE endpoints where the `event` field is part of the SSE protocol, not a property inside the `data` payload.
+
+| Value | Meaning |
+| --- | --- |
+| `data` | Discriminator is a property inside the JSON body (default) |
+| `protocol` | Discriminator is at the protocol level (e.g., the SSE `event` field) |
+
+Place `x-fern-discriminator-context` on the `discriminator` object of a `oneOf` schema.
+
+## Protocol-level discrimination (SSE)
+
+In the SSE protocol, the `event` field is part of the wire framing and isn't included in the parsed `data` payload. Setting `x-fern-discriminator-context: protocol` tells Fern and the generated SDKs that the discriminant lives outside the data, so they deserialize each variant's `data` without expecting the discriminant property to be present.
+
+```yaml {5} title="openapi.yml"
+components:
+  schemas:
+    StreamEvent:
+      discriminator:
+        propertyName: event
+        x-fern-discriminator-context: protocol
+        mapping:
+          completion: "#/components/schemas/CompletionEvent"
+          error: "#/components/schemas/ErrorEvent"
+      oneOf:
+        - $ref: "#/components/schemas/CompletionEvent"
+        - $ref: "#/components/schemas/ErrorEvent"
+
+    CompletionEvent:
+      type: object
+      properties:
+        content:
+          type: string
+
+    ErrorEvent:
+      type: object
+      properties:
+        message:
+          type: string
+        code:
+          type: integer
+```
+
+The corresponding SSE stream would look like:
+
+```
+event: completion
+data: {"content": "Hello"}
+
+event: error
+data: {"message": "Rate limited", "code": 429}
+```
+
+Without `x-fern-discriminator-context: protocol`, Fern would treat `event` as a field inside each variant's JSON body and expect it in the `data` payload.
+
+## Data-level discrimination (default)
+
+When `x-fern-discriminator-context` is omitted or set to `data`, the discriminator is a property inside the JSON body. This is standard OpenAPI discriminated-union behavior and requires no extension.
+
+```yaml title="openapi.yml"
+components:
+  schemas:
+    Plant:
+      discriminator:
+        propertyName: type
+        mapping:
+          tree: "#/components/schemas/Tree"
+          flower: "#/components/schemas/Flower"
+      oneOf:
+        - $ref: "#/components/schemas/Tree"
+        - $ref: "#/components/schemas/Flower"
+
+    Tree:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: ["tree"]
+        height:
+          type: number
+
+    Flower:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: ["flower"]
+        color:
+          type: string
+```
+
+## Auto-inference
+
+Fern auto-infers `protocol` context when every variant in a discriminated union uses only SSE spec fields (`event`, `data`, `id`, `retry`) with their expected types. In that case you don't need to add the extension. Use `x-fern-discriminator-context` explicitly when you want to override the inferred value or when your variant schemas don't match the SSE shape exactly.

--- a/fern/products/api-def/openapi/extensions/overview.md
+++ b/fern/products/api-def/openapi/extensions/overview.md
@@ -21,6 +21,7 @@ The table below shows all available extensions and links to detailed documentati
 | [`x-fern-availability`](./availability) | Mark availability status (beta, generally-available, deprecated) |
 | [`x-fern-base-path`](./base-path) | Set base path prepended to all endpoints |
 | [`x-fern-default`](./default-values) | Set client-side default values for path, header, and query parameters |
+| [`x-fern-discriminator-context`](./discriminator-context) | Distinguish protocol-level discriminators (e.g., SSE event types) from data-level discriminators |
 | [`x-displayName`](./tag-display-names) | Specify how tag names display in your API Reference |
 | [`x-fern-enum`](./enum-descriptions-and-names) | Add descriptions, custom names, and deprecation status to enum values |
 | [`x-fern-examples`](./request-response-examples) | Associate request and response examples |


### PR DESCRIPTION
## Summary

Documents the `x-fern-discriminator-context` OpenAPI extension, which distinguishes protocol-level discriminators (e.g., SSE `event` field) from data-level discriminators embedded in the JSON payload.

**New page** at `extensions/discriminator-context.mdx` covering:
- The two values: `data` (default, discriminator inside JSON body) and `protocol` (discriminator at protocol framing level, e.g. SSE `event`)
- Placement: on the `discriminator` object of a `oneOf` schema
- Protocol-level example with SSE stream showing `event: completion` / `event: error`
- Data-level example (standard OpenAPI behavior, no extension needed)
- Auto-inference: Fern infers `protocol` when all variants use only SSE spec fields (`event`, `data`, `id`, `retry`)

**Cross-references added:**
- Row in extensions overview table
- Entry in `api-def.yml` navigation (alphabetical, after Default values)
- Sentence on the SSE endpoints page linking to the new extension page

Link to Devin session: https://app.devin.ai/sessions/d7c50a4a976e411a9a2b162e7dc097e3
Requested by: @Swimburger