### PR TITLE
docs: document layout.show-nav-availability-badges

### DIFF
--- a/fern/products/docs/pages/changelog/2026-07-09.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-09.mdx
@@ -2,6 +2,6 @@
 
 <ChangelogTags>navigation, api-reference, deprecated</ChangelogTags>
 
-Availability set on a page, section, folder, or API Reference section or endpoint now shows as a badge in the sidebar navigation, so you no longer need to hardcode a status like "(Beta)" in the title. `beta`, `pre-release`, and `in-development` render a badge; `deprecated` renders a badge and strikes through the title.
+Availability set on a page, section, folder, or API Reference section or endpoint now automatically shows as a badge in the sidebar navigation, so you no longer need to hardcode a status like "(Beta)" in the title. `beta`, `pre-release`, and `in-development` render a badge; `deprecated` renders a badge and strikes through the title.
 
 <Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/configuration/navigation#availability">Read the docs</Button>

--- a/fern/products/docs/pages/changelog/2026-07-09.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-09.mdx
@@ -1,6 +1,6 @@
 ## Availability badges in the sidebar navigation
 
-<ChangelogTags>navigation, api-reference</ChangelogTags>
+<ChangelogTags>navigation, api-reference, deprecated</ChangelogTags>
 
 Availability set on a page, section, folder, or API Reference section or endpoint now shows as a badge in the sidebar navigation, so you no longer need to hardcode a status like "(Beta)" in the title. `beta`, `pre-release`, and `in-development` render a badge; `deprecated` renders a badge and strikes through the title.
 

--- a/fern/products/docs/pages/changelog/2026-07-23.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-23.mdx
@@ -1,0 +1,7 @@
+## Show availability badges in the sidebar
+
+<ChangelogTags>navigation, docs.yml</ChangelogTags>
+
+You can now render availability badges (Beta, Deprecated, etc.) inline next to navigation items in the sidebar. Set `layout.show-nav-availability-badges: true` in `docs.yml` to enable this for your site. The page-header availability badge is unaffected.
+
+<Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/configuration/navigation#availability">Read the docs</Button>

--- a/fern/products/docs/pages/changelog/2026-07-23.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-23.mdx
@@ -2,6 +2,6 @@
 
 <ChangelogTags>navigation, docs.yml</ChangelogTags>
 
-Rendering availability badges (Beta, Deprecated, etc.) inline next to navigation items in the sidebar is now opt-in rather than automatic. Set `layout.show-nav-availability-badges: true` in `docs.yml` to enable it for your site; it's off by default. The page-header availability badge is unaffected.
+Rendering availability badges (Beta, Deprecated, etc.) as a badge in the sidebar navigation is now opt-in rather than automatic. Set `layout.show-nav-availability-badges: true` in `docs.yml` to enable it for your site; it's off by default.
 
 <Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/configuration/navigation#availability">Read the docs</Button>

--- a/fern/products/docs/pages/changelog/2026-07-23.mdx
+++ b/fern/products/docs/pages/changelog/2026-07-23.mdx
@@ -2,6 +2,6 @@
 
 <ChangelogTags>navigation, docs.yml</ChangelogTags>
 
-You can now render availability badges (Beta, Deprecated, etc.) inline next to navigation items in the sidebar. Set `layout.show-nav-availability-badges: true` in `docs.yml` to enable this for your site. The page-header availability badge is unaffected.
+Rendering availability badges (Beta, Deprecated, etc.) inline next to navigation items in the sidebar is now opt-in rather than automatic. Set `layout.show-nav-availability-badges: true` in `docs.yml` to enable it for your site; it's off by default. The page-header availability badge is unaffected.
 
 <Button intent="none" outlined rightIcon="arrow-right" href="/learn/docs/configuration/navigation#availability">Read the docs</Button>

--- a/fern/products/docs/pages/navigation/navigation.mdx
+++ b/fern/products/docs/pages/navigation/navigation.mdx
@@ -217,7 +217,7 @@ Set availability badges on pages, sections, or folders to indicate their lifecyc
 | `stable` | No (default available state) |
 | `generally-available` | No (default available state) |
 
