### PR TITLE
docs(csharp): reference enable-wire-tests for mock server tests config

### DIFF
--- a/fern/products/sdks/deep-dives/testing.mdx
+++ b/fern/products/sdks/deep-dives/testing.mdx
@@ -28,7 +28,7 @@ Mock server tests are available for TypeScript, Python, Go, Java, C#, PHP, Swift
 | Python | [`enable_wire_tests`](/learn/sdks/generators/python/configuration#enable_wire_tests) | false |
 | Go | [`enableWireTests`](/learn/sdks/generators/go/configuration#enablewiretests) | true |
 | Java | [`enable-wire-tests`](/learn/sdks/generators/java/configuration#enable-wire-tests) | false |
-| .NET/C# | [`generate-mock-server-tests`](/learn/sdks/generators/csharp/configuration#generate-mock-server-tests) | true |
+| .NET/C# | [`enable-wire-tests`](/learn/sdks/generators/csharp/configuration#enable-wire-tests) | true |
 | PHP | [`enable-wire-tests`](/learn/sdks/generators/php/configuration#enable-wire-tests) | false |
 | Swift | [`enableWireTests`](/learn/sdks/generators/swift/configuration#enablewiretests) | true |
 | Rust | [`enableWireTests`](/learn/sdks/generators/rust/configuration#enablewiretests) | false |

--- a/fern/products/sdks/generators/csharp/configuration.mdx
+++ b/fern/products/sdks/generators/csharp/configuration.mdx
@@ -40,6 +40,10 @@ The default timeout for network requests, in seconds. Set to `infinity` to disab
 When enabled, generates enum types that can handle unknown values. This allows the SDK to process new enum values that may be added to the API without breaking existing client code, improving forward compatibility.
 </ParamField>
 
+<ParamField path="enable-wire-tests" type="boolean" default="true" required={false} toc={true}>
+Generates [mock server (wire) tests](/learn/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
+</ParamField>
+
 <ParamField path="environment-class-name" type="string" required={false} toc={true}>
 Specifies the name of the environment configuration class used for managing different API environments (e.g., development, staging, production).
 </ParamField>
@@ -57,7 +61,7 @@ When enabled, generates specific error type classes for different API errors. Th
 </ParamField>
 
 <ParamField path="generate-mock-server-tests" type="boolean" default="true" required={false} toc={true}>
-Generates [mock server (wire) tests](/learn/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
+Alias for [`enable-wire-tests`](#enable-wire-tests), retained for backward compatibility. Generates [mock server (wire) tests](/learn/sdks/deep-dives/testing#mock-server-tests) to verify that the SDK sends and receives HTTP requests as expected.
 </ParamField>
 
 <ParamField path="include-exception-handler" type="boolean" required={false} toc={true}>

--- a/fern/translations/zh/products/sdks/deep-dives/testing.mdx
+++ b/fern/translations/zh/products/sdks/deep-dives/testing.mdx
@@ -28,7 +28,7 @@ Fern 为所有 SDK 语言生成单元测试。它们在不进行网络调用的�
 | Python | [`enable_wire_tests`](/learn/sdks/generators/python/configuration#enable_wire_tests) | false |
 | Go | [`enableWireTests`](/learn/sdks/generators/go/configuration#enablewiretests) | true |
 | Java | [`enable-wire-tests`](/learn/sdks/generators/java/configuration#enable-wire-tests) | false |
-| .NET/C# | [`generate-mock-server-tests`](/learn/sdks/generators/csharp/configuration#generate-mock-server-tests) | true |
+| .NET/C# | [`enable-wire-tests`](/learn/sdks/generators/csharp/configuration#enable-wire-tests) | true |
 | PHP | [`enable-wire-tests`](/learn/sdks/generators/php/configuration#enable-wire-tests) | false |
 | Swift | [`enableWireTests`](/learn/sdks/generators/swift/configuration#enablewiretests) | true |
 | Rust | [`enableWireTests`](/learn/sdks/generators/rust/configuration#enablewiretests) | false |

--- a/fern/translations/zh/products/sdks/generators/csharp/configuration.mdx
+++ b/fern/translations/zh/products/sdks/generators/csharp/configuration.mdx
@@ -39,6 +39,10 @@ groups:
 启用后，生成可以处理未知值的枚举类型。这允许 SDK 处理可能添加到 API 中的新枚举值，而不会破坏现有的客户端代码，提高前向兼容性。
 </ParamField>
 
+<ParamField path="enable-wire-tests" type="boolean" default="true" required={false} toc={true}>
+生成[模拟服务器（网络）测试](/learn/sdks/deep-dives/testing#mock-server-tests)以验证 SDK 按预期发送和接收 HTTP 请求。
+</ParamField>
+
 <ParamField path="environment-class-name" type="string" required={false} toc={true}>
 指定用于管理不同 API 环境（例如开发、测试、生产）的环境配置类的名称。
 </ParamField>
@@ -56,7 +60,7 @@ groups:
 </ParamField>
 
 <ParamField path="generate-mock-server-tests" type="boolean" default="true" required={false} toc={true}>
-生成[模拟服务器（网络）测试](/learn/sdks/deep-dives/testing#mock-server-tests)以验证 SDK 按预期发送和接收 HTTP 请求。
+[`enable-wire-tests`](#enable-wire-tests) 的别名，为向后兼容而保留。生成[模拟服务器（网络）测试](/learn/sdks/deep-dives/testing#mock-server-tests)以验证 SDK 按预期发送和接收 HTTP 请求。
 </ParamField>
 
 <ParamField path="include-exception-handler" type="boolean" required={false} toc={true}>


### PR DESCRIPTION
## Summary
The C# SDK's wire-test config is now primarily `enable-wire-tests`, with `generate-mock-server-tests` kept as a backward-compat alias (see C# generator changelog 2.9.8). Docs are updated to match.

- Mock server tests table in `deep-dives/testing.mdx`: `.NET/C#` row now points to `enable-wire-tests` (`#enable-wire-tests`), default `true`.
- `generators/csharp/configuration.mdx`: added an `enable-wire-tests` `ParamField` (boolean, default `true`); the existing `generate-mock-server-tests` `ParamField` is kept and its description notes it's now an alias linking to `#enable-wire-tests`.
- Applied the equivalent changes to the Chinese translations (`translations/zh/...`) to keep them in sync.

Anchors (`#enable-wire-tests`) are generated from the new `ParamField path`, so the table link resolves. Changelog files were not modified.


Link to Devin session: https://app.devin.ai/sessions/7a404cd7e5864d4390246759ef3083db
Requested by: @Swimburger