### PR TITLE
Refresh CSS selectors reference: fix sigils, current changelog selectors, complete generated index

### DIFF
--- a/fern/products/docs/pages/customization/css-selectors.mdx
+++ b/fern/products/docs/pages/customization/css-selectors.mdx
@@ -2808,408 +2808,414 @@ Changelog entry label.
 
 The sections of this page document the most commonly customized selectors in detail. The table below is the complete set of stable `fern-*` selectors present in the rendered docs, generated from the Fern docs source. Any `fern-*` selector not in the table doesn't exist in the rendered site.
 
-<SearchableTable>
-| Selector | Type |
-|----------|------|
-| `.fern-accordion` | Class |
-| `.fern-accordion-item` | Class |
-| `.fern-accordion-trigger` | Class |
-| `.fern-accordion-trigger-arrow` | Class |
-| `.fern-accordion-trigger-title` | Class |
-| `.fern-air` | Class |
-| `.fern-analytics-ga` | Class |
-| `.fern-analytics-gtm` | Class |
-| `.fern-analytics-segment` | Class |
-| `.fern-anchor` | Class |
-| `.fern-anchor-icon` | Class |
-| `#fern-announcement` | ID |
-| `.fern-announcement-dismissed` | Class |
-| `.fern-api-property` | Class |
-| `.fern-api-property-constraint` | Class |
-| `.fern-api-property-default` | Class |
-| `.fern-api-property-header` | Class |
-| `.fern-api-property-key` | Class |
-| `.fern-api-property-meta` | Class |
-| `.fern-api-property-optional` | Class |
-| `.fern-api-property-readonly` | Class |
-| `.fern-api-property-required` | Class |
-| `.fern-api-property-type` | Class |
-| `#fern-ask-ai-button` | ID |
-| `#fern-ask-ai-button-icon` | ID |
-| `#fern-ask-ai-panel` | ID |
-| `#fern-ask-ai-panel-header` | ID |
-| `#fern-ask-ai-panel-header-icon` | ID |
-| `#fern-ask-ai-panel-input` | ID |
-| `.fern-audio-player` | Class |
-| `#fern-auth-button` | ID |
-| `.fern-back-to-top` | Class |
-| `.fern-background-image` | Class |
-| `.fern-bleed` | Class |
-| `.fern-breadcrumb` | Class |
-| `.fern-breadcrumb-arrow` | Class |
-| `.fern-breadcrumb-item` | Class |
-| `.fern-button` | Class |
-| `.fern-button-content` | Class |
-| `.fern-button-group` | Class |
-| `.fern-button-text` | Class |
-| `.fern-callout` | Class |
-| `.fern-card` | Class |
-| `.fern-card-group` | Class |
-| `.fern-changelog-card` | Class |
-| `.fern-changelog-card-body` | Class |
-| `.fern-changelog-card-excerpt` | Class |
-| `.fern-changelog-card-link` | Class |
-| `.fern-changelog-card-marker` | Class |
-| `.fern-changelog-card-preview` | Class |
-| `.fern-changelog-card-tags` | Class |
-| `.fern-changelog-card-title` | Class |
-| `.fern-changelog-content` | Class |
-| `.fern-changelog-controls` | Class |
-| `.fern-changelog-controls-row` | Class |
-| `.fern-changelog-day` | Class |
-| `.fern-changelog-day-entries` | Class |
-| `.fern-changelog-day-group` | Class |
-| `.fern-changelog-empty` | Class |
-| `.fern-changelog-feed` | Class |
-| `.fern-changelog-highlight` | Class |
-| `.fern-changelog-highlight-style` | Class |
-| `.fern-changelog-label` | Class |
-| `.fern-changelog-overview` | Class |
-| `.fern-changelog-search` | Class |
-| `.fern-changelog-tags` | Class |
-| `.fern-changelog-timeline` | Class |
-| `.fern-checkbox-indicator` | Class |
-| `.fern-checkbox-item` | Class |
-| `.fern-checkbox-label` | Class |
-| `.fern-code` | Class |
-| `.fern-code-actions` | Class |
-| `.fern-code-block` | Class |
-| `.fern-code-block-actions` | Class |
-| `.fern-code-block-content` | Class |
-| `.fern-code-block-header` | Class |
-| `.fern-code-block-header-inner` | Class |
-| `.fern-code-block-title` | Class |
-| `.fern-code-block-title-label` | Class |
-| `.fern-code-content` | Class |
-| `.fern-code-group` | Class |
-| `.fern-code-group-actions` | Class |
-| `.fern-code-group-content` | Class |
-| `.fern-code-group-header` | Class |
-| `.fern-code-group-header-inner` | Class |
-| `.fern-code-group-tab` | Class |
-| `.fern-code-group-tab-label` | Class |
-| `.fern-code-group-tabs` | Class |
-| `.fern-code-header` | Class |
-| `.fern-code-header-inner` | Class |
-| `.fern-code-label` | Class |
-| `.fern-code-link` | Class |
-| `.fern-collapse-trigger` | Class |
-| `.fern-collapsible` | Class |
-| `.fern-collapsible-card` | Class |
-| `.fern-collapsible-card-nested` | Class |
-| `.fern-collapsible-card-print-truncated` | Class |
-| `.fern-collapsible-child` | Class |
-| `.fern-copy-button` | Class |
-| `.fern-copy-inline` | Class |
-| `.fern-dashboard` | Class |
-| `.fern-docs-badge` | Class |
-| `.fern-docs-feedback` | Class |
-| `.fern-docs-static` | Class |
-| `.fern-docs-track-analytics` | Class |
-| `.fern-dropdown` | Class |
-| `.fern-dropdown-checkmark` | Class |
-| `.fern-dropdown-item` | Class |
-| `.fern-dropdown-item-indicator` | Class |
-| `.fern-endpoint-code-snippets` | Class |
-| `.fern-endpoint-request-snippet` | Class |
-| `.fern-endpoint-response-snippet` | Class |
-| `.fern-endpoint-section-auth` | Class |
-| `.fern-endpoint-section-errors` | Class |
-| `.fern-endpoint-section-headers` | Class |
-| `.fern-endpoint-section-path-parameters` | Class |
-| `.fern-endpoint-section-query-parameters` | Class |
-| `.fern-endpoint-section-request-body` | Class |
-| `.fern-endpoint-section-response-body` | Class |
-| `.fern-endpoint-section-response-headers` | Class |
-| `.fern-endpoint-selector` | Class |
-| `.fern-env-switcher` | Class |
-| `.fern-expand-button` | Class |
-| `.fern-explorer-auth-form` | Class |
-| `.fern-explorer-clear-form-button` | Class |
-| `.fern-explorer-endpoint-form` | Class |
-| `.fern-explorer-example-selector` | Class |
-| `.fern-explorer-form` | Class |
-| `.fern-explorer-form-buttons` | Class |
-| `.fern-explorer-request-card` | Class |
-| `.fern-explorer-request-header` | Class |
-| `.fern-explorer-request-title` | Class |
-| `.fern-explorer-response-card` | Class |
-| `.fern-explorer-response-header` | Class |
-| `.fern-explorer-response-title` | Class |
-| `.fern-explorer-section-body` | Class |
-| `.fern-explorer-section-body-parameters` | Class |
-| `.fern-explorer-section-content` | Class |
-| `.fern-explorer-section-header` | Class |
-| `.fern-explorer-section-headers` | Class |
-| `.fern-explorer-section-multipart-form` | Class |
-| `.fern-explorer-section-parameters` | Class |
-| `.fern-explorer-section-path-parameters` | Class |
-| `.fern-explorer-section-query-parameters` | Class |
-| `.fern-explorer-send-request-button` | Class |
-| `.fern-feedback-button` | Class |
-| `.fern-file-icon` | Class |
-| `.fern-filter-badge` | Class |
-| `.fern-filter-badge-selected` | Class |
-| `.fern-filter-badge-unselected` | Class |
-| `.fern-filter-dropdown-button` | Class |
-| `.fern-filter-dropdown-button-content` | Class |
-| `.fern-filter-dropdown-button-icon` | Class |
-| `.fern-filter-dropdown-button-text` | Class |
-| `.fern-filter-dropdown-item` | Class |
-| `#fern-footer` | ID |
-| `.fern-footer-nav` | Class |
-| `.fern-footer-nav--simple` | Class |
-| `.fern-footer-next` | Class |
-| `.fern-footer-prev` | Class |
-| `.fern-ground` | Class |
-| `#fern-header` | ID |
-| `.fern-header-content` | Class |
-| `.fern-header-height` | Class |
-| `.fern-header-logo-container` | Class |
-| `.fern-header-mobile-menu-button` | Class |
-| `.fern-header-navbar-links` | Class |
-| `.fern-header-search-bar` | Class |
-| `.fern-header-selectors` | Class |
-| `.fern-header-switchers` | Class |
-| `.fern-header-switchers-separator` | Class |
-| `.fern-header-tabs` | Class |
-| `.fern-highlight` | Class |
-| `.fern-image-loader` | Class |
-| `.fern-indent` | Class |
-| `.fern-input` | Class |
-| `.fern-input-clear-button` | Class |
-| `.fern-input-group` | Class |
-| `.fern-input-icon` | Class |
-| `.fern-input-right-element` | Class |
-| `.fern-kbd` | Class |
-| `.fern-language-dropdown-content` | Class |
-| `.fern-language-dropdown-item` | Class |
-| `.fern-language-dropdown-item-label` | Class |
-| `.fern-language-selector` | Class |
-| `.fern-language-selector-radio-group` | Class |
-| `.fern-layout-changelog` | Class |
-| `.fern-layout-changelog-entry` | Class |
-| `.fern-layout-content-wrapper` | Class |
-| `.fern-layout-footer` | Class |
-| `.fern-layout-footer-toolbar` | Class |
-| `.fern-layout-guide` | Class |
-| `.fern-layout-overview` | Class |
-| `.fern-layout-page` | Class |
-| `.fern-layout-reference` | Class |
-| `.fern-layout-reference-aside` | Class |
-| `.fern-layout-reference-content` | Class |
-| `.fern-logo-text` | Class |
-| `.fern-main` | Class |
-| `.fern-mdx-icon` | Class |
-| `.fern-mdx-link` | Class |
-| `.fern-mdx-tooltip-content` | Class |
-| `.fern-mdx-tooltip-trigger` | Class |
-| `.fern-mermaid` | Class |
-| `.fern-navigation-storage` | Class |
-| `.fern-not-found-shell` | Class |
-| `.fern-numeric-input-group` | Class |
-| `.fern-numeric-input-step` | Class |
-| `.fern-page-actions` | Class |
-| `.fern-page-heading` | Class |
-| `.fern-page-roles` | Class |
-| `.fern-page-subtitle` | Class |
-| `.fern-pdf-cover-date` | Class |
-| `.fern-pdf-cover-footer` | Class |
-| `.fern-pdf-cover-footer-brand` | Class |
-| `.fern-pdf-cover-root` | Class |
-| `.fern-pdf-cover-subtitle` | Class |
-| `.fern-pdf-cover-title` | Class |
-| `.fern-playground-field` | Class |
-| `.fern-playground-field-actions` | Class |
-| `.fern-playground-field-block` | Class |
-| `.fern-playground-field-control` | Class |
-| `.fern-playground-field-count` | Class |
-| `.fern-playground-field-header` | Class |
-| `.fern-playground-field-help-icon` | Class |
-| `.fern-playground-field-inline` | Class |
-| `.fern-playground-field-item` | Class |
-| `.fern-playground-field-key` | Class |
-| `.fern-playground-field-label` | Class |
-| `.fern-playground-field-list` | Class |
-| `.fern-playground-field-remove` | Class |
-| `.fern-playground-field-type` | Class |
-| `.fern-playground-floating-button` | Class |
-| `.fern-playground-object-properties` | Class |
-| `.fern-product-item` | Class |
-| `.fern-product-item-link` | Class |
-| `.fern-product-selector` | Class |
-| `.fern-product-selector-radio-group` | Class |
-| `.fern-product-tabs` | Class |
-| `.fern-product-tabs-row` | Class |
-| `.fern-programming-language` | Class |
-| `.fern-prompt` | Class |
-| `.fern-prompt-code` | Class |
-| `.fern-prompt-code-wrapper` | Class |
-| `.fern-prompt-icon` | Class |
-| `.fern-prompt-icon-wrapper` | Class |
-| `.fern-prose` | Class |
-| `.fern-radio-group` | Class |
-| `.fern-radio-indicator` | Class |
-| `.fern-radio-item` | Class |
-| `.fern-radio-label` | Class |
-| `.fern-rss-feed-button` | Class |
-| `.fern-runnable-actions` | Class |
-| `.fern-runnable-auth` | Class |
-| `.fern-runnable-auth-content` | Class |
-| `.fern-runnable-auth-fields` | Class |
-| `.fern-runnable-auth-title` | Class |
-| `.fern-runnable-auth-toggle` | Class |
-| `.fern-runnable-card` | Class |
-| `.fern-runnable-clear-button` | Class |
-| `.fern-runnable-endpoint` | Class |
-| `.fern-runnable-endpoint-values` | Class |
-| `.fern-runnable-form` | Class |
-| `.fern-runnable-form-inner` | Class |
-| `.fern-runnable-header` | Class |
-| `.fern-runnable-header-actions` | Class |
-| `.fern-runnable-header-inner` | Class |
-| `.fern-runnable-response` | Class |
-| `.fern-runnable-response-header` | Class |
-| `.fern-runnable-response-label` | Class |
-| `.fern-runnable-response-meta` | Class |
-| `.fern-runnable-response-size` | Class |
-| `.fern-runnable-response-status` | Class |
-| `.fern-runnable-response-time` | Class |
-| `.fern-runnable-section-content` | Class |
-| `.fern-runnable-section-title` | Class |
-| `.fern-runnable-send-button` | Class |
-| `.fern-scroll-area` | Class |
-| `.fern-scroll-area-corner` | Class |
-| `.fern-scroll-area-scrollbar` | Class |
-| `.fern-scroll-area-scrollbar-fade-in` | Class |
-| `.fern-scroll-area-scrollbar-fade-out` | Class |
-| `.fern-scroll-area-thumb` | Class |
-| `.fern-scroll-area-viewport` | Class |
-| `.fern-scroll-walkthrough` | Class |
-| `.fern-scroll-walkthrough-aside` | Class |
-| `.fern-scroll-walkthrough-aside-sticky` | Class |
-| `.fern-scroll-walkthrough-code` | Class |
-| `.fern-scroll-walkthrough-main` | Class |
-| `.fern-scroll-walkthrough-panel` | Class |
-| `.fern-scroll-walkthrough-panel-header` | Class |
-| `.fern-scroll-walkthrough-panel-header-inner` | Class |
-| `.fern-scroll-walkthrough-spacer` | Class |
-| `.fern-scroll-walkthrough-step-body` | Class |
-| `.fern-scroll-walkthrough-step-description` | Class |
-| `.fern-scroll-walkthrough-step-detail` | Class |
-| `.fern-scroll-walkthrough-step-head` | Class |
-| `.fern-scroll-walkthrough-step-item` | Class |
-| `.fern-scroll-walkthrough-step-marker` | Class |
-| `.fern-scroll-walkthrough-step-title` | Class |
-| `.fern-scroll-walkthrough-steps` | Class |
-| `.fern-scroll-walkthrough-substep` | Class |
-| `.fern-scroll-walkthrough-substep-body` | Class |
-| `.fern-scroll-walkthrough-substep-code` | Class |
-| `.fern-scroll-walkthrough-substep-content` | Class |
-| `.fern-scroll-walkthrough-substep-marker` | Class |
-| `.fern-scroll-walkthrough-substep-title` | Class |
-| `.fern-scroll-walkthrough-substeps` | Class |
-| `.fern-scroll-walkthrough-tab` | Class |
-| `.fern-scroll-walkthrough-tabs` | Class |
-| `#fern-search-button` | ID |
-| `.fern-search-desktop-command` | Class |
-| `#fern-search-dialog` | ID |
-| `#fern-search-dialog-overlay` | ID |
-| `.fern-search-hit-breadcrumb` | Class |
-| `.fern-search-hit-endpoint-path` | Class |
-| `.fern-search-hit-highlighted` | Class |
-| `.fern-search-hit-non-highlighted` | Class |
-| `.fern-search-hit-snippet` | Class |
-| `.fern-search-hit-title` | Class |
-| `#fern-search-mobile-command` | ID |
-| `.fern-segmented-control` | Class |
-| `.fern-selection-item` | Class |
-| `.fern-selection-item-end-icon` | Class |
-| `.fern-selection-item-icon` | Class |
-| `.fern-selection-item-subtitle` | Class |
-| `.fern-selection-item-title` | Class |
-| `#fern-sidebar` | ID |
-| `.fern-sidebar-desktop` | Class |
-| `.fern-sidebar-group` | Class |
-| `.fern-sidebar-group-level-1` | Class |
-| `.fern-sidebar-group-root` | Class |
-| `.fern-sidebar-header` | Class |
-| `.fern-sidebar-heading` | Class |
-| `.fern-sidebar-heading-content` | Class |
-| `.fern-sidebar-level-0` | Class |
-| `.fern-sidebar-link` | Class |
-| `.fern-sidebar-link-inline-badge` | Class |
-| `.fern-sidebar-link-title` | Class |
-| `.fern-sidebar-link-title-inner` | Class |
-| `.fern-sidebar-marquee` | Class |
-| `#fern-sidebar-overlay` | ID |
-| `#fern-sidebar-scroll-area` | ID |
-| `.fern-sidebar-scroll-position` | Class |
-| `#fern-sidebar-spacer` | ID |
-| `.fern-sidebar-tabs` | Class |
-| `.fern-step` | Class |
-| `.fern-steps` | Class |
-| `.fern-stream` | Class |
-| `.fern-table` | Class |
-| `.fern-table-collapse` | Class |
-| `.fern-table-pagination` | Class |
-| `.fern-table-pagination-controls` | Class |
-| `.fern-table-pagination-label` | Class |
-| `.fern-table-root` | Class |
-| `.fern-table-search` | Class |
-| `.fern-table-search-clear` | Class |
-| `.fern-table-search-icon` | Class |
-| `.fern-table-search-input` | Class |
-| `.fern-table-show-all` | Class |
-| `.fern-textarea` | Class |
-| `.fern-textarea-group` | Class |
-| `#fern-theme-color` | ID |
-| `#fern-theme-color-preferred-dark` | ID |
-| `#fern-theme-color-preferred-light` | ID |
-| `#fern-toc` | ID |
-| `.fern-token` | Class |
-| `.fern-toolbar` | Class |
-| `.fern-user` | Class |
-| `.fern-variant-selector` | Class |
-| `.fern-variant-selector-dropdown` | Class |
-| `.fern-variant-selector-radio-group` | Class |
-| `.fern-version-selector` | Class |
-| `.fern-version-selector-radio-group` | Class |
-| `.fern-walkthrough` | Class |
-| `.fern-walkthrough-aside` | Class |
-| `.fern-walkthrough-aside-sticky` | Class |
-| `.fern-walkthrough-close` | Class |
-| `.fern-walkthrough-control` | Class |
-| `.fern-walkthrough-controls` | Class |
-| `.fern-walkthrough-frame` | Class |
-| `.fern-walkthrough-progress` | Class |
-| `.fern-walkthrough-step` | Class |
-| `.fern-walkthrough-step-body` | Class |
-| `.fern-walkthrough-step-description` | Class |
-| `.fern-walkthrough-step-item` | Class |
-| `.fern-walkthrough-step-number` | Class |
-| `.fern-walkthrough-step-title` | Class |
-| `.fern-walkthrough-steps` | Class |
-| `.fern-walkthrough-toolbar` | Class |
-| `.fern-web-socket-badge` | Class |
-| `.fern-web-socket-chevron` | Class |
-| `.fern-web-socket-client` | Class |
-| `.fern-web-socket-content` | Class |
-| `.fern-web-socket-copy` | Class |
-| `.fern-web-socket-end-sample` | Class |
-| `.fern-web-socket-server` | Class |
-| `.fern-web-socket-trigger` | Class |
-| `.fern-web-socket-trigger-data` | Class |
-| `.fern-web-socket-type` | Class |
-| `.fern-x-overflow` | Class |
-</SearchableTable>
+<table sticky searchable paginate pageSize={25} className="fern-table" placeholder="Search selectors...">
+  <thead>
+    <tr>
+      <th>Selector</th>
+      <th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td><code>.fern-accordion</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-accordion-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-accordion-trigger</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-accordion-trigger-arrow</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-accordion-trigger-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-air</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-analytics-ga</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-analytics-gtm</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-analytics-segment</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-anchor</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-anchor-icon</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-announcement</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-announcement-dismissed</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property-constraint</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property-default</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property-key</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property-meta</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property-optional</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property-readonly</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property-required</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-api-property-type</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-ask-ai-button</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-ask-ai-button-icon</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-ask-ai-panel</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-ask-ai-panel-header</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-ask-ai-panel-header-icon</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-ask-ai-panel-input</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-audio-player</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-auth-button</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-back-to-top</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-background-image</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-bleed</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-breadcrumb</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-breadcrumb-arrow</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-breadcrumb-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-button-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-button-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-button-text</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-callout</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-card</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-card-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-card</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-card-body</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-card-excerpt</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-card-link</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-card-marker</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-card-preview</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-card-tags</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-card-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-controls</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-controls-row</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-day</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-day-entries</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-day-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-empty</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-feed</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-highlight</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-highlight-style</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-overview</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-search</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-tags</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-changelog-timeline</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-checkbox-indicator</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-checkbox-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-checkbox-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-actions</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-block</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-block-actions</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-block-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-block-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-block-header-inner</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-block-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-block-title-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-group-actions</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-group-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-group-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-group-header-inner</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-group-tab</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-group-tab-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-group-tabs</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-header-inner</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-code-link</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-collapse-trigger</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-collapsible</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-collapsible-card</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-collapsible-card-nested</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-collapsible-card-print-truncated</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-collapsible-child</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-copy-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-copy-inline</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-dashboard</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-docs-badge</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-docs-feedback</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-docs-static</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-docs-track-analytics</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-dropdown</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-dropdown-checkmark</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-dropdown-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-dropdown-item-indicator</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-code-snippets</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-request-snippet</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-response-snippet</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-section-auth</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-section-errors</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-section-headers</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-section-path-parameters</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-section-query-parameters</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-section-request-body</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-section-response-body</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-section-response-headers</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-endpoint-selector</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-env-switcher</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-expand-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-auth-form</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-clear-form-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-endpoint-form</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-example-selector</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-form</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-form-buttons</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-request-card</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-request-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-request-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-response-card</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-response-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-response-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-section-body</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-section-body-parameters</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-section-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-section-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-section-headers</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-section-multipart-form</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-section-parameters</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-section-path-parameters</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-section-query-parameters</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-explorer-send-request-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-feedback-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-file-icon</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-filter-badge</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-filter-badge-selected</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-filter-badge-unselected</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-filter-dropdown-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-filter-dropdown-button-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-filter-dropdown-button-icon</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-filter-dropdown-button-text</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-filter-dropdown-item</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-footer</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-footer-nav</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-footer-nav--simple</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-footer-next</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-footer-prev</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-ground</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-header</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-header-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-header-height</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-header-logo-container</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-header-mobile-menu-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-header-navbar-links</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-header-search-bar</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-header-selectors</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-header-switchers</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-header-switchers-separator</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-header-tabs</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-highlight</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-image-loader</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-indent</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-input</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-input-clear-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-input-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-input-icon</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-input-right-element</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-kbd</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-language-dropdown-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-language-dropdown-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-language-dropdown-item-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-language-selector</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-language-selector-radio-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-changelog</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-changelog-entry</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-content-wrapper</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-footer</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-footer-toolbar</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-guide</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-overview</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-page</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-reference</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-reference-aside</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-layout-reference-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-logo-text</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-main</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-mdx-icon</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-mdx-link</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-mdx-tooltip-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-mdx-tooltip-trigger</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-mermaid</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-navigation-storage</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-not-found-shell</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-numeric-input-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-numeric-input-step</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-page-actions</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-page-heading</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-page-roles</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-page-subtitle</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-pdf-cover-date</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-pdf-cover-footer</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-pdf-cover-footer-brand</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-pdf-cover-root</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-pdf-cover-subtitle</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-pdf-cover-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-actions</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-block</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-control</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-count</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-help-icon</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-inline</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-key</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-list</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-remove</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-field-type</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-floating-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-playground-object-properties</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-product-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-product-item-link</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-product-selector</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-product-selector-radio-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-product-tabs</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-product-tabs-row</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-programming-language</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-prompt</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-prompt-code</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-prompt-code-wrapper</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-prompt-icon</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-prompt-icon-wrapper</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-prose</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-radio-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-radio-indicator</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-radio-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-radio-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-rss-feed-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-actions</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-auth</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-auth-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-auth-fields</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-auth-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-auth-toggle</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-card</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-clear-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-endpoint</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-endpoint-values</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-form</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-form-inner</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-header-actions</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-header-inner</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-response</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-response-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-response-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-response-meta</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-response-size</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-response-status</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-response-time</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-section-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-section-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-runnable-send-button</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-area</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-area-corner</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-area-scrollbar</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-area-scrollbar-fade-in</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-area-scrollbar-fade-out</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-area-thumb</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-area-viewport</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-aside</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-aside-sticky</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-code</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-main</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-panel</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-panel-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-panel-header-inner</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-spacer</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-step-body</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-step-description</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-step-detail</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-step-head</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-step-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-step-marker</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-step-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-steps</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-substep</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-substep-body</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-substep-code</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-substep-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-substep-marker</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-substep-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-substeps</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-tab</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-scroll-walkthrough-tabs</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-search-button</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-search-desktop-command</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-search-dialog</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-search-dialog-overlay</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-search-hit-breadcrumb</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-search-hit-endpoint-path</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-search-hit-highlighted</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-search-hit-non-highlighted</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-search-hit-snippet</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-search-hit-title</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-search-mobile-command</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-segmented-control</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-selection-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-selection-item-end-icon</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-selection-item-icon</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-selection-item-subtitle</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-selection-item-title</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-sidebar</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-sidebar-desktop</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-group-level-1</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-group-root</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-header</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-heading</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-heading-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-level-0</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-link</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-link-inline-badge</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-link-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-link-title-inner</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-sidebar-marquee</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-sidebar-overlay</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-sidebar-scroll-area</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-sidebar-scroll-position</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-sidebar-spacer</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-sidebar-tabs</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-step</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-steps</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-stream</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-collapse</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-pagination</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-pagination-controls</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-pagination-label</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-root</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-search</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-search-clear</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-search-icon</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-search-input</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-table-show-all</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-textarea</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-textarea-group</code></td><td>Class</td></tr>
+    <tr><td><code>#fern-theme-color</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-theme-color-preferred-dark</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-theme-color-preferred-light</code></td><td>ID</td></tr>
+    <tr><td><code>#fern-toc</code></td><td>ID</td></tr>
+    <tr><td><code>.fern-token</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-toolbar</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-user</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-variant-selector</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-variant-selector-dropdown</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-variant-selector-radio-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-version-selector</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-version-selector-radio-group</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-aside</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-aside-sticky</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-close</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-control</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-controls</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-frame</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-progress</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-step</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-step-body</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-step-description</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-step-item</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-step-number</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-step-title</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-steps</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-walkthrough-toolbar</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-badge</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-chevron</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-client</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-content</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-copy</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-end-sample</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-server</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-trigger</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-trigger-data</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-web-socket-type</code></td><td>Class</td></tr>
+    <tr><td><code>.fern-x-overflow</code></td><td>Class</td></tr>
+  </tbody>
+</table>

