### PR TITLE
ci: add Deploy Static Docs workflow (docs-static-build container → CF Pages)

### DIFF
--- a/.github/workflows/deploy-static-docs.yml
+++ b/.github/workflows/deploy-static-docs.yml
@@ -1,0 +1,84 @@
+name: Deploy Static Docs
+
+# Renders the published docs site to static HTML and uploads it to Cloudflare
+# Pages using the public fernenterprise/docs-static-build container.
+#
+# Runs AFTER "Publish Docs" completes successfully, so the ledger manifest + CAS
+# blobs the container reads from S3 are already up to date. Also runnable
+# manually via workflow_dispatch.
+#
+# The container takes three logical inputs (see the fern-platform astro
+# package README): the docs URL, an S3 key to READ the ledger blobs, and a CF
+# Pages key to UPLOAD the built site. All are provided as GitHub secrets.
+
+# workflow_run is required so this runs after "Publish Docs" updates the ledger.
+# It's safe here: the job checks out no (untrusted) code, is granted no token
+# permissions (permissions: {}), and only runs a pinned public container with
+# read-only S3 + Cloudflare deploy credentials.
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: ["Publish Docs"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "fernenterprise/docs-static-build tag to run"
+        required: false
+        default: "latest"
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # For workflow_run: only proceed when the upstream "Publish Docs" run
+    # succeeded (a failed/cancelled publish leaves the ledger unchanged, so
+    # there's nothing new to build). workflow_dispatch runs always proceed.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Build static docs and deploy to Cloudflare Pages
+        env:
+          # 1. Docs URL — the site to build.
+          NEXT_PUBLIC_DOCS_DOMAIN: fern.docs.buildwithfern.com/learn
+          # 2. S3 key — read the published ledger manifest + CAS blobs.
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          DOCS_DEFINITION_S3_BUCKET_NAME: ${{ secrets.DOCS_DEFINITION_S3_BUCKET_NAME }}
+          CONTENT_ADDRESSABLE_FILES_S3_BUCKET_NAME: ${{ secrets.CONTENT_ADDRESSABLE_FILES_S3_BUCKET_NAME }}
+          # 3. CF Pages key — upload the built dist/ to Cloudflare Pages.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_PAGES_PROJECT: ${{ secrets.CF_PAGES_PROJECT }}
+          CF_PAGES_BRANCH: ${{ secrets.CF_PAGES_BRANCH }}
+          # Optional: used only to resolve Ask AI enablement at build time.
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}
+        run: |
+          IMAGE="fernenterprise/docs-static-build:${IMAGE_TAG}"
+          echo "Running $IMAGE for $NEXT_PUBLIC_DOCS_DOMAIN"
+          docker pull "$IMAGE"
+          # Forward each secret by name (values come from this step's env), so no
+          # secret is interpolated into the command line.
+          docker run --rm \
+            -e NEXT_PUBLIC_DOCS_DOMAIN \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e AWS_REGION \
+            -e DOCS_DEFINITION_S3_BUCKET_NAME \
+            -e CONTENT_ADDRESSABLE_FILES_S3_BUCKET_NAME \
+            -e CLOUDFLARE_API_TOKEN \
+            -e CLOUDFLARE_ACCOUNT_ID \
+            -e CF_PAGES_PROJECT \
+            -e CF_PAGES_BRANCH \
+            -e FERN_TOKEN \
+            "$IMAGE"

--- a/.github/workflows/deploy-static-docs.yml
+++ b/.github/workflows/deploy-static-docs.yml
@@ -52,9 +52,9 @@ jobs:
           # 2. S3 key — read the published ledger manifest + CAS blobs.
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          DOCS_DEFINITION_S3_BUCKET_NAME: ${{ secrets.DOCS_DEFINITION_S3_BUCKET_NAME }}
-          CONTENT_ADDRESSABLE_FILES_S3_BUCKET_NAME: ${{ secrets.CONTENT_ADDRESSABLE_FILES_S3_BUCKET_NAME }}
+          AWS_REGION: us-east-1
+          DOCS_DEFINITION_S3_BUCKET_NAME: fdr-prod-docs-definitions-public
+          CONTENT_ADDRESSABLE_FILES_S3_BUCKET_NAME: fdr-prod-content-addressable-storage
           # 3. CF Pages key — upload the built dist/ to Cloudflare Pages.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deploy-static-docs.yml`, which renders the published docs site to static HTML and uploads it to Cloudflare Pages using the public `fernenterprise/docs-static-build` container (added in fern-platform).

It runs **after** the existing `Publish Docs` workflow completes successfully — so the ledger manifest + CAS blobs the container reads from S3 are already fresh — and is also manually runnable via `workflow_dispatch` (with an `image_tag` input, default `latest`).

The container's three logical inputs. The docs URL, AWS region, and prod ledger bucket names are hardcoded; only the credentials come from GitHub secrets:

```
NEXT_PUBLIC_DOCS_DOMAIN = fern.docs.buildwithfern.com/learn          # 1. docs URL
AWS_REGION = us-east-1                                              # 2. S3: read ledger blobs
DOCS_DEFINITION_S3_BUCKET_NAME = fdr-prod-docs-definitions-public
CONTENT_ADDRESSABLE_FILES_S3_BUCKET_NAME = fdr-prod-content-addressable-storage
AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY                           # (secrets)
CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID / CF_PAGES_PROJECT     # 3. CF Pages: upload (secrets)
CF_PAGES_BRANCH (optional secret) / FERN_TOKEN (optional, Ask AI)
```

Job shape:

```yaml
on:
  workflow_run: { workflows: ["Publish Docs"], types: [completed] }
  workflow_dispatch: { inputs: { image_tag: latest } }
permissions: {}
jobs.deploy:
  if: dispatch || workflow_run.conclusion == 'success'
  run: docker pull $IMAGE && docker run --rm -e ... $IMAGE   # forwards secrets by name
```

Secrets are forwarded to the container by name (`docker run -e VAR`, values from the step `env:`) rather than interpolated into the command line, and the job requests no token permissions.

**Required repo secrets** (configure before the first run): `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `CF_PAGES_PROJECT` (optional: `CF_PAGES_BRANCH`). `FERN_TOKEN` already exists.

### Testing

- `zizmor --offline` passes (the `workflow_run` dangerous-triggers finding is suppressed inline with a safety justification: no untrusted checkout, `permissions: {}`, only runs the public container).
- YAML parses.
- End-to-end run pending the secrets being added to the repo.
</body>
</invoke>


Link to Devin session: https://app.devin.ai/sessions/91dba5ee2dda4ff198a3cc4e3b23fa51
Requested by: @thesandlord