-To also render availability badges inline next to navigation items in the sidebar, set `layout.show-nav-availability-badges: true` in `docs.yml`. The default is `false`; the page-header badge is unaffected.
+To render availability badges in the sidebar navigation in addition to the page header, [set `layout.show-nav-availability-badges: true` in `docs.yml`](/learn/docs/configuration/site-level-settings#layoutshow-nav-availability-badges).
 
 Pages inherit availability from their parent section or folder unless overridden by:
 - A per-page `availability` setting in `docs.yml` (shown below)

--- a/fern/products/docs/pages/navigation/navigation.mdx
+++ b/fern/products/docs/pages/navigation/navigation.mdx
@@ -206,16 +206,18 @@ navigation:
 
 ## Availability
 
-Set availability badges on pages, sections, or folders to show their status in the sidebar next to the title, without hardcoding it in the title text. The value controls what renders in the sidebar:
+Set availability badges on pages, sections, or folders to indicate their lifecycle status. The badge is shown in the page header; the value controls the badge label and style:
 
-| Value | Sidebar badge |
-|-------|---------------|
+| Value | Badge |
+|-------|-------|
 | `beta` | Yes |
 | `pre-release` | Yes |
 | `in-development` | Yes |
-| `deprecated` | Yes, and the title is struck through |
+| `deprecated` | Yes, and the title is struck through in the sidebar |
 | `stable` | No (default available state) |
 | `generally-available` | No (default available state) |
+
+To also render availability badges inline next to navigation items in the sidebar, set `layout.show-nav-availability-badges: true` in `docs.yml`. The default is `false`; the page-header badge is unaffected.
 
 Pages inherit availability from their parent section or folder unless overridden by:
 - A per-page `availability` setting in `docs.yml` (shown below)

--- a/fern/products/docs/pages/navigation/site-level-settings.mdx
+++ b/fern/products/docs/pages/navigation/site-level-settings.mdx
@@ -584,6 +584,7 @@ layout:
   hide-nav-links: true
   hide-feedback: true
   changelog-layout: timeline
+  show-nav-availability-badges: true
 ```
 
 <ParamField path="layout.header-height" type="string" required={false} toc={true}>
@@ -653,6 +654,10 @@ layout:
   - `classic` — stacked full entries rendered inline, preserving code formatting, copy buttons, and links.
 
   Individual changelogs can override this setting with the `layout` frontmatter property in their [overview page](/learn/docs/configuration/changelogs#add-an-overview-page-optional).
+</ParamField>
+
+<ParamField path="layout.show-nav-availability-badges" type="boolean" required={false} default="false" toc={true}>
+  If set to true, availability badges (Beta, Deprecated, etc.) are rendered inline next to navigation items in the sidebar. The page-header availability badge is unaffected.
 </ParamField>
 
 ## Theme configuration

--- a/fern/products/docs/pages/navigation/site-level-settings.mdx
+++ b/fern/products/docs/pages/navigation/site-level-settings.mdx
@@ -657,7 +657,7 @@ layout:
 </ParamField>
 
 <ParamField path="layout.show-nav-availability-badges" type="boolean" required={false} default="false" toc={true}>
-  If set to true, availability badges (Beta, Deprecated, etc.) are rendered inline next to navigation items in the sidebar. The page-header availability badge is unaffected.
+  If set to true, availability badges (Beta, Deprecated, etc.) are rendered inline next to navigation items in the sidebar (in addition to the badge rendered automatically in the page header).
 </ParamField>
 
 ## Theme configuration


### PR DESCRIPTION
## Summary

Documents the `layout.show-nav-availability-badges` `docs.yml` setting introduced in CLI 5.80.0 on the [navigation availability section](/learn/docs/configuration/navigation#availability) and the [site-level layout configuration reference](/learn/docs/configuration/site-level-settings#layout-configuration), and adds a changelog entry.

### Changes

- `fern/products/docs/pages/navigation/navigation.mdx`
  - Clarifies that availability badges are shown in the page header by default.
  - Explains how to render them inline next to navigation items in the sidebar with `layout.show-nav-availability-badges: true`.

- `fern/products/docs/pages/navigation/site-level-settings.mdx`
  - Adds `layout.show-nav-availability-badges` to the layout example.
  - Adds a `<ParamField>` reference with type, default, and behavior.

- `fern/products/docs/pages/changelog/2026-07-23.mdx`
  - New docs changelog entry for the feature.

`fern check --warnings` and pre-commit both pass.

Link to Devin session: https://app.devin.ai/sessions/df29ac7384a84c54866aac72cb2b77b6
Requested by: @thesandlord