--- a/fern/products/docs/pages/customization/css-selectors.mdx
+++ b/fern/products/docs/pages/customization/css-selectors.mdx
@@ -7,8 +7,6 @@ max-toc-depth: 3
 
 Fern selectors use Tailwind CSS utilities and CSS custom properties. This page is a reference of the stable `fern-*` selectors for customizing your documentation site.
 
-Most hooks are classes (like `.fern-card`), but the page chrome elements are element `id`s: `#fern-header`, `#fern-sidebar`, `#fern-toc`, and `#fern-footer`. The [complete selector index](#complete-selector-index) at the bottom lists every stable selector, generated from the Fern docs source.
-
 ## Layout and structure
 
 Selectors for page layout, backgrounds, and headings.

--- a/fern/products/docs/pages/customization/css-selectors.mdx
+++ b/fern/products/docs/pages/customization/css-selectors.mdx
@@ -5,7 +5,9 @@ max-toc-depth: 3
 ---
 
 
-Fern selectors use Tailwind CSS utilities and CSS custom properties. This page is a reference of all `.fern-*` selectors for customizing your documentation site.
+Fern selectors use Tailwind CSS utilities and CSS custom properties. This page is a reference of the stable `fern-*` selectors for customizing your documentation site.
+
+Most hooks are classes (like `.fern-card`), but the page chrome elements are element `id`s: `#fern-header`, `#fern-sidebar`, `#fern-toc`, and `#fern-footer`. Only target selectors that appear on this page — a stylesheet that targets a `fern-*` selector that doesn't exist in the rendered site loads without errors and styles nothing. The [complete selector index](#complete-selector-index) at the bottom lists every stable selector, generated from the Fern docs source.
 
 ## Layout and structure
 
@@ -180,14 +182,21 @@ Changelog page layout.
 Selectors for the site header, tabs, and mobile menu.
 
 <AccordionGroup>
-<Accordion title=".fern-header">
+<Accordion title="#fern-header">
 
-Site header container.
+Site header container. The header is an element `id`, not a class — target `#fern-header`, not `.fern-header`.
 
 ```css Default CSS
-.fern-header {
-  backdrop-filter: blur(0.5rem);
-  background-color: transparent;
+#fern-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 30;
+  pointer-events: auto;
+  border-bottom: 1px solid var(--border-concealed);
+  background-color: var(--header-background);
+  backdrop-filter: blur(16px);
 }
 ```
 
@@ -2581,90 +2590,176 @@ Next page link.
 
 ## Changelog components
 
-Selectors for [changelog pages](/learn/docs/configuration/changelogs).
+Selectors for [changelog pages](/learn/docs/configuration/changelogs). The changelog overview renders a feed: a control bar (search and tag filters) above a vertical timeline of entry cards grouped by day. The page layout container is `.fern-layout-changelog` (documented under [Layout and structure](#layout-and-structure)).
 
 <AccordionGroup>
-<Accordion title=".fern-changelog">
+<Accordion title=".fern-changelog-feed">
 
-Changelog page container.
+Centered column that holds the changelog header, control bar, and timeline.
 
 ```css Default CSS
-.fern-changelog {
-  display: flex;
-  justify-content: space-between;
-  padding-left: 1rem;
-  padding-right: 1rem;
-}
-
-@media (min-width: 768px) {
-  .fern-changelog {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-  }
-}
-
-@media (min-width: 1024px) {
-  .fern-changelog {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-}
-
-.fern-changelog > main {
+.fern-changelog-feed {
+  width: var(--content-wide-width);
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
-  width: 100%;
-  max-width: 1024px;
-  word-wrap: break-word;
-}
-```
-
-**Variants:**
-- `.full-width` - Full-width layout with sidebar date display
-
-</Accordion>
-
-<Accordion title=".fern-changelog-entry">
-
-Changelog entry.
-
-```css Default CSS
-.fern-changelog-entry {
   display: flex;
-  align-items: stretch;
-}
-
-.fern-changelog-entry:is(article) {
-  padding-top: 2rem;
-  padding-bottom: 2rem;
-}
-
-@media (min-width: 1024px) {
-  .fern-changelog-entry:is(article) {
-    padding-top: 4rem;
-    padding-bottom: 4rem;
-  }
+  flex-direction: column;
+  gap: 2rem;
 }
 ```
 
 </Accordion>
 
-<Accordion title=".fern-changelog-date">
+<Accordion title=".fern-changelog-controls">
 
-Changelog date.
+Control bar with the full-text search and tag filter. Inner elements: `.fern-changelog-controls-row` and `.fern-changelog-search`.
 
 ```css Default CSS
-.fern-changelog-date {
-  color: var(--grayscale-a11);
-  font-size: 1rem;
-  margin-bottom: 2rem;
+.fern-changelog-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--grayscale-a4);
 }
 
-@media (min-width: 1024px) {
-  .fern-changelog.full-width .fern-changelog-entry > aside .fern-changelog-date {
-    position: sticky;
-    top: calc(var(--header-height) + 1rem);
-  }
+.fern-changelog-controls-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.fern-changelog-search {
+  min-width: 0;
+  flex: 1 1 0%;
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-changelog-timeline">
+
+Vertical timeline: a left date gutter beside a rail of entry cards. Entries are grouped per day into `.fern-changelog-day-group`, with the date in `.fern-changelog-day` and that day's cards in `.fern-changelog-day-entries`.
+
+```css Default CSS
+.fern-changelog-timeline {
+  display: flex;
+  flex-direction: column;
+}
+
+.fern-changelog-day-group {
+  display: flex;
+  gap: 1rem;
+}
+
+.fern-changelog-day {
+  color: var(--grayscale-a11);
+  width: 6rem;
+  flex-shrink: 0;
+  align-self: flex-start;
+  padding-top: 1.25rem;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  position: sticky;
+  top: calc(var(--fern-changelog-sticky-top, var(--spacing-header-height-padded)) + 0.5rem);
+}
+
+.fern-changelog-day-entries {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 0%;
+  flex-direction: column;
+  border-left: 1px solid var(--grayscale-a4);
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-changelog-card">
+
+A single clickable changelog entry card in the timeline. Inner elements: `.fern-changelog-card-marker` (timeline dot), `.fern-changelog-card-body`, `.fern-changelog-card-title`, `.fern-changelog-card-link`, `.fern-changelog-card-excerpt`, `.fern-changelog-card-preview` (rich MDX preview), and `.fern-changelog-card-tags`.
+
+```css Default CSS
+.fern-changelog-card {
+  position: relative;
+  border-radius: var(--radius-3);
+  padding: 1.25rem 1rem 1.25rem 1.5rem;
+  transition: color, background-color;
+}
+
+.fern-changelog-card:hover {
+  background-color: var(--grayscale-a2);
+}
+
+.fern-changelog-card-marker {
+  position: absolute;
+  left: 0;
+  top: 2rem;
+  width: 0.625rem;
+  height: 0.625rem;
+  transform: translate(-50%, -50%);
+  border-radius: 9999px;
+  background-color: var(--grayscale-6);
+}
+
+.fern-changelog-card:hover .fern-changelog-card-marker {
+  background-color: var(--accent);
+}
+
+.fern-changelog-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.fern-changelog-card-title {
+  margin: 0;
+  color: var(--grayscale-a12);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.fern-changelog-card-excerpt {
+  margin: 0;
+  color: var(--grayscale-a11);
+  font-size: 0.875rem;
+  line-height: 1.625;
+}
+```
+
+</Accordion>
+
+<Accordion title=".fern-changelog-tags">
+
+Tag chips as rendered inside a full changelog entry page. In the timeline cards the chips render in `.fern-changelog-card-tags`. Search matches are highlighted with `.fern-changelog-highlight`, and `.fern-changelog-empty` shows when no entries match the active filters.
+
+```css Default CSS
+.fern-changelog-tags {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.fern-changelog-highlight {
+  background-color: var(--accent-a3);
+  color: var(--accent-a11);
+  border-radius: var(--radius-1);
+}
+
+.fern-changelog-empty {
+  color: var(--grayscale-a11);
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+  text-align: center;
+  font-size: 0.875rem;
 }
 ```
 
@@ -2681,7 +2776,7 @@ Changelog content area.
   margin-right: auto;
   display: grid;
   width: 100%;
-  max-width: var(--content-wide-width);
+  max-width: var(--content-width);
   grid-template-columns: 1fr;
   gap: 1rem;
 }
@@ -2710,3 +2805,420 @@ Changelog entry label.
 
 </Accordion>
 </AccordionGroup>
+
+## Complete selector index
+
+The sections above document the most commonly customized selectors in detail. The list below is the complete set of stable `fern-*` selectors present in the rendered docs, generated from the Fern docs source.
+
+Any `fern-*` selector not in this list doesn't exist in the rendered site. Mind the sigil: entries beginning with `#` are element `id`s; everything else is a class.
+
+### IDs
+
+```css
+#fern-announcement
+#fern-ask-ai-button
+#fern-ask-ai-button-icon
+#fern-ask-ai-panel
+#fern-ask-ai-panel-header
+#fern-ask-ai-panel-header-icon
+#fern-ask-ai-panel-input
+#fern-auth-button
+#fern-footer
+#fern-header
+#fern-search-button
+#fern-search-dialog
+#fern-search-dialog-overlay
+#fern-search-mobile-command
+#fern-sidebar
+#fern-sidebar-overlay
+#fern-sidebar-scroll-area
+#fern-sidebar-spacer
+#fern-theme-color
+#fern-theme-color-preferred-dark
+#fern-theme-color-preferred-light
+#fern-toc
+```
+
+### Classes
+
+```css
+.fern-accordion
+.fern-accordion-item
+.fern-accordion-trigger
+.fern-accordion-trigger-arrow
+.fern-accordion-trigger-title
+.fern-air
+.fern-analytics-ga
+.fern-analytics-gtm
+.fern-analytics-segment
+.fern-anchor
+.fern-anchor-icon
+.fern-announcement-dismissed
+.fern-api-property
+.fern-api-property-constraint
+.fern-api-property-default
+.fern-api-property-header
+.fern-api-property-key
+.fern-api-property-meta
+.fern-api-property-optional
+.fern-api-property-readonly
+.fern-api-property-required
+.fern-api-property-type
+.fern-audio-player
+.fern-back-to-top
+.fern-background-image
+.fern-bleed
+.fern-breadcrumb
+.fern-breadcrumb-arrow
+.fern-breadcrumb-item
+.fern-button
+.fern-button-content
+.fern-button-group
+.fern-button-text
+.fern-callout
+.fern-card
+.fern-card-group
+.fern-changelog-card
+.fern-changelog-card-body
+.fern-changelog-card-excerpt
+.fern-changelog-card-link
+.fern-changelog-card-marker
+.fern-changelog-card-preview
+.fern-changelog-card-tags
+.fern-changelog-card-title
+.fern-changelog-content
+.fern-changelog-controls
+.fern-changelog-controls-row
+.fern-changelog-day
+.fern-changelog-day-entries
+.fern-changelog-day-group
+.fern-changelog-empty
+.fern-changelog-feed
+.fern-changelog-highlight
+.fern-changelog-highlight-style
+.fern-changelog-label
+.fern-changelog-overview
+.fern-changelog-search
+.fern-changelog-tags
+.fern-changelog-timeline
+.fern-checkbox-indicator
+.fern-checkbox-item
+.fern-checkbox-label
+.fern-code
+.fern-code-actions
+.fern-code-block
+.fern-code-block-actions
+.fern-code-block-content
+.fern-code-block-header
+.fern-code-block-header-inner
+.fern-code-block-title
+.fern-code-block-title-label
+.fern-code-content
+.fern-code-group
+.fern-code-group-actions
+.fern-code-group-content
+.fern-code-group-header
+.fern-code-group-header-inner
+.fern-code-group-tab
+.fern-code-group-tab-label
+.fern-code-group-tabs
+.fern-code-header
+.fern-code-header-inner
+.fern-code-label
+.fern-code-link
+.fern-collapse-trigger
+.fern-collapsible
+.fern-collapsible-card
+.fern-collapsible-card-nested
+.fern-collapsible-card-print-truncated
+.fern-collapsible-child
+.fern-copy-button
+.fern-copy-inline
+.fern-dashboard
+.fern-docs-badge
+.fern-docs-feedback
+.fern-docs-static
+.fern-docs-track-analytics
+.fern-dropdown
+.fern-dropdown-checkmark
+.fern-dropdown-item
+.fern-dropdown-item-indicator
+.fern-endpoint-code-snippets
+.fern-endpoint-request-snippet
+.fern-endpoint-response-snippet
+.fern-endpoint-section-auth
+.fern-endpoint-section-errors
+.fern-endpoint-section-headers
+.fern-endpoint-section-path-parameters
+.fern-endpoint-section-query-parameters
+.fern-endpoint-section-request-body
+.fern-endpoint-section-response-body
+.fern-endpoint-section-response-headers
+.fern-endpoint-selector
+.fern-env-switcher
+.fern-expand-button
+.fern-explorer-auth-form
+.fern-explorer-clear-form-button
+.fern-explorer-endpoint-form
+.fern-explorer-example-selector
+.fern-explorer-form
+.fern-explorer-form-buttons
+.fern-explorer-request-card
+.fern-explorer-request-header
+.fern-explorer-request-title
+.fern-explorer-response-card
+.fern-explorer-response-header
+.fern-explorer-response-title
+.fern-explorer-section-body
+.fern-explorer-section-body-parameters
+.fern-explorer-section-content
+.fern-explorer-section-header
+.fern-explorer-section-headers
+.fern-explorer-section-multipart-form
+.fern-explorer-section-parameters
+.fern-explorer-section-path-parameters
+.fern-explorer-section-query-parameters
+.fern-explorer-send-request-button
+.fern-feedback-button
+.fern-file-icon
+.fern-filter-badge
+.fern-filter-badge-selected
+.fern-filter-badge-unselected
+.fern-filter-dropdown-button
+.fern-filter-dropdown-button-content
+.fern-filter-dropdown-button-icon
+.fern-filter-dropdown-button-text
+.fern-filter-dropdown-item
+.fern-footer-nav
+.fern-footer-nav--simple
+.fern-footer-next
+.fern-footer-prev
+.fern-ground
+.fern-header-content
+.fern-header-height
+.fern-header-logo-container
+.fern-header-mobile-menu-button
+.fern-header-navbar-links
+.fern-header-search-bar
+.fern-header-selectors
+.fern-header-switchers
+.fern-header-switchers-separator
+.fern-header-tabs
+.fern-highlight
+.fern-image-loader
+.fern-indent
+.fern-input
+.fern-input-clear-button
+.fern-input-group
+.fern-input-icon
+.fern-input-right-element
+.fern-kbd
+.fern-language-dropdown-content
+.fern-language-dropdown-item
+.fern-language-dropdown-item-label
+.fern-language-selector
+.fern-language-selector-radio-group
+.fern-layout-changelog
+.fern-layout-changelog-entry
+.fern-layout-content-wrapper
+.fern-layout-footer
+.fern-layout-footer-toolbar
+.fern-layout-guide
+.fern-layout-overview
+.fern-layout-page
+.fern-layout-reference
+.fern-layout-reference-aside
+.fern-layout-reference-content
+.fern-logo-text
+.fern-main
+.fern-mdx-icon
+.fern-mdx-link
+.fern-mdx-tooltip-content
+.fern-mdx-tooltip-trigger
+.fern-mermaid
+.fern-navigation-storage
+.fern-not-found-shell
+.fern-numeric-input-group
+.fern-numeric-input-step
+.fern-page-actions
+.fern-page-heading
+.fern-page-roles
+.fern-page-subtitle
+.fern-pdf-cover-date
+.fern-pdf-cover-footer
+.fern-pdf-cover-footer-brand
+.fern-pdf-cover-root
+.fern-pdf-cover-subtitle
+.fern-pdf-cover-title
+.fern-playground-field
+.fern-playground-field-actions
+.fern-playground-field-block
+.fern-playground-field-control
+.fern-playground-field-count
+.fern-playground-field-header
+.fern-playground-field-help-icon
+.fern-playground-field-inline
+.fern-playground-field-item
+.fern-playground-field-key
+.fern-playground-field-label
+.fern-playground-field-list
+.fern-playground-field-remove
+.fern-playground-field-type
+.fern-playground-floating-button
+.fern-playground-object-properties
+.fern-product-item
+.fern-product-item-link
+.fern-product-selector
+.fern-product-selector-radio-group
+.fern-product-tabs
+.fern-product-tabs-row
+.fern-programming-language
+.fern-prompt
+.fern-prompt-code
+.fern-prompt-code-wrapper
+.fern-prompt-icon
+.fern-prompt-icon-wrapper
+.fern-prose
+.fern-radio-group
+.fern-radio-indicator
+.fern-radio-item
+.fern-radio-label
+.fern-rss-feed-button
+.fern-runnable-actions
+.fern-runnable-auth
+.fern-runnable-auth-content
+.fern-runnable-auth-fields
+.fern-runnable-auth-title
+.fern-runnable-auth-toggle
+.fern-runnable-card
+.fern-runnable-clear-button
+.fern-runnable-endpoint
+.fern-runnable-endpoint-values
+.fern-runnable-form
+.fern-runnable-form-inner
+.fern-runnable-header
+.fern-runnable-header-actions
+.fern-runnable-header-inner
+.fern-runnable-response
+.fern-runnable-response-header
+.fern-runnable-response-label
+.fern-runnable-response-meta
+.fern-runnable-response-size
+.fern-runnable-response-status
+.fern-runnable-response-time
+.fern-runnable-section-content
+.fern-runnable-section-title
+.fern-runnable-send-button
+.fern-scroll-area
+.fern-scroll-area-corner
+.fern-scroll-area-scrollbar
+.fern-scroll-area-scrollbar-fade-in
+.fern-scroll-area-scrollbar-fade-out
+.fern-scroll-area-thumb
+.fern-scroll-area-viewport
+.fern-scroll-walkthrough
+.fern-scroll-walkthrough-aside
+.fern-scroll-walkthrough-aside-sticky
+.fern-scroll-walkthrough-code
+.fern-scroll-walkthrough-main
+.fern-scroll-walkthrough-panel
+.fern-scroll-walkthrough-panel-header
+.fern-scroll-walkthrough-panel-header-inner
+.fern-scroll-walkthrough-spacer
+.fern-scroll-walkthrough-step-body
+.fern-scroll-walkthrough-step-description
+.fern-scroll-walkthrough-step-detail
+.fern-scroll-walkthrough-step-head
+.fern-scroll-walkthrough-step-item
+.fern-scroll-walkthrough-step-marker
+.fern-scroll-walkthrough-step-title
+.fern-scroll-walkthrough-steps
+.fern-scroll-walkthrough-substep
+.fern-scroll-walkthrough-substep-body
+.fern-scroll-walkthrough-substep-code
+.fern-scroll-walkthrough-substep-content
+.fern-scroll-walkthrough-substep-marker
+.fern-scroll-walkthrough-substep-title
+.fern-scroll-walkthrough-substeps
+.fern-scroll-walkthrough-tab
+.fern-scroll-walkthrough-tabs
+.fern-search-desktop-command
+.fern-search-hit-breadcrumb
+.fern-search-hit-endpoint-path
+.fern-search-hit-highlighted
+.fern-search-hit-non-highlighted
+.fern-search-hit-snippet
+.fern-search-hit-title
+.fern-segmented-control
+.fern-selection-item
+.fern-selection-item-end-icon
+.fern-selection-item-icon
+.fern-selection-item-subtitle
+.fern-selection-item-title
+.fern-sidebar-desktop
+.fern-sidebar-group
+.fern-sidebar-group-level-1
+.fern-sidebar-group-root
+.fern-sidebar-header
+.fern-sidebar-heading
+.fern-sidebar-heading-content
+.fern-sidebar-level-0
+.fern-sidebar-link
+.fern-sidebar-link-inline-badge
+.fern-sidebar-link-title
+.fern-sidebar-link-title-inner
+.fern-sidebar-marquee
+.fern-sidebar-scroll-position
+.fern-sidebar-tabs
+.fern-step
+.fern-steps
+.fern-stream
+.fern-table
+.fern-table-collapse
+.fern-table-pagination
+.fern-table-pagination-controls
+.fern-table-pagination-label
+.fern-table-root
+.fern-table-search
+.fern-table-search-clear
+.fern-table-search-icon
+.fern-table-search-input
+.fern-table-show-all
+.fern-textarea
+.fern-textarea-group
+.fern-token
+.fern-toolbar
+.fern-user
+.fern-variant-selector
+.fern-variant-selector-dropdown
+.fern-variant-selector-radio-group
+.fern-version-selector
+.fern-version-selector-radio-group
+.fern-walkthrough
+.fern-walkthrough-aside
+.fern-walkthrough-aside-sticky
+.fern-walkthrough-close
+.fern-walkthrough-control
+.fern-walkthrough-controls
+.fern-walkthrough-frame
+.fern-walkthrough-progress
+.fern-walkthrough-step
+.fern-walkthrough-step-body
+.fern-walkthrough-step-description
+.fern-walkthrough-step-item
+.fern-walkthrough-step-number
+.fern-walkthrough-step-title
+.fern-walkthrough-steps
+.fern-walkthrough-toolbar
+.fern-web-socket-badge
+.fern-web-socket-chevron
+.fern-web-socket-client
+.fern-web-socket-content
+.fern-web-socket-copy
+.fern-web-socket-end-sample
+.fern-web-socket-server
+.fern-web-socket-trigger
+.fern-web-socket-trigger-data
+.fern-web-socket-type
+.fern-x-overflow
+```

--- a/fern/products/docs/pages/customization/css-selectors.mdx
+++ b/fern/products/docs/pages/customization/css-selectors.mdx
@@ -184,7 +184,7 @@ Selectors for the site header, tabs, and mobile menu.
 <AccordionGroup>
 <Accordion title="#fern-header">
 
-Site header container. The header is an element `id`, not a class — target `#fern-header`, not `.fern-header`.
+Site header container.
 
 ```css Default CSS
 #fern-header {

--- a/fern/products/docs/pages/customization/css-selectors.mdx
+++ b/fern/products/docs/pages/customization/css-selectors.mdx
@@ -7,7 +7,7 @@ max-toc-depth: 3
 
 Fern selectors use Tailwind CSS utilities and CSS custom properties. This page is a reference of the stable `fern-*` selectors for customizing your documentation site.
 
-Most hooks are classes (like `.fern-card`), but the page chrome elements are element `id`s: `#fern-header`, `#fern-sidebar`, `#fern-toc`, and `#fern-footer`. Only target selectors that appear on this page — a stylesheet that targets a `fern-*` selector that doesn't exist in the rendered site loads without errors and styles nothing. The [complete selector index](#complete-selector-index) at the bottom lists every stable selector, generated from the Fern docs source.
+Most hooks are classes (like `.fern-card`), but the page chrome elements are element `id`s: `#fern-header`, `#fern-sidebar`, `#fern-toc`, and `#fern-footer`. The [complete selector index](#complete-selector-index) at the bottom lists every stable selector, generated from the Fern docs source.
 
 ## Layout and structure
 

--- a/fern/products/docs/pages/customization/css-selectors.mdx
+++ b/fern/products/docs/pages/customization/css-selectors.mdx
@@ -2808,417 +2808,410 @@ Changelog entry label.
 
 ## Complete selector index
 
-The sections above document the most commonly customized selectors in detail. The list below is the complete set of stable `fern-*` selectors present in the rendered docs, generated from the Fern docs source.
+The sections of this page document the most commonly customized selectors in detail. The table below is the complete set of stable `fern-*` selectors present in the rendered docs, generated from the Fern docs source. Any `fern-*` selector not in the table doesn't exist in the rendered site.
 
-Any `fern-*` selector not in this list doesn't exist in the rendered site. Mind the sigil: entries beginning with `#` are element `id`s; everything else is a class.
-
-### IDs
-
-```css
-#fern-announcement
-#fern-ask-ai-button
-#fern-ask-ai-button-icon
-#fern-ask-ai-panel
-#fern-ask-ai-panel-header
-#fern-ask-ai-panel-header-icon
-#fern-ask-ai-panel-input
-#fern-auth-button
-#fern-footer
-#fern-header
-#fern-search-button
-#fern-search-dialog
-#fern-search-dialog-overlay
-#fern-search-mobile-command
-#fern-sidebar
-#fern-sidebar-overlay
-#fern-sidebar-scroll-area
-#fern-sidebar-spacer
-#fern-theme-color
-#fern-theme-color-preferred-dark
-#fern-theme-color-preferred-light
-#fern-toc
-```
-
-### Classes
-
-```css
-.fern-accordion
-.fern-accordion-item
-.fern-accordion-trigger
-.fern-accordion-trigger-arrow
-.fern-accordion-trigger-title
-.fern-air
-.fern-analytics-ga
-.fern-analytics-gtm
-.fern-analytics-segment
-.fern-anchor
-.fern-anchor-icon
-.fern-announcement-dismissed
-.fern-api-property
-.fern-api-property-constraint
-.fern-api-property-default
-.fern-api-property-header
-.fern-api-property-key
-.fern-api-property-meta
-.fern-api-property-optional
-.fern-api-property-readonly
-.fern-api-property-required
-.fern-api-property-type
-.fern-audio-player
-.fern-back-to-top
-.fern-background-image
-.fern-bleed
-.fern-breadcrumb
-.fern-breadcrumb-arrow
-.fern-breadcrumb-item
-.fern-button
-.fern-button-content
-.fern-button-group
-.fern-button-text
-.fern-callout
-.fern-card
-.fern-card-group
-.fern-changelog-card
-.fern-changelog-card-body
-.fern-changelog-card-excerpt
-.fern-changelog-card-link
-.fern-changelog-card-marker
-.fern-changelog-card-preview
-.fern-changelog-card-tags
-.fern-changelog-card-title
-.fern-changelog-content
-.fern-changelog-controls
-.fern-changelog-controls-row
-.fern-changelog-day
-.fern-changelog-day-entries
-.fern-changelog-day-group
-.fern-changelog-empty
-.fern-changelog-feed
-.fern-changelog-highlight
-.fern-changelog-highlight-style
-.fern-changelog-label
-.fern-changelog-overview
-.fern-changelog-search
-.fern-changelog-tags
-.fern-changelog-timeline
-.fern-checkbox-indicator
-.fern-checkbox-item
-.fern-checkbox-label
-.fern-code
-.fern-code-actions
-.fern-code-block
-.fern-code-block-actions
-.fern-code-block-content
-.fern-code-block-header
-.fern-code-block-header-inner
-.fern-code-block-title
-.fern-code-block-title-label
-.fern-code-content
-.fern-code-group
-.fern-code-group-actions
-.fern-code-group-content
-.fern-code-group-header
-.fern-code-group-header-inner
-.fern-code-group-tab
-.fern-code-group-tab-label
-.fern-code-group-tabs
-.fern-code-header
-.fern-code-header-inner
-.fern-code-label
-.fern-code-link
-.fern-collapse-trigger
-.fern-collapsible
-.fern-collapsible-card
-.fern-collapsible-card-nested
-.fern-collapsible-card-print-truncated
-.fern-collapsible-child
-.fern-copy-button
-.fern-copy-inline
-.fern-dashboard
-.fern-docs-badge
-.fern-docs-feedback
-.fern-docs-static
-.fern-docs-track-analytics
-.fern-dropdown
-.fern-dropdown-checkmark
-.fern-dropdown-item
-.fern-dropdown-item-indicator
-.fern-endpoint-code-snippets
-.fern-endpoint-request-snippet
-.fern-endpoint-response-snippet
-.fern-endpoint-section-auth
-.fern-endpoint-section-errors
-.fern-endpoint-section-headers
-.fern-endpoint-section-path-parameters
-.fern-endpoint-section-query-parameters
-.fern-endpoint-section-request-body
-.fern-endpoint-section-response-body
-.fern-endpoint-section-response-headers
-.fern-endpoint-selector
-.fern-env-switcher
-.fern-expand-button
-.fern-explorer-auth-form
-.fern-explorer-clear-form-button
-.fern-explorer-endpoint-form
-.fern-explorer-example-selector
-.fern-explorer-form
-.fern-explorer-form-buttons
-.fern-explorer-request-card
-.fern-explorer-request-header
-.fern-explorer-request-title
-.fern-explorer-response-card
-.fern-explorer-response-header
-.fern-explorer-response-title
-.fern-explorer-section-body
-.fern-explorer-section-body-parameters
-.fern-explorer-section-content
-.fern-explorer-section-header
-.fern-explorer-section-headers
-.fern-explorer-section-multipart-form
-.fern-explorer-section-parameters
-.fern-explorer-section-path-parameters
-.fern-explorer-section-query-parameters
-.fern-explorer-send-request-button
-.fern-feedback-button
-.fern-file-icon
-.fern-filter-badge
-.fern-filter-badge-selected
-.fern-filter-badge-unselected
-.fern-filter-dropdown-button
-.fern-filter-dropdown-button-content
-.fern-filter-dropdown-button-icon
-.fern-filter-dropdown-button-text
-.fern-filter-dropdown-item
-.fern-footer-nav
-.fern-footer-nav--simple
-.fern-footer-next
-.fern-footer-prev
-.fern-ground
-.fern-header-content
-.fern-header-height
-.fern-header-logo-container
-.fern-header-mobile-menu-button
-.fern-header-navbar-links
-.fern-header-search-bar
-.fern-header-selectors
-.fern-header-switchers
-.fern-header-switchers-separator
-.fern-header-tabs
-.fern-highlight
-.fern-image-loader
-.fern-indent
-.fern-input
-.fern-input-clear-button
-.fern-input-group
-.fern-input-icon
-.fern-input-right-element
-.fern-kbd
-.fern-language-dropdown-content
-.fern-language-dropdown-item
-.fern-language-dropdown-item-label
-.fern-language-selector
-.fern-language-selector-radio-group
-.fern-layout-changelog
-.fern-layout-changelog-entry
-.fern-layout-content-wrapper
-.fern-layout-footer
-.fern-layout-footer-toolbar
-.fern-layout-guide
-.fern-layout-overview
-.fern-layout-page
-.fern-layout-reference
-.fern-layout-reference-aside
-.fern-layout-reference-content
-.fern-logo-text
-.fern-main
-.fern-mdx-icon
-.fern-mdx-link
-.fern-mdx-tooltip-content
-.fern-mdx-tooltip-trigger
-.fern-mermaid
-.fern-navigation-storage
-.fern-not-found-shell
-.fern-numeric-input-group
-.fern-numeric-input-step
-.fern-page-actions
-.fern-page-heading
-.fern-page-roles
-.fern-page-subtitle
-.fern-pdf-cover-date
-.fern-pdf-cover-footer
-.fern-pdf-cover-footer-brand
-.fern-pdf-cover-root
-.fern-pdf-cover-subtitle
-.fern-pdf-cover-title
-.fern-playground-field
-.fern-playground-field-actions
-.fern-playground-field-block
-.fern-playground-field-control
-.fern-playground-field-count
-.fern-playground-field-header
-.fern-playground-field-help-icon
-.fern-playground-field-inline
-.fern-playground-field-item
-.fern-playground-field-key
-.fern-playground-field-label
-.fern-playground-field-list
-.fern-playground-field-remove
-.fern-playground-field-type
-.fern-playground-floating-button
-.fern-playground-object-properties
-.fern-product-item
-.fern-product-item-link
-.fern-product-selector
-.fern-product-selector-radio-group
-.fern-product-tabs
-.fern-product-tabs-row
-.fern-programming-language
-.fern-prompt
-.fern-prompt-code
-.fern-prompt-code-wrapper
-.fern-prompt-icon
-.fern-prompt-icon-wrapper
-.fern-prose
-.fern-radio-group
-.fern-radio-indicator
-.fern-radio-item
-.fern-radio-label
-.fern-rss-feed-button
-.fern-runnable-actions
-.fern-runnable-auth
-.fern-runnable-auth-content
-.fern-runnable-auth-fields
-.fern-runnable-auth-title
-.fern-runnable-auth-toggle
-.fern-runnable-card
-.fern-runnable-clear-button
-.fern-runnable-endpoint
-.fern-runnable-endpoint-values
-.fern-runnable-form
-.fern-runnable-form-inner
-.fern-runnable-header
-.fern-runnable-header-actions
-.fern-runnable-header-inner
-.fern-runnable-response
-.fern-runnable-response-header
-.fern-runnable-response-label
-.fern-runnable-response-meta
-.fern-runnable-response-size
-.fern-runnable-response-status
-.fern-runnable-response-time
-.fern-runnable-section-content
-.fern-runnable-section-title
-.fern-runnable-send-button
-.fern-scroll-area
-.fern-scroll-area-corner
-.fern-scroll-area-scrollbar
-.fern-scroll-area-scrollbar-fade-in
-.fern-scroll-area-scrollbar-fade-out
-.fern-scroll-area-thumb
-.fern-scroll-area-viewport
-.fern-scroll-walkthrough
-.fern-scroll-walkthrough-aside
-.fern-scroll-walkthrough-aside-sticky
-.fern-scroll-walkthrough-code
-.fern-scroll-walkthrough-main
-.fern-scroll-walkthrough-panel
-.fern-scroll-walkthrough-panel-header
-.fern-scroll-walkthrough-panel-header-inner
-.fern-scroll-walkthrough-spacer
-.fern-scroll-walkthrough-step-body
-.fern-scroll-walkthrough-step-description
-.fern-scroll-walkthrough-step-detail
-.fern-scroll-walkthrough-step-head
-.fern-scroll-walkthrough-step-item
-.fern-scroll-walkthrough-step-marker
-.fern-scroll-walkthrough-step-title
-.fern-scroll-walkthrough-steps
-.fern-scroll-walkthrough-substep
-.fern-scroll-walkthrough-substep-body
-.fern-scroll-walkthrough-substep-code
-.fern-scroll-walkthrough-substep-content
-.fern-scroll-walkthrough-substep-marker
-.fern-scroll-walkthrough-substep-title
-.fern-scroll-walkthrough-substeps
-.fern-scroll-walkthrough-tab
-.fern-scroll-walkthrough-tabs
-.fern-search-desktop-command
-.fern-search-hit-breadcrumb
-.fern-search-hit-endpoint-path
-.fern-search-hit-highlighted
-.fern-search-hit-non-highlighted
-.fern-search-hit-snippet
-.fern-search-hit-title
-.fern-segmented-control
-.fern-selection-item
-.fern-selection-item-end-icon
-.fern-selection-item-icon
-.fern-selection-item-subtitle
-.fern-selection-item-title
-.fern-sidebar-desktop
-.fern-sidebar-group
-.fern-sidebar-group-level-1
-.fern-sidebar-group-root
-.fern-sidebar-header
-.fern-sidebar-heading
-.fern-sidebar-heading-content
-.fern-sidebar-level-0
-.fern-sidebar-link
-.fern-sidebar-link-inline-badge
-.fern-sidebar-link-title
-.fern-sidebar-link-title-inner
-.fern-sidebar-marquee
-.fern-sidebar-scroll-position
-.fern-sidebar-tabs
-.fern-step
-.fern-steps
-.fern-stream
-.fern-table
-.fern-table-collapse
-.fern-table-pagination
-.fern-table-pagination-controls
-.fern-table-pagination-label
-.fern-table-root
-.fern-table-search
-.fern-table-search-clear
-.fern-table-search-icon
-.fern-table-search-input
-.fern-table-show-all
-.fern-textarea
-.fern-textarea-group
-.fern-token
-.fern-toolbar
-.fern-user
-.fern-variant-selector
-.fern-variant-selector-dropdown
-.fern-variant-selector-radio-group
-.fern-version-selector
-.fern-version-selector-radio-group
-.fern-walkthrough
-.fern-walkthrough-aside
-.fern-walkthrough-aside-sticky
-.fern-walkthrough-close
-.fern-walkthrough-control
-.fern-walkthrough-controls
-.fern-walkthrough-frame
-.fern-walkthrough-progress
-.fern-walkthrough-step
-.fern-walkthrough-step-body
-.fern-walkthrough-step-description
-.fern-walkthrough-step-item
-.fern-walkthrough-step-number
-.fern-walkthrough-step-title
-.fern-walkthrough-steps
-.fern-walkthrough-toolbar
-.fern-web-socket-badge
-.fern-web-socket-chevron
-.fern-web-socket-client
-.fern-web-socket-content
-.fern-web-socket-copy
-.fern-web-socket-end-sample
-.fern-web-socket-server
-.fern-web-socket-trigger
-.fern-web-socket-trigger-data
-.fern-web-socket-type
-.fern-x-overflow
-```
+<SearchableTable>
+| Selector | Type |
+|----------|------|
+| `.fern-accordion` | Class |
+| `.fern-accordion-item` | Class |
+| `.fern-accordion-trigger` | Class |
+| `.fern-accordion-trigger-arrow` | Class |
+| `.fern-accordion-trigger-title` | Class |
+| `.fern-air` | Class |
+| `.fern-analytics-ga` | Class |
+| `.fern-analytics-gtm` | Class |
+| `.fern-analytics-segment` | Class |
+| `.fern-anchor` | Class |
+| `.fern-anchor-icon` | Class |
+| `#fern-announcement` | ID |
+| `.fern-announcement-dismissed` | Class |
+| `.fern-api-property` | Class |
+| `.fern-api-property-constraint` | Class |
+| `.fern-api-property-default` | Class |
+| `.fern-api-property-header` | Class |
+| `.fern-api-property-key` | Class |
+| `.fern-api-property-meta` | Class |
+| `.fern-api-property-optional` | Class |
+| `.fern-api-property-readonly` | Class |
+| `.fern-api-property-required` | Class |
+| `.fern-api-property-type` | Class |
+| `#fern-ask-ai-button` | ID |
+| `#fern-ask-ai-button-icon` | ID |
+| `#fern-ask-ai-panel` | ID |
+| `#fern-ask-ai-panel-header` | ID |
+| `#fern-ask-ai-panel-header-icon` | ID |
+| `#fern-ask-ai-panel-input` | ID |
+| `.fern-audio-player` | Class |
+| `#fern-auth-button` | ID |
+| `.fern-back-to-top` | Class |
+| `.fern-background-image` | Class |
+| `.fern-bleed` | Class |
+| `.fern-breadcrumb` | Class |
+| `.fern-breadcrumb-arrow` | Class |
+| `.fern-breadcrumb-item` | Class |
+| `.fern-button` | Class |
+| `.fern-button-content` | Class |
+| `.fern-button-group` | Class |
+| `.fern-button-text` | Class |
+| `.fern-callout` | Class |
+| `.fern-card` | Class |
+| `.fern-card-group` | Class |
+| `.fern-changelog-card` | Class |
+| `.fern-changelog-card-body` | Class |
+| `.fern-changelog-card-excerpt` | Class |
+| `.fern-changelog-card-link` | Class |
+| `.fern-changelog-card-marker` | Class |
+| `.fern-changelog-card-preview` | Class |
+| `.fern-changelog-card-tags` | Class |
+| `.fern-changelog-card-title` | Class |
+| `.fern-changelog-content` | Class |
+| `.fern-changelog-controls` | Class |
+| `.fern-changelog-controls-row` | Class |
+| `.fern-changelog-day` | Class |
+| `.fern-changelog-day-entries` | Class |
+| `.fern-changelog-day-group` | Class |
+| `.fern-changelog-empty` | Class |
+| `.fern-changelog-feed` | Class |
+| `.fern-changelog-highlight` | Class |
+| `.fern-changelog-highlight-style` | Class |
+| `.fern-changelog-label` | Class |
+| `.fern-changelog-overview` | Class |
+| `.fern-changelog-search` | Class |
+| `.fern-changelog-tags` | Class |
+| `.fern-changelog-timeline` | Class |
+| `.fern-checkbox-indicator` | Class |
+| `.fern-checkbox-item` | Class |
+| `.fern-checkbox-label` | Class |
+| `.fern-code` | Class |
+| `.fern-code-actions` | Class |
+| `.fern-code-block` | Class |
+| `.fern-code-block-actions` | Class |
+| `.fern-code-block-content` | Class |
+| `.fern-code-block-header` | Class |
+| `.fern-code-block-header-inner` | Class |
+| `.fern-code-block-title` | Class |
+| `.fern-code-block-title-label` | Class |
+| `.fern-code-content` | Class |
+| `.fern-code-group` | Class |
+| `.fern-code-group-actions` | Class |
+| `.fern-code-group-content` | Class |
+| `.fern-code-group-header` | Class |
+| `.fern-code-group-header-inner` | Class |
+| `.fern-code-group-tab` | Class |
+| `.fern-code-group-tab-label` | Class |
+| `.fern-code-group-tabs` | Class |
+| `.fern-code-header` | Class |
+| `.fern-code-header-inner` | Class |
+| `.fern-code-label` | Class |
+| `.fern-code-link` | Class |
+| `.fern-collapse-trigger` | Class |
+| `.fern-collapsible` | Class |
+| `.fern-collapsible-card` | Class |
+| `.fern-collapsible-card-nested` | Class |
+| `.fern-collapsible-card-print-truncated` | Class |
+| `.fern-collapsible-child` | Class |
+| `.fern-copy-button` | Class |
+| `.fern-copy-inline` | Class |
+| `.fern-dashboard` | Class |
+| `.fern-docs-badge` | Class |
+| `.fern-docs-feedback` | Class |
+| `.fern-docs-static` | Class |
+| `.fern-docs-track-analytics` | Class |
+| `.fern-dropdown` | Class |
+| `.fern-dropdown-checkmark` | Class |
+| `.fern-dropdown-item` | Class |
+| `.fern-dropdown-item-indicator` | Class |
+| `.fern-endpoint-code-snippets` | Class |
+| `.fern-endpoint-request-snippet` | Class |
+| `.fern-endpoint-response-snippet` | Class |
+| `.fern-endpoint-section-auth` | Class |
+| `.fern-endpoint-section-errors` | Class |
+| `.fern-endpoint-section-headers` | Class |
+| `.fern-endpoint-section-path-parameters` | Class |
+| `.fern-endpoint-section-query-parameters` | Class |
+| `.fern-endpoint-section-request-body` | Class |
+| `.fern-endpoint-section-response-body` | Class |
+| `.fern-endpoint-section-response-headers` | Class |
+| `.fern-endpoint-selector` | Class |
+| `.fern-env-switcher` | Class |
+| `.fern-expand-button` | Class |
+| `.fern-explorer-auth-form` | Class |
+| `.fern-explorer-clear-form-button` | Class |
+| `.fern-explorer-endpoint-form` | Class |
+| `.fern-explorer-example-selector` | Class |
+| `.fern-explorer-form` | Class |
+| `.fern-explorer-form-buttons` | Class |
+| `.fern-explorer-request-card` | Class |
+| `.fern-explorer-request-header` | Class |
+| `.fern-explorer-request-title` | Class |
+| `.fern-explorer-response-card` | Class |
+| `.fern-explorer-response-header` | Class |
+| `.fern-explorer-response-title` | Class |
+| `.fern-explorer-section-body` | Class |
+| `.fern-explorer-section-body-parameters` | Class |
+| `.fern-explorer-section-content` | Class |
+| `.fern-explorer-section-header` | Class |
+| `.fern-explorer-section-headers` | Class |
+| `.fern-explorer-section-multipart-form` | Class |
+| `.fern-explorer-section-parameters` | Class |
+| `.fern-explorer-section-path-parameters` | Class |
+| `.fern-explorer-section-query-parameters` | Class |
+| `.fern-explorer-send-request-button` | Class |
+| `.fern-feedback-button` | Class |
+| `.fern-file-icon` | Class |
+| `.fern-filter-badge` | Class |
+| `.fern-filter-badge-selected` | Class |
+| `.fern-filter-badge-unselected` | Class |
+| `.fern-filter-dropdown-button` | Class |
+| `.fern-filter-dropdown-button-content` | Class |
+| `.fern-filter-dropdown-button-icon` | Class |
+| `.fern-filter-dropdown-button-text` | Class |
+| `.fern-filter-dropdown-item` | Class |
+| `#fern-footer` | ID |
+| `.fern-footer-nav` | Class |
+| `.fern-footer-nav--simple` | Class |
+| `.fern-footer-next` | Class |
+| `.fern-footer-prev` | Class |
+| `.fern-ground` | Class |
+| `#fern-header` | ID |
+| `.fern-header-content` | Class |
+| `.fern-header-height` | Class |
+| `.fern-header-logo-container` | Class |
+| `.fern-header-mobile-menu-button` | Class |
+| `.fern-header-navbar-links` | Class |
+| `.fern-header-search-bar` | Class |
+| `.fern-header-selectors` | Class |
+| `.fern-header-switchers` | Class |
+| `.fern-header-switchers-separator` | Class |
+| `.fern-header-tabs` | Class |
+| `.fern-highlight` | Class |
+| `.fern-image-loader` | Class |
+| `.fern-indent` | Class |
+| `.fern-input` | Class |
+| `.fern-input-clear-button` | Class |
+| `.fern-input-group` | Class |
+| `.fern-input-icon` | Class |
+| `.fern-input-right-element` | Class |
+| `.fern-kbd` | Class |
+| `.fern-language-dropdown-content` | Class |
+| `.fern-language-dropdown-item` | Class |
+| `.fern-language-dropdown-item-label` | Class |
+| `.fern-language-selector` | Class |
+| `.fern-language-selector-radio-group` | Class |
+| `.fern-layout-changelog` | Class |
+| `.fern-layout-changelog-entry` | Class |
+| `.fern-layout-content-wrapper` | Class |
+| `.fern-layout-footer` | Class |
+| `.fern-layout-footer-toolbar` | Class |
+| `.fern-layout-guide` | Class |
+| `.fern-layout-overview` | Class |
+| `.fern-layout-page` | Class |
+| `.fern-layout-reference` | Class |
+| `.fern-layout-reference-aside` | Class |
+| `.fern-layout-reference-content` | Class |
+| `.fern-logo-text` | Class |
+| `.fern-main` | Class |
+| `.fern-mdx-icon` | Class |
+| `.fern-mdx-link` | Class |
+| `.fern-mdx-tooltip-content` | Class |
+| `.fern-mdx-tooltip-trigger` | Class |
+| `.fern-mermaid` | Class |
+| `.fern-navigation-storage` | Class |
+| `.fern-not-found-shell` | Class |
+| `.fern-numeric-input-group` | Class |
+| `.fern-numeric-input-step` | Class |
+| `.fern-page-actions` | Class |
+| `.fern-page-heading` | Class |
+| `.fern-page-roles` | Class |
+| `.fern-page-subtitle` | Class |
+| `.fern-pdf-cover-date` | Class |
+| `.fern-pdf-cover-footer` | Class |
+| `.fern-pdf-cover-footer-brand` | Class |
+| `.fern-pdf-cover-root` | Class |
+| `.fern-pdf-cover-subtitle` | Class |
+| `.fern-pdf-cover-title` | Class |
+| `.fern-playground-field` | Class |
+| `.fern-playground-field-actions` | Class |
+| `.fern-playground-field-block` | Class |
+| `.fern-playground-field-control` | Class |
+| `.fern-playground-field-count` | Class |
+| `.fern-playground-field-header` | Class |
+| `.fern-playground-field-help-icon` | Class |
+| `.fern-playground-field-inline` | Class |
+| `.fern-playground-field-item` | Class |
+| `.fern-playground-field-key` | Class |
+| `.fern-playground-field-label` | Class |
+| `.fern-playground-field-list` | Class |
+| `.fern-playground-field-remove` | Class |
+| `.fern-playground-field-type` | Class |
+| `.fern-playground-floating-button` | Class |
+| `.fern-playground-object-properties` | Class |
+| `.fern-product-item` | Class |
+| `.fern-product-item-link` | Class |
+| `.fern-product-selector` | Class |
+| `.fern-product-selector-radio-group` | Class |
+| `.fern-product-tabs` | Class |
+| `.fern-product-tabs-row` | Class |
+| `.fern-programming-language` | Class |
+| `.fern-prompt` | Class |
+| `.fern-prompt-code` | Class |
+| `.fern-prompt-code-wrapper` | Class |
+| `.fern-prompt-icon` | Class |
+| `.fern-prompt-icon-wrapper` | Class |
+| `.fern-prose` | Class |
+| `.fern-radio-group` | Class |
+| `.fern-radio-indicator` | Class |
+| `.fern-radio-item` | Class |
+| `.fern-radio-label` | Class |
+| `.fern-rss-feed-button` | Class |
+| `.fern-runnable-actions` | Class |
+| `.fern-runnable-auth` | Class |
+| `.fern-runnable-auth-content` | Class |
+| `.fern-runnable-auth-fields` | Class |
+| `.fern-runnable-auth-title` | Class |
+| `.fern-runnable-auth-toggle` | Class |
+| `.fern-runnable-card` | Class |
+| `.fern-runnable-clear-button` | Class |
+| `.fern-runnable-endpoint` | Class |
+| `.fern-runnable-endpoint-values` | Class |
+| `.fern-runnable-form` | Class |
+| `.fern-runnable-form-inner` | Class |
+| `.fern-runnable-header` | Class |
+| `.fern-runnable-header-actions` | Class |
+| `.fern-runnable-header-inner` | Class |
+| `.fern-runnable-response` | Class |
+| `.fern-runnable-response-header` | Class |
+| `.fern-runnable-response-label` | Class |
+| `.fern-runnable-response-meta` | Class |
+| `.fern-runnable-response-size` | Class |
+| `.fern-runnable-response-status` | Class |
+| `.fern-runnable-response-time` | Class |
+| `.fern-runnable-section-content` | Class |
+| `.fern-runnable-section-title` | Class |
+| `.fern-runnable-send-button` | Class |
+| `.fern-scroll-area` | Class |
+| `.fern-scroll-area-corner` | Class |
+| `.fern-scroll-area-scrollbar` | Class |
+| `.fern-scroll-area-scrollbar-fade-in` | Class |
+| `.fern-scroll-area-scrollbar-fade-out` | Class |
+| `.fern-scroll-area-thumb` | Class |
+| `.fern-scroll-area-viewport` | Class |
+| `.fern-scroll-walkthrough` | Class |
+| `.fern-scroll-walkthrough-aside` | Class |
+| `.fern-scroll-walkthrough-aside-sticky` | Class |
+| `.fern-scroll-walkthrough-code` | Class |
+| `.fern-scroll-walkthrough-main` | Class |
+| `.fern-scroll-walkthrough-panel` | Class |
+| `.fern-scroll-walkthrough-panel-header` | Class |
+| `.fern-scroll-walkthrough-panel-header-inner` | Class |
+| `.fern-scroll-walkthrough-spacer` | Class |
+| `.fern-scroll-walkthrough-step-body` | Class |
+| `.fern-scroll-walkthrough-step-description` | Class |
+| `.fern-scroll-walkthrough-step-detail` | Class |
+| `.fern-scroll-walkthrough-step-head` | Class |
+| `.fern-scroll-walkthrough-step-item` | Class |
+| `.fern-scroll-walkthrough-step-marker` | Class |
+| `.fern-scroll-walkthrough-step-title` | Class |
+| `.fern-scroll-walkthrough-steps` | Class |
+| `.fern-scroll-walkthrough-substep` | Class |
+| `.fern-scroll-walkthrough-substep-body` | Class |
+| `.fern-scroll-walkthrough-substep-code` | Class |
+| `.fern-scroll-walkthrough-substep-content` | Class |
+| `.fern-scroll-walkthrough-substep-marker` | Class |
+| `.fern-scroll-walkthrough-substep-title` | Class |
+| `.fern-scroll-walkthrough-substeps` | Class |
+| `.fern-scroll-walkthrough-tab` | Class |
+| `.fern-scroll-walkthrough-tabs` | Class |
+| `#fern-search-button` | ID |
+| `.fern-search-desktop-command` | Class |
+| `#fern-search-dialog` | ID |
+| `#fern-search-dialog-overlay` | ID |
+| `.fern-search-hit-breadcrumb` | Class |
+| `.fern-search-hit-endpoint-path` | Class |
+| `.fern-search-hit-highlighted` | Class |
+| `.fern-search-hit-non-highlighted` | Class |
+| `.fern-search-hit-snippet` | Class |
+| `.fern-search-hit-title` | Class |
+| `#fern-search-mobile-command` | ID |
+| `.fern-segmented-control` | Class |
+| `.fern-selection-item` | Class |
+| `.fern-selection-item-end-icon` | Class |
+| `.fern-selection-item-icon` | Class |
+| `.fern-selection-item-subtitle` | Class |
+| `.fern-selection-item-title` | Class |
+| `#fern-sidebar` | ID |
+| `.fern-sidebar-desktop` | Class |
+| `.fern-sidebar-group` | Class |
+| `.fern-sidebar-group-level-1` | Class |
+| `.fern-sidebar-group-root` | Class |
+| `.fern-sidebar-header` | Class |
+| `.fern-sidebar-heading` | Class |
+| `.fern-sidebar-heading-content` | Class |
+| `.fern-sidebar-level-0` | Class |
+| `.fern-sidebar-link` | Class |
+| `.fern-sidebar-link-inline-badge` | Class |
+| `.fern-sidebar-link-title` | Class |
+| `.fern-sidebar-link-title-inner` | Class |
+| `.fern-sidebar-marquee` | Class |
+| `#fern-sidebar-overlay` | ID |
+| `#fern-sidebar-scroll-area` | ID |
+| `.fern-sidebar-scroll-position` | Class |
+| `#fern-sidebar-spacer` | ID |
+| `.fern-sidebar-tabs` | Class |
+| `.fern-step` | Class |
+| `.fern-steps` | Class |
+| `.fern-stream` | Class |
+| `.fern-table` | Class |
+| `.fern-table-collapse` | Class |
+| `.fern-table-pagination` | Class |
+| `.fern-table-pagination-controls` | Class |
+| `.fern-table-pagination-label` | Class |
+| `.fern-table-root` | Class |
+| `.fern-table-search` | Class |
+| `.fern-table-search-clear` | Class |
+| `.fern-table-search-icon` | Class |
+| `.fern-table-search-input` | Class |
+| `.fern-table-show-all` | Class |
+| `.fern-textarea` | Class |
+| `.fern-textarea-group` | Class |
+| `#fern-theme-color` | ID |
+| `#fern-theme-color-preferred-dark` | ID |
+| `#fern-theme-color-preferred-light` | ID |
+| `#fern-toc` | ID |
+| `.fern-token` | Class |
+| `.fern-toolbar` | Class |
+| `.fern-user` | Class |
+| `.fern-variant-selector` | Class |
+| `.fern-variant-selector-dropdown` | Class |
+| `.fern-variant-selector-radio-group` | Class |
+| `.fern-version-selector` | Class |
+| `.fern-version-selector-radio-group` | Class |
+| `.fern-walkthrough` | Class |
+| `.fern-walkthrough-aside` | Class |
+| `.fern-walkthrough-aside-sticky` | Class |
+| `.fern-walkthrough-close` | Class |
+| `.fern-walkthrough-control` | Class |
+| `.fern-walkthrough-controls` | Class |
+| `.fern-walkthrough-frame` | Class |
+| `.fern-walkthrough-progress` | Class |
+| `.fern-walkthrough-step` | Class |
+| `.fern-walkthrough-step-body` | Class |
+| `.fern-walkthrough-step-description` | Class |
+| `.fern-walkthrough-step-item` | Class |
+| `.fern-walkthrough-step-number` | Class |
+| `.fern-walkthrough-step-title` | Class |
+| `.fern-walkthrough-steps` | Class |
+| `.fern-walkthrough-toolbar` | Class |
+| `.fern-web-socket-badge` | Class |
+| `.fern-web-socket-chevron` | Class |
+| `.fern-web-socket-client` | Class |
+| `.fern-web-socket-content` | Class |
+| `.fern-web-socket-copy` | Class |
+| `.fern-web-socket-end-sample` | Class |
+| `.fern-web-socket-server` | Class |
+| `.fern-web-socket-trigger` | Class |
+| `.fern-web-socket-trigger-data` | Class |
+| `.fern-web-socket-type` | Class |
+| `.fern-x-overflow` | Class |
+</SearchableTable>


### PR DESCRIPTION
## Summary

The CSS selectors reference page had drifted from the rendered docs, and it is the page the docs-editing agents (and customers) consult when writing custom CSS — stale entries produce stylesheets that load fine but style nothing. This brings it back in line with the selector catalog generated from the fern-platform docs source (`pnpm generate-docs-agent-references`, 401 selectors at the current `app` tip):

- `.fern-header` → `#fern-header`: the rendered header is `id="fern-header"` (`FERN_HEADER_ID`), not a class. Default CSS updated to the actual header styles (fixed, `--header-background`, `backdrop-filter`).
- Changelog section rewritten for the current timeline UI: removed `.fern-changelog` / `.fern-changelog-entry` / `.fern-changelog-date` (no longer exist) and documented `.fern-changelog-feed`, `.fern-changelog-controls`, `.fern-changelog-timeline` (day groups), and `.fern-changelog-card` (+ inner parts) with their real default CSS.
- New **Complete selector index** section: all 401 stable `fern-*` selectors in one table with a `Type` column (`ID` / `Class`), sorted by selector name, plus a note that any selector not in the table doesn't exist in the rendered site. Written as `<table sticky searchable paginate pageSize={25} className="fern-table">` rather than a wrapper component, since sticky + searchable + paginated is only expressible through the HTML attribute form. The `Type` column carries the id-vs-class distinction that the `#`/`.` sigil alone conveyed.

Every accordion title and every `fern-*` selector on the page validates against the generated catalog (previously 4 documented selectors didn't exist).

Validated with `pre-commit run --files ...` (vale clean) and `fern check --warnings` (0 errors; remaining warnings pre-existing/unrelated).

Follow-up (separate fern-platform PR): point the docs-editing agent prompts at this page's `.md` endpoint as the authoritative full selector list.


Link to Devin session: https://app.devin.ai/sessions/69e7bf2e2fd445f78daa20e7b46d8cbf