### PR TITLE
docs: same-day changelog entries to stress-test entry anchors

### DIFF
--- a/fern/products/docs/pages/changelog/2026-07-02-a.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-a.mdx
@@ -1,0 +1,9 @@
+## Bulk content import — entry A
+
+<ChangelogTags>writing-content, cli</ChangelogTags>
+
+You can now import multiple markdown pages in a single CLI command, preserving folder structure and frontmatter.
+
+> **Anchor stress test:** this entry is authored in its own file `2026-07-02-a.mdx` and shares the date `2026-07-02` with nine sibling files. Its timeline card should deep-link to `#2026-07-02-a`, not the top of the shared date page.
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/getting-started/quickstart">Read the docs</Button>

--- a/fern/products/docs/pages/changelog/2026-07-02-b.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-b.mdx
@@ -1,0 +1,18 @@
+## Nested tabs in components — entry B
+
+<ChangelogTags>components, writing-content</ChangelogTags>
+
+Tabs can now be nested inside other tabs and accordions without losing keyboard focus or breaking anchor scrolling.
+
+> **Anchor stress test:** authored in `2026-07-02-b.mdx`; expected deep-link anchor is `#2026-07-02-b`.
+
+```mdx
+<Tabs>
+  <Tab title="Outer">
+    <Tabs>
+      <Tab title="Inner A">Content</Tab>
+      <Tab title="Inner B">Content</Tab>
+    </Tabs>
+  </Tab>
+</Tabs>
+```

--- a/fern/products/docs/pages/changelog/2026-07-02-c.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-c.mdx
@@ -1,0 +1,7 @@
+## Search keyboard shortcuts — entry C
+
+<ChangelogTags>search, navigation</ChangelogTags>
+
+Press <kbd>/</kbd> to focus the search bar from anywhere, and use arrow keys plus <kbd>Enter</kbd> to jump straight to a result.
+
+> **Anchor stress test:** authored in `2026-07-02-c.mdx`; expected deep-link anchor is `#2026-07-02-c`.

--- a/fern/products/docs/pages/changelog/2026-07-02-d.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-d.mdx
@@ -1,0 +1,21 @@
+## Per-language code sample tabs — entry D
+
+<ChangelogTags>api-reference, sdks</ChangelogTags>
+
+API Reference code samples now remember the reader's last-selected language across pages, so switching to Python once keeps every endpoint on Python.
+
+> **Anchor stress test:** authored in `2026-07-02-d.mdx`; expected deep-link anchor is `#2026-07-02-d`. This is a deliberately longer entry so its timeline card has a different height than its siblings — anchor scrolling must land on this card regardless of the offset introduced by the entries above it.
+
+```python
+import petstore
+client = petstore.Client(token="...")
+client.plants.list()
+```
+
+```typescript
+import { Client } from "petstore";
+const client = new Client({ token: "..." });
+await client.plants.list();
+```
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/api-references/generate-api-ref">Read the docs</Button>

--- a/fern/products/docs/pages/changelog/2026-07-02-e.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-e.mdx
@@ -1,0 +1,7 @@
+## Redirect validation — entry E
+
+<ChangelogTags>docs.yml, cli</ChangelogTags>
+
+`fern check` now flags redirects whose destination does not resolve to a real page, catching broken `redirects` config before it ships.
+
+> **Anchor stress test:** authored in `2026-07-02-e.mdx`; expected deep-link anchor is `#2026-07-02-e`.

--- a/fern/products/docs/pages/changelog/2026-07-02-f.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-f.mdx
@@ -1,0 +1,13 @@
+## Dark-mode logo override — entry F
+
+<ChangelogTags>customization, docs.yml</ChangelogTags>
+
+You can now set a separate logo for dark mode with `logo.dark`, alongside the existing `logo.light`.
+
+> **Anchor stress test:** authored in `2026-07-02-f.mdx`; expected deep-link anchor is `#2026-07-02-f`.
+
+```yaml docs.yml
+logo:
+  light: ./logo-light.svg
+  dark: ./logo-dark.svg
+```

--- a/fern/products/docs/pages/changelog/2026-07-02-g.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-g.mdx
@@ -1,0 +1,7 @@
+## Feedback reactions — entry G
+
+<ChangelogTags>analytics</ChangelogTags>
+
+Readers can now leave a thumbs-up or thumbs-down on any page, and the aggregated reactions surface in your analytics dashboard.
+
+> **Anchor stress test:** authored in `2026-07-02-g.mdx`; expected deep-link anchor is `#2026-07-02-g`.

--- a/fern/products/docs/pages/changelog/2026-07-02-h.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-h.mdx
@@ -1,0 +1,11 @@
+## Snippet includes — entry H
+
+<ChangelogTags>writing-content, reuse</ChangelogTags>
+
+Reuse a shared markdown snippet across pages with the `<Snippet>` component, so common warnings and setup steps live in one place.
+
+> **Anchor stress test:** authored in `2026-07-02-h.mdx`; expected deep-link anchor is `#2026-07-02-h`.
+
+```mdx
+<Snippet src="/snippets/auth-warning.mdx" />
+```

