### PR TITLE
docs: password protection is now free on every plan

### DIFF
--- a/fern/products/dashboard/pages/password-protection.mdx
+++ b/fern/products/dashboard/pages/password-protection.mdx
@@ -3,9 +3,6 @@ title: Password protection
 description: Manage password protection for your documentation site from the Fern Dashboard.
 ---
 
-
-<Markdown src="/snippets/team-plan.mdx"/>
-
 Protect your published documentation site with a shared password directly from the [Fern Dashboard](https://dashboard.buildwithfern.com/). When enabled, visitors must enter the password before they can view any content. You can also set up multiple passwords for use with [RBAC](/learn/docs/authentication/features/rbac).
 
 <Note>

--- a/fern/products/docs/pages/authentication/password.mdx
+++ b/fern/products/docs/pages/authentication/password.mdx
@@ -3,9 +3,6 @@ title: Password protection
 subtitle: Gate your docs with a shared password
 ---
 
-
-<Markdown src="/snippets/team-plan.mdx"/>
-
 Password protection allows you to restrict access to your documentation site using a single shared password or multiple passwords (up to three), each mapped to a role. This is useful for pre-release documentation, internal resources, or any content you want to keep private without requiring individual user accounts. 
 
 [Set up and manage password protection](/learn/dashboard/configuration/password-protection) in the [Fern Dashboard](https://dashboard.buildwithfern.com/). If you set up multiple passwords for different user roles, then configure [RBAC](/learn/docs/authentication/features/rbac) to control which content different groups can access.


### PR DESCRIPTION
Companion to fern-api/fern-platform#13165, which grants the `password_protection` entitlement on the free plan (password protection is no longer a Team-only feature).

## Changes

Removes the "Team and Enterprise feature" warning (`/snippets/team-plan.mdx`) from the two password-protection docs, since the feature now works on every plan:

- `fern/products/dashboard/pages/password-protection.mdx`
- `fern/products/docs/pages/authentication/password.mdx`

## Left intentionally unchanged

- `fern/products/docs/pages/authentication/rbac.mdx` still notes that **password-based RBAC** (multiple passwords mapped to roles) is a Team/Enterprise feature — that's a separate entitlement and the fern-platform PR only frees the base `password_protection` entitlement.
- The shared `/snippets/team-plan.mdx` snippet is untouched (still used by PDF export, versions, products, audiences, etc.).

Generated with [Claude Code](https://claude.com/claude-code)