### PR TITLE
fix(footer): give footer links accessible names and clear 4.5:1 contrast

### DIFF
--- a/fern/components/FernFooter.tsx
+++ b/fern/components/FernFooter.tsx
@@ -166,7 +166,7 @@ function FernStatusWidget() {
         }} />
         <span style={{
           fontSize: '0.875rem',
-          color: 'var(--grayscale-10)',
+          color: 'var(--grayscale-a11)',
           fontWeight: 400,
         }}>{status.statusMessage}</span>
       </div>
@@ -229,7 +229,7 @@ export default function FernFooter() {
 
         .fern-cf-status-text {
           font-size: 0.875rem;
-          color: var(--grayscale-10);
+          color: var(--grayscale-a11);
           font-weight: 400;
         }
 
@@ -283,10 +283,13 @@ export default function FernFooter() {
           min-width: 120px;
         }
 
+        /* Rendered as a div, not a heading, so the footer does not break the
+           page's heading order; keeps the heading font of the previous markup. */
         .fern-cf-column-title {
+          font-family: var(--typography-heading-font-family, var(--font-heading));
           font-size: 0.875rem;
           font-weight: 400;
-          color: var(--grayscale-9);
+          color: var(--grayscale-a12);
           letter-spacing: -0.025em;
         }
 
@@ -327,7 +330,7 @@ export default function FernFooter() {
         .fern-cf-bottom-text {
           font-weight: 400;
           font-size: 0.875rem;
-          color: var(--grayscale-10);
+          color: var(--grayscale-a11);
           text-decoration: none;
           transition: color 0.15s ease-in-out;
           width: fit-content;
@@ -410,7 +413,7 @@ export default function FernFooter() {
 
       <footer className="fern-cf">
         <div className="fern-cf-top">
-          <a className="fern-cf-logo" href="https://buildwithfern.com">
+          <a className="fern-cf-logo" href="https://buildwithfern.com" aria-label="Built with Fern">
             <span className="fern-cf-light">
               <BuiltWithFernLight className="fern-cf-logo-img" />
             </span>
@@ -436,7 +439,7 @@ export default function FernFooter() {
 
           <div className="fern-cf-columns">
             <div className="fern-cf-column">
-              <h4 className="fern-cf-column-title">Documentation</h4>
+              <div className="fern-cf-column-title">Documentation</div>
               <div className="fern-cf-column-links">
                 <a href="/learn/sdks/overview/introduction" className="fern-cf-link">SDKs</a>
                 <a href="/learn/docs/getting-started/overview" className="fern-cf-link">Docs</a>
@@ -446,7 +449,7 @@ export default function FernFooter() {
             </div>
 
             <div className="fern-cf-column">
-              <h4 className="fern-cf-column-title">API Definitions</h4>
+              <div className="fern-cf-column-title">API Definitions</div>
               <div className="fern-cf-column-links">
                 <a href="/learn/api-definitions/openapi/overview" className="fern-cf-link">OpenAPI</a>
                 <a href="/learn/api-definitions/asyncapi/overview" className="fern-cf-link">AsyncAPI</a>
@@ -456,7 +459,7 @@ export default function FernFooter() {
             </div>
 
             <div className="fern-cf-column">
-              <h4 className="fern-cf-column-title">Resources</h4>
+              <div className="fern-cf-column-title">Resources</div>
               <div className="fern-cf-column-links">
                 <a href="https://buildwithfern.com/blog" className="fern-cf-link">Blog</a>
                 <a href="/learn/home#get-support" className="fern-cf-link">Support</a>
@@ -465,7 +468,7 @@ export default function FernFooter() {
             </div>
 
             <div className="fern-cf-column">
-              <h4 className="fern-cf-column-title">Company</h4>
+              <div className="fern-cf-column-title">Company</div>
               <div className="fern-cf-column-links">
                 <a href="https://brandfetch.com/buildwithfern.com" className="fern-cf-link">Brand Kit</a>
                 <a href="https://buildwithfern.com/privacy-policy" className="fern-cf-link">Privacy Policy</a>
@@ -474,15 +477,15 @@ export default function FernFooter() {
             </div>
 
             <div className="fern-cf-socials">
-              <a href="https://github.com/fern-api/fern" className="fern-cf-link">
+              <a href="https://github.com/fern-api/fern" className="fern-cf-link" aria-label="Fern on GitHub">
                 <span className="fern-cf-light"><GitHubIcon color="#62636C" className="fern-cf-social-icon" /></span>
                 <span className="fern-cf-dark"><GitHubIcon color="#B2B3BD" className="fern-cf-social-icon" /></span>
               </a>
-              <a href="https://x.com/buildwithfern" className="fern-cf-link">
+              <a href="https://x.com/buildwithfern" className="fern-cf-link" aria-label="Fern on X">
                 <span className="fern-cf-light"><XIcon color="#62636C" className="fern-cf-social-icon" /></span>
                 <span className="fern-cf-dark"><XIcon color="#B2B3BD" className="fern-cf-social-icon" /></span>
               </a>
-              <a href="https://www.linkedin.com/company/buildwithfern" className="fern-cf-link">
+              <a href="https://www.linkedin.com/company/buildwithfern" className="fern-cf-link" aria-label="Fern on LinkedIn">
                 <span className="fern-cf-light"><LinkedInIcon color="#62636C" className="fern-cf-social-icon" /></span>
                 <span className="fern-cf-dark"><LinkedInIcon color="#B2B3BD" className="fern-cf-social-icon" /></span>
               </a>


### PR DESCRIPTION
## Summary

`FernFooter.tsx` accounts for 2 of the 3 accessibility failures on the docs site (Lighthouse Accessibility 90 on https://fern.static.ferndocs.dev/learn/docs/configuration/overview): `link-name` (weight 7) and `color-contrast` (weight 7).

- **`link-name`** — the "Built with Fern" logo link and the GitHub / X / LinkedIn icon links contain only SVGs, so they had no accessible name. Added `aria-label`s ("Built with Fern", "Fern on GitHub", "Fern on X", "Fern on LinkedIn").
- **`color-contrast`** — text on `--grayscale-10` / `--grayscale-9` measured **3.82:1** (light) and **4.45:1** (dark), both under 4.5:1. Measured the actual resolved token values on the live site instead of guessing:

  | token | light on `#fff` | dark on `#111113` |
  |---|---|---|
  | `--grayscale-9` | 3.34:1 | 3.68:1 |
  | `--grayscale-10` / `a10` | 3.82:1 | 4.45:1 |
  | `--grayscale-a11` | **5.93:1** | **9.08:1** |
  | `--grayscale-a12` | **16.27:1** | **16.27:1** |

  So: status pill text, `.fern-cf-status-text` (SOC2) and `.fern-cf-bottom-text` (copyright) → `--grayscale-a11`; `.fern-cf-column-title` → `--grayscale-a12`.
- **`heading-order`** — the four column titles were `<h4>`s in the footer, which follow the page's `<h2>`/`<h3>`s. axe only surfaced the bundle's bottom-nav `<h4>` first; once that is fixed ([fern-platform#13943](https://github.com/fern-api/fern-platform/pull/13943)) these become the next violation, so they are now `<div className="fern-cf-column-title">`. `<h4>` was picking up the theme's heading font, so the rule now sets `font-family: var(--typography-heading-font-family, var(--font-heading))` to keep the rendering identical.

Verified with axe-core 4.13 (`color-contrast`, `link-name`, `heading-order`) against the live site with these changes applied in-page, in both themes: light went 8 → 1 contrast nodes, dark 7 → 0, `link-name` 4 → 0, `heading-order` 1 → 0. The one remaining light-mode node is unrelated to the footer (the active sidebar link's accent-green label, `#008300` on `#e6f8e4`, 4.45:1) and is left alone.

Footer, after (light / dark):

![footer light](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19zYmRpcnN4enl4dGN0emFqL2U0M2YwYTFiLTNkNjgtNDBiYi1iOWFmLTdkYTI3MzE5OWQ1ZiIsImlhdCI6MTc4NjY1OTE3NywiZXhwIjoxNzg3MjYzOTc3LCJmaWxlbmFtZSI6ImZvb3Rlci1saWdodC1hZnRlci5wbmcifQ.toLAGedYV4wsZJCBOJKPNRko_nVaCSMuSjJgxfrmwo0)
![footer dark](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfc2JkaXJzeHp5eHRjdHphaiIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19zYmRpcnN4enl4dGN0emFqL2M1MjkzYThmLThkN2MtNGJiYy04NmEwLTBlNzc5MGQ5ODRlNiIsImlhdCI6MTc4NjY1OTE3NywiZXhwIjoxNzg3MjYzOTc3LCJmaWxlbmFtZSI6ImZvb3Rlci1kYXJrLWFmdGVyLnBuZyJ9.r5nGQ3BmNS3ldLd29utgE-wwWVrHQ02yOFcYA24iZhw)


Link to Devin session: https://app.devin.ai/sessions/ce2264ed01724b329f20ffa88eb8543f
Requested by: @thesandlord