--- a/fern/products/docs/pages/changelog/2026-07-02-i.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-i.mdx
@@ -1,0 +1,7 @@
+## Sticky table headers — entry I
+
+<ChangelogTags>components</ChangelogTags>
+
+Long tables now keep their header row pinned while you scroll, so column meanings stay visible in dense reference tables.
+
+> **Anchor stress test:** authored in `2026-07-02-i.mdx`; expected deep-link anchor is `#2026-07-02-i`.

--- a/fern/products/docs/pages/changelog/2026-07-02-j.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-02-j.mdx
@@ -1,0 +1,9 @@
+## Last entry of the day — entry J
+
+<ChangelogTags>navigation</ChangelogTags>
+
+This is the tenth and final same-day entry for `2026-07-02`, placed last so we can verify that deep-linking to the *bottom* card of a large same-day group still scrolls correctly.
+
+> **Anchor stress test:** authored in `2026-07-02-j.mdx`; expected deep-link anchor is `#2026-07-02-j`. Because this is the last card in a ten-entry group, its target offset is the furthest from the top of the shared date page — the strongest test that the anchor overrides the "scroll to top of page" fallback.
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/configuration/changelogs">Read the docs</Button>

--- a/fern/products/docs/pages/changelog/2026-07-03-a.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-03-a.mdx
@@ -1,0 +1,7 @@
+## Suffixed sibling of a bare date — entry A
+
+<ChangelogTags>navigation</ChangelogTags>
+
+Authored in `2026-07-03-a.mdx`, this entry shares its date with the bare `2026-07-03.mdx` file above.
+
+> **Anchor stress test:** expected deep-link anchor is `#2026-07-03-a`. Verifies that suffixed and bare files on the same date each get distinct anchors without colliding.

--- a/fern/products/docs/pages/changelog/2026-07-03-b.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-03-b.mdx
@@ -1,0 +1,7 @@
+## Suffixed sibling of a bare date — entry B
+
+<ChangelogTags>navigation</ChangelogTags>
+
+Authored in `2026-07-03-b.mdx`, the second suffixed sibling of the bare `2026-07-03.mdx` file.
+
+> **Anchor stress test:** expected deep-link anchor is `#2026-07-03-b`.

--- a/fern/products/docs/pages/changelog/2026-07-03.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-03.mdx
@@ -1,0 +1,7 @@
+## Bare date file (no suffix)
+
+<ChangelogTags>navigation</ChangelogTags>
+
+This entry uses the classic bare filename `2026-07-03.mdx`, with no `-suffix`. It shares the date `2026-07-03` with two suffixed siblings (`-a` and `-b`).
+
+> **Anchor stress test:** this is the edge case where a bare date file coexists with suffixed files on the same date. The bare file's card should still deep-link correctly to its own entry (anchor `#2026-07-03`) and not get swallowed by, or collide with, the suffixed siblings below it.

--- a/fern/products/docs/pages/changelog/2026-07-04-a.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-04-a.mdx
@@ -1,0 +1,7 @@
+## Slug-less same-day entry — entry A
+
+<ChangelogTags>writing-content</ChangelogTags>
+
+Authored in `2026-07-04-a.mdx` with no frontmatter `slug`, so it falls back to the date-derived slug and must be disambiguated by a filename anchor.
+
+> **Anchor stress test:** expected deep-link anchor is `#2026-07-04-a`. Shares the date with a slug-less sibling (`-b`) and a slug'd sibling (`-c`).

--- a/fern/products/docs/pages/changelog/2026-07-04-b.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-04-b.mdx
@@ -1,0 +1,7 @@
+## Slug-less same-day entry — entry B
+
+<ChangelogTags>writing-content</ChangelogTags>
+
+Authored in `2026-07-04-b.mdx`, also with no frontmatter `slug`.
+
+> **Anchor stress test:** expected deep-link anchor is `#2026-07-04-b`. This card and `-a` share the same date-derived slug and are separated only by their filename anchors.

--- a/fern/products/docs/pages/changelog/2026-07-04-c.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-04-c.mdx
@@ -1,0 +1,11 @@
+---
+slug: custom-slug-2026-07-04
+---
+
+## Same-day entry with an explicit frontmatter slug — entry C
+
+<ChangelogTags>writing-content, docs.yml</ChangelogTags>
+
+Authored in `2026-07-04-c.mdx` with an explicit `slug: custom-slug-2026-07-04` in frontmatter.
+
+> **Anchor stress test:** because this entry declares its own `slug`, it should be **left untouched** — it gets its own dedicated URL (`.../changelog/custom-slug-2026-07-04`) and should NOT be forced into the shared date page or given a filename-derived anchor. Verifies the slug-collision fix does not disturb entries that opt into a distinct slug, even when they share a date with slug-less siblings (`-a`, `-b`).

--- a/fern/products/docs/pages/changelog/2026-07-05-a.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-05-a.mdx
@@ -1,0 +1,19 @@
+## Multiple headings in one file — first release
+
+<ChangelogTags>navigation</ChangelogTags>
+
+This is the *old* same-day pattern: several releases authored as multiple `##` headings inside a single file (`2026-07-05-a.mdx`). This path already wired up heading anchors before the fix.
+
+> **Anchor stress test:** the entry card should deep-link to `#2026-07-05-a`, and the individual headings below should keep their own in-page heading anchors.
+
+## Multiple headings in one file — second release
+
+<ChangelogTags>navigation, search</ChangelogTags>
+
+A second `##` heading within the same file. Verifies that a file carrying multiple headings still resolves to a single entry anchor for the card while preserving per-heading anchors within the entry.
+
+## Multiple headings in one file — third release
+
+<ChangelogTags>components</ChangelogTags>
+
+A third heading, added to make this a tall entry so scroll positioning has to account for its height when linking to the separate-file sibling (`-b`) below it.

--- a/fern/products/docs/pages/changelog/2026-07-05-b.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-05-b.mdx
@@ -1,0 +1,7 @@
+## Separate file for the same day — entry B
+
+<ChangelogTags>navigation</ChangelogTags>
+
+This is the *new* same-day pattern: a distinct file (`2026-07-05-b.mdx`) sharing the date with the multi-heading file `2026-07-05-a.mdx`.
+
+> **Anchor stress test:** expected deep-link anchor is `#2026-07-05-b`. Verifies the two same-day mechanisms — multiple headings in one file (`-a`) and multiple files for one day (`-b`) — coexist and produce non-colliding anchors.

--- a/fern/products/docs/pages/changelog/2026-07-06-1.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-06-1.mdx
@@ -1,0 +1,7 @@
+## Numeric suffix — entry 1
+
+<ChangelogTags>cli</ChangelogTags>
+
+Authored in `2026-07-06-1.mdx`. Uses a numeric suffix instead of a letter.
+
+> **Anchor stress test:** expected deep-link anchor is `#2026-07-06-1`. Verifies the anchor derivation handles a purely numeric suffix (which visually resembles a date part) without truncating the date or mangling the anchor.

--- a/fern/products/docs/pages/changelog/2026-07-06-2.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-06-2.mdx
@@ -1,0 +1,7 @@
+## Numeric suffix — entry 2
+
+<ChangelogTags>cli</ChangelogTags>
+
+Authored in `2026-07-06-2.mdx`, a second numeric-suffixed sibling.
+
+> **Anchor stress test:** expected deep-link anchor is `#2026-07-06-2`.

--- a/fern/products/docs/pages/changelog/2026-07-06-feature-x.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-06-feature-x.mdx
@@ -1,0 +1,7 @@
+## Multi-word hyphenated suffix
+
+<ChangelogTags>writing-content</ChangelogTags>
+
+Authored in `2026-07-06-feature-x.mdx`. The suffix itself contains a hyphen (`feature-x`).
+
+> **Anchor stress test:** expected deep-link anchor is `#2026-07-06-feature-x`. The hardest case for the derivation regex: the date has hyphens *and* the suffix has hyphens, so the split must keep the full `feature-x` suffix intact rather than stopping at the first hyphen after the date.

--- a/fern/products/docs/pages/changelog/2026-07-06-hotfix.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-06-hotfix.mdx
@@ -1,0 +1,7 @@
+## Word suffix
+
+<ChangelogTags>cli</ChangelogTags>
+
+Authored in `2026-07-06-hotfix.mdx`, using a descriptive word as the suffix.
+
+> **Anchor stress test:** expected deep-link anchor is `#2026-07-06-hotfix`. Confirms alphabetic word suffixes work alongside numeric (`-1`, `-2`) and hyphenated (`-feature-x`) siblings on the same date.


### PR DESCRIPTION
Adds 22 changelog entries authored as **separate same-day files** (not frontmatter slugs) to stress-test the filename-derived entry anchors from [fern-platform#12914](https://github.com/fern-api/fern-platform/pull/12914). The set covers a 10-file collision on a single date (`2026-07-02-a`…`-j`), a bare date file mixed with suffixed siblings (`2026-07-03`), a same-date entry that opts into its own frontmatter `slug` alongside slug-less siblings (`2026-07-04`), coexisting "multiple headings in one file" and "multiple files per day" patterns (`2026-07-05`), and tricky suffix formats — numeric, hyphenated, and word (`2026-07-06`). Each entry self-documents its filename and expected deep-link anchor so cards can be verified against the URL hash on the rendered timeline, and card heights are deliberately varied to exercise scroll positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)