### PR TITLE
fix: pass EDGE_CONFIG to static-docs build (hide Built-with-Fern footer badge)

### DIFF
--- a/.github/workflows/deploy-static-docs.yml
+++ b/.github/workflows/deploy-static-docs.yml
@@ -77,11 +77,13 @@ jobs:
         run: |
           IMAGE="fernenterprise/docs-static-build:${IMAGE_TAG}"
           echo "Running $IMAGE for $NEXT_PUBLIC_DOCS_DOMAIN"
-          # Loud, non-blocking guard: a missing EDGE_CONFIG secret otherwise
-          # regresses silently (edge flags default to false → "Built with Fern"
-          # badge leaks) while the workflow stays green.
+          # Hard guard: this workflow only ever builds one known-whitelabeled
+          # site (fern.docs.buildwithfern.com), so a missing EDGE_CONFIG means the
+          # edge flags default to false and the "Built with Fern" badge leaks —
+          # that's always wrong here. Fail the deploy rather than ship it green.
           if [ -z "${EDGE_CONFIG:-}" ]; then
-            echo "::warning title=EDGE_CONFIG missing::EDGE_CONFIG is empty — edge flags (whitelabel, etc.) will fall back to defaults and the 'Built with Fern' badge will leak. Set the EDGE_CONFIG repo secret."
+            echo "::error title=EDGE_CONFIG missing::EDGE_CONFIG is empty — edge flags (whitelabel, etc.) would fall back to defaults and leak the 'Built with Fern' badge. Set the EDGE_CONFIG repo secret."
+            exit 1
           fi
           docker pull "$IMAGE"
           # Forward each secret by name (values come from this step's env), so no

--- a/.github/workflows/deploy-static-docs.yml
+++ b/.github/workflows/deploy-static-docs.yml
@@ -69,13 +69,20 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           # Vercel Edge Config connection string. Read at build time to resolve
           # per-domain edge flags (e.g. `isWhitelabeled`, which hides the
-          # "Built with Fern" footer badge). Without it, getEdgeFlags fails and
-          # every flag falls back to `false`, leaking the badge onto every page.
+          # "Built with Fern" footer badge). If empty, the edge-config read
+          # returns undefined and getEdgeFlags falls back to all-false defaults,
+          # leaking the badge onto every page — see the guard in the run step.
           EDGE_CONFIG: ${{ secrets.EDGE_CONFIG }}
           IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}
         run: |
           IMAGE="fernenterprise/docs-static-build:${IMAGE_TAG}"
           echo "Running $IMAGE for $NEXT_PUBLIC_DOCS_DOMAIN"
+          # Loud, non-blocking guard: a missing EDGE_CONFIG secret otherwise
+          # regresses silently (edge flags default to false → "Built with Fern"
+          # badge leaks) while the workflow stays green.
+          if [ -z "${EDGE_CONFIG:-}" ]; then
+            echo "::warning title=EDGE_CONFIG missing::EDGE_CONFIG is empty — edge flags (whitelabel, etc.) will fall back to defaults and the 'Built with Fern' badge will leak. Set the EDGE_CONFIG repo secret."
+          fi
           docker pull "$IMAGE"
           # Forward each secret by name (values come from this step's env), so no
           # secret is interpolated into the command line.

--- a/.github/workflows/deploy-static-docs.yml
+++ b/.github/workflows/deploy-static-docs.yml
@@ -67,6 +67,11 @@ jobs:
           CF_PAGES_BRANCH: ${{ secrets.CF_PAGES_BRANCH }}
           # Optional: used only to resolve Ask AI enablement at build time.
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          # Vercel Edge Config connection string. Read at build time to resolve
+          # per-domain edge flags (e.g. `isWhitelabeled`, which hides the
+          # "Built with Fern" footer badge). Without it, getEdgeFlags fails and
+          # every flag falls back to `false`, leaking the badge onto every page.
+          EDGE_CONFIG: ${{ secrets.EDGE_CONFIG }}
           IMAGE_TAG: ${{ github.event.inputs.image_tag || 'latest' }}
         run: |
           IMAGE="fernenterprise/docs-static-build:${IMAGE_TAG}"
@@ -87,4 +92,5 @@ jobs:
             -e CF_PAGES_PROJECT \
             -e CF_PAGES_BRANCH \
             -e FERN_TOKEN \
+            -e EDGE_CONFIG \
             "$IMAGE"


### PR DESCRIPTION
## Problem
The static Astro build of `buildwithfern.com/learn` shows the **"Built with Fern" footer badge on every page**, while the Vercel-served docs correctly hide it (fern.docs is whitelabeled).

## Root cause
The `docs-static-build` container renders with `astro build`, which resolves per-domain edge flags via `getEdgeFlags(domain)` → `process.env.EDGE_CONFIG`. This workflow never passed `EDGE_CONFIG`, so the read returns `undefined` and `getEdgeFlags` falls back to **all-false defaults** — including `isWhitelabeled`, which gates the badge. (Note: `getEdgeFlags` never throws.)

## Change
Pass `EDGE_CONFIG` to the container (env ref + `-e` forward) + a loud non-blocking `::warning::` when the secret is empty (so a missing secret can't silently regress the badge). No product code change.

## Required before merge
`EDGE_CONFIG` repo secret — **set** ✅ (`gh secret set EDGE_CONFIG --repo fern-api/docs`).

## Blast-radius check (dumped the edge-config store `ecfg_lp1z4a…` for both domains)
Turning on edge reads only affects flags where the domain is actually listed. For `buildwithfern.com`:
- **whitelabeled**: listed → `isWhitelabeled` false→**true** (the intended badge fix). ✅
- **seo-disabled / seo-enabled**: in neither list. `getSeoDisabled("buildwithfern.com")` = `true` **both with and without** `EDGE_CONFIG` (driven by the `!isCustomDomain` fallback, unchanged) → **no re-deindex**. ✅
- **trailing-slash**: list is `["uploadcare.com"]` — neither fern domain → **no URL change**. ✅
- **changelog-classic / discriminated-union / prefetch**: all `false` for both domains → no change. ✅

Net: the *only* behavioral change from this PR is `isWhitelabeled` (the badge). Verified via direct `getEdgeFlags`/`getSeoDisabled` probes against the store.

## Pairs with fern-platform#13430 (both required)
That PR makes the loader resolve edge flags against the public host (`buildwithfern.com`), which this `EDGE_CONFIG` then lets it read. Badge only drops once both land + the image is republished.

## Follow-up (out of scope)
Pin `fernenterprise/docs-static-build` by digest instead of `:latest` for supply-chain hardening (pre-existing; conflicts with the current `image_tag` input